### PR TITLE
feat: add AuthContext with session persistence

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,12 +1,15 @@
 // app/_layout.tsx
 import { Stack } from 'expo-router'
 import { SafeAreaProvider } from 'react-native-safe-area-context'
+import { AuthProvider } from '@/context/AuthContext'
 import '../global.css'
 
 export default function RootLayout() {
   return (
     <SafeAreaProvider>
-      <Stack screenOptions={{ headerShown: false }} />
+      <AuthProvider>
+        <Stack screenOptions={{ headerShown: false }} />
+      </AuthProvider>
     </SafeAreaProvider>
   )
 }

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -1,0 +1,106 @@
+// context/AuthContext.tsx
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react'
+import * as SecureStore from 'expo-secure-store'
+import { insforge } from '@/lib/insforge'
+import type { User } from '@/types/database.types'
+
+const ACCESS_TOKEN_KEY = 'insforge_access_token'
+const REFRESH_TOKEN_KEY = 'insforge_refresh_token'
+
+interface AuthState {
+  user: User | null
+  loading: boolean
+  signOut: () => Promise<void>
+}
+
+const AuthContext = createContext<AuthState>({
+  user: null,
+  loading: true,
+  signOut: async () => {},
+})
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    restoreSession()
+  }, [])
+
+  async function restoreSession() {
+    try {
+      const refreshToken = await SecureStore.getItemAsync(REFRESH_TOKEN_KEY)
+      if (!refreshToken) {
+        setLoading(false)
+        return
+      }
+
+      const { data, error } = await insforge.auth.refreshSession({ refreshToken })
+      if (error || !data) {
+        await clearStoredTokens()
+        setLoading(false)
+        return
+      }
+
+      // Persist updated tokens (server may rotate them)
+      await SecureStore.setItemAsync(ACCESS_TOKEN_KEY, data.accessToken)
+      if (data.refreshToken) {
+        await SecureStore.setItemAsync(REFRESH_TOKEN_KEY, data.refreshToken)
+      }
+
+      await loadUserProfile(data.user.id)
+    } catch {
+      await clearStoredTokens()
+      setLoading(false)
+    }
+  }
+
+  async function loadUserProfile(userId: string) {
+    try {
+      const { data } = await insforge.database
+        .from('users')
+        .select('*')
+        .eq('id', userId)
+        .maybeSingle()
+
+      setUser(data as User | null)
+    } catch {
+      setUser(null)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function clearStoredTokens() {
+    await SecureStore.deleteItemAsync(ACCESS_TOKEN_KEY)
+    await SecureStore.deleteItemAsync(REFRESH_TOKEN_KEY)
+  }
+
+  async function signOut() {
+    await insforge.auth.signOut()
+    await clearStoredTokens()
+    setUser(null)
+  }
+
+  return (
+    <AuthContext.Provider value={{ user, loading, signOut }}>
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export const useAuth = () => useContext(AuthContext)
+
+/**
+ * Call this after a successful signInWithPassword to persist the session.
+ * Typically used in the login screen:
+ *
+ * const { data, error } = await insforge.auth.signInWithPassword({ email, password })
+ * if (data) await persistSession(data.accessToken, data.refreshToken)
+ */
+export async function persistSession(accessToken: string, refreshToken?: string) {
+  await SecureStore.setItemAsync(ACCESS_TOKEN_KEY, accessToken)
+  if (refreshToken) {
+    await SecureStore.setItemAsync(REFRESH_TOKEN_KEY, refreshToken)
+  }
+}

--- a/lib/insforge.ts
+++ b/lib/insforge.ts
@@ -10,4 +10,6 @@ if (!process.env.EXPO_PUBLIC_INSFORGE_ANON_KEY) {
 export const insforge = createClient({
   baseUrl: process.env.EXPO_PUBLIC_INSFORGE_URL,
   anonKey: process.env.EXPO_PUBLIC_INSFORGE_ANON_KEY,
+  // isServerMode enables refresh_token in response body (required for mobile/native)
+  isServerMode: true,
 })


### PR DESCRIPTION
## Cambios
- context/AuthContext.tsx: gestión de sesión con SecureStore usando refreshToken
- app/_layout.tsx: envuelto con AuthProvider
- lib/insforge.ts: habilitado isServerMode para recibir refreshToken en el cuerpo (flujo mobile)

## Decisiones de implementación
El SDK InsForge no expone `onAuthStateChange` ni `setSession` (esos son APIs de Supabase). La sesión se persiste así:
- Al hacer login: llamar `persistSession(accessToken, refreshToken)` desde la pantalla de login
- Al iniciar la app: AuthContext lee el refreshToken de SecureStore y llama `auth.refreshSession()` para re-hidratar el TokenManager en memoria
- Al cerrar sesión: `auth.signOut()` + borrar tokens de SecureStore

## Exports
- `AuthProvider` — envuelve la app
- `useAuth()` — hook para acceder a `{ user, loading, signOut }`
- `persistSession(accessToken, refreshToken?)` — helper para la pantalla de login

Closes #10