### PR TITLE
fix: handle RPC errors and guard missing records in transactions actions

### DIFF
--- a/lib/actions/transactions.actions.ts
+++ b/lib/actions/transactions.actions.ts
@@ -30,6 +30,7 @@ export async function getTransactionById(
   id: string,
   userId: string
 ): Promise<{ success: boolean; data?: TransactionWithCategory; error?: string }> {
+  if (!id || !userId) return { success: false, error: 'Parámetros requeridos' }
   try {
     const { data, error } = await insforge.database
       .from('transactions')
@@ -49,21 +50,21 @@ export async function createTransaction(
   userId: string,
   input: CreateTransactionInput
 ): Promise<{ success: boolean; error?: string }> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
   try {
     const validated = createTransactionSchema.parse(input)
-    const { data: transaction, error } = await insforge.database
+    const { error } = await insforge.database
       .from('transactions')
       .insert([{ ...validated, user_id: userId, source: 'manual' }])
-      .select()
-      .single()
     if (error) throw error
 
     if (validated.account_id) {
       const rpc = validated.type === 'income' ? 'increment_account_balance' : 'decrement_account_balance'
-      await insforge.database.rpc(rpc, {
+      const { error: rpcError } = await insforge.database.rpc(rpc, {
         account_id: validated.account_id,
         amount: validated.amount,
       })
+      if (rpcError) throw rpcError
     }
     return { success: true }
   } catch {
@@ -76,6 +77,7 @@ export async function updateTransaction(
   userId: string,
   input: UpdateTransactionInput
 ): Promise<{ success: boolean; error?: string }> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
   try {
     const { data: oldTx, error: fetchError } = await insforge.database
       .from('transactions')
@@ -97,17 +99,19 @@ export async function updateTransaction(
 
     if (oldTx.account_id) {
       const reverseRpc = oldTx.type === 'expense' ? 'increment_account_balance' : 'decrement_account_balance'
-      await insforge.database.rpc(reverseRpc, {
+      const { error: rpcError } = await insforge.database.rpc(reverseRpc, {
         account_id: oldTx.account_id,
         amount: Number(oldTx.amount),
       })
+      if (rpcError) throw rpcError
     }
     if (transaction.account_id) {
       const applyRpc = transaction.type === 'income' ? 'increment_account_balance' : 'decrement_account_balance'
-      await insforge.database.rpc(applyRpc, {
+      const { error: rpcError } = await insforge.database.rpc(applyRpc, {
         account_id: transaction.account_id,
         amount: Number(transaction.amount),
       })
+      if (rpcError) throw rpcError
     }
     return { success: true }
   } catch {
@@ -119,6 +123,7 @@ export async function deleteTransaction(
   id: string,
   userId: string
 ): Promise<{ success: boolean; error?: string }> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
   try {
     const { data: tx } = await insforge.database
       .from('transactions')
@@ -127,6 +132,8 @@ export async function deleteTransaction(
       .eq('user_id', userId)
       .maybeSingle()
 
+    if (!tx) return { success: false, error: 'Transacción no encontrada' }
+
     const { error } = await insforge.database
       .from('transactions')
       .delete()
@@ -134,12 +141,13 @@ export async function deleteTransaction(
       .eq('user_id', userId)
     if (error) throw error
 
-    if (tx?.account_id) {
+    if (tx.account_id) {
       const reverseRpc = tx.type === 'expense' ? 'increment_account_balance' : 'decrement_account_balance'
-      await insforge.database.rpc(reverseRpc, {
+      const { error: rpcError } = await insforge.database.rpc(reverseRpc, {
         account_id: tx.account_id,
         amount: Number(tx.amount),
       })
+      if (rpcError) throw rpcError
     }
     return { success: true }
   } catch {


### PR DESCRIPTION
## Summary
- Check RPC return errors in `createTransaction`, `updateTransaction`, `deleteTransaction` — previously a failed RPC silently corrupted account balances while returning `{ success: true }`
- Guard `deleteTransaction` against non-existent/unauthorized records — pre-fetch result is now checked before proceeding with delete
- Add `userId` guards to all mutating functions (`createTransaction`, `updateTransaction`, `deleteTransaction`)
- Add `id`/`userId` guard to `getTransactionById`
- Remove unused `data: transaction` destructuring in `createTransaction` insert call

## Test plan
- [ ] Create a transaction with a valid account — balance updates correctly
- [ ] Attempt to delete a non-existent transaction ID — returns `{ success: false, error: 'Transacción no encontrada' }`
- [ ] Call any mutating function with an empty `userId` — returns `{ success: false, error: 'User ID requerido' }`
- [ ] Call `getTransactionById` with missing `id` or `userId` — returns `{ success: false, error: 'Parámetros requeridos' }`
- [ ] TypeScript check: `npx tsc --noEmit` returns 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)