### PR TITLE
feat: portear tipos y schemas Zod faltantes desde el repo web

### DIFF
--- a/app/(dashboard)/transactions/[id].tsx
+++ b/app/(dashboard)/transactions/[id].tsx
@@ -61,7 +61,7 @@ export default function TransactionFormScreen() {
           setAmount(String(tx.amount))
           setCurrency(tx.currency)
           setType(tx.type)
-          setCategoryId(tx.category_id)
+          setCategoryId(tx.category_id ?? '')
           setAccountId(tx.account_id ?? '')
           setDate(tx.date)
           setNotes(tx.notes ?? '')
@@ -114,7 +114,7 @@ export default function TransactionFormScreen() {
     ])
   }
 
-  const filteredCategories = categories.filter((c) => c.type === type)
+  const filteredCategories = categories.filter((c) => c.type === type || c.type === 'both')
   const categoryOptions = filteredCategories.map((c) => ({
     label: `${c.icon ?? ''} ${c.name}`.trim(),
     value: c.id,

--- a/lib/validations/budget.ts
+++ b/lib/validations/budget.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod'
+
+export const createBudgetSchema = z.object({
+  category_id: z.string().uuid(),
+  amount: z.number().positive('El monto debe ser positivo'),
+  currency: z.enum(['COP', 'USD', 'VES']),
+  period: z.enum(['monthly', 'yearly']),
+  start_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Fecha inválida'),
+})
+
+export const updateBudgetSchema = createBudgetSchema.partial()
+
+export type CreateBudgetInput = z.infer<typeof createBudgetSchema>
+export type UpdateBudgetInput = z.infer<typeof updateBudgetSchema>

--- a/lib/validations/category.ts
+++ b/lib/validations/category.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod'
+
+export const createCategorySchema = z.object({
+  name: z.string().min(1, 'El nombre es requerido'),
+  type: z.enum(['income', 'expense', 'both']),
+  icon: z.string().nullable().optional(),
+  color: z.string().nullable().optional(),
+})
+
+export const updateCategorySchema = createCategorySchema.partial()
+
+export type CreateCategoryInput = z.infer<typeof createCategorySchema>
+export type UpdateCategoryInput = z.infer<typeof updateCategorySchema>

--- a/lib/validations/loan.ts
+++ b/lib/validations/loan.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod'
+
+export const createLoanSchema = z.object({
+  person_name: z.string().min(1, 'El nombre es requerido'),
+  amount: z.number().positive('El monto debe ser mayor a 0'),
+  currency: z.enum(['COP', 'USD', 'VES']),
+  account_id: z.string().uuid().nullable().optional(),
+  type: z.enum(['lent', 'borrowed']),
+  notes: z.string().nullable().optional(),
+})
+
+export const updateLoanSchema = createLoanSchema.partial()
+
+export const createLoanPaymentSchema = z.object({
+  amount: z.number().positive('El monto debe ser positivo'),
+  currency: z.enum(['COP', 'USD', 'VES']),
+  date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Fecha inválida'),
+  notes: z.string().nullable().optional(),
+})
+
+export type CreateLoanInput = z.infer<typeof createLoanSchema>
+export type UpdateLoanInput = z.infer<typeof updateLoanSchema>
+export type CreateLoanPaymentInput = z.infer<typeof createLoanPaymentSchema>

--- a/lib/validations/reminder.ts
+++ b/lib/validations/reminder.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod'
+
+export const createReminderSchema = z.object({
+  description: z.string().min(1, 'La descripción es requerida'),
+  category_id: z.string().uuid().nullable().optional(),
+  account_id: z.string().uuid().nullable().optional(),
+  frequency: z.enum(['once', 'weekly', 'monthly', 'yearly']),
+  day_of_week: z.number().int().min(0).max(6).nullable().optional(),
+  day_of_month: z.number().int().min(1).max(31).nullable().optional(),
+  month_of_year: z.number().int().min(1).max(12).nullable().optional(),
+  specific_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Fecha inválida').nullable().optional(),
+  is_active: z.boolean().optional().default(true),
+})
+
+export const updateReminderSchema = createReminderSchema.partial()
+
+export type CreateReminderInput = z.infer<typeof createReminderSchema>
+export type UpdateReminderInput = z.infer<typeof updateReminderSchema>

--- a/lib/validations/savings.ts
+++ b/lib/validations/savings.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod'
+
+export const createSavingsGoalSchema = z.object({
+  name: z.string().min(1, 'El nombre es requerido'),
+  target_amount: z.number().positive('El monto objetivo debe ser positivo'),
+  currency: z.enum(['COP', 'USD', 'VES']),
+  deadline: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Fecha inválida').nullable().optional(),
+})
+
+export const updateSavingsGoalSchema = createSavingsGoalSchema.partial()
+
+export const addFundsSchema = z.object({
+  amount: z.number().positive('El monto debe ser positivo'),
+})
+
+export type CreateSavingsGoalInput = z.infer<typeof createSavingsGoalSchema>
+export type UpdateSavingsGoalInput = z.infer<typeof updateSavingsGoalSchema>
+export type AddFundsInput = z.infer<typeof addFundsSchema>

--- a/lib/validations/tags.ts
+++ b/lib/validations/tags.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod'
+
+export const createTagSchema = z.object({
+  name: z.string().min(1, 'El nombre del tag es requerido'),
+  color: z.string().default('#3182CE'),
+})
+
+export const updateTagSchema = createTagSchema.partial()
+
+export const addTagToTransactionSchema = z.object({
+  tag_id: z.string().uuid(),
+})
+
+export type CreateTagInput = z.infer<typeof createTagSchema>
+export type UpdateTagInput = z.infer<typeof updateTagSchema>
+export type AddTagToTransactionInput = z.infer<typeof addTagToTransactionSchema>

--- a/types/database.types.ts
+++ b/types/database.types.ts
@@ -1,9 +1,20 @@
 // types/database.types.ts
 export type Currency = 'COP' | 'USD' | 'VES'
 export type TransactionType = 'income' | 'expense'
+export type CategoryType = 'income' | 'expense' | 'both'
 export type BudgetPeriod = 'monthly' | 'yearly'
-export type TransactionSource = 'manual' | 'conversational'
+export type TransactionSource = 'manual' | 'conversational' | 'import' | 'gmail'
 export type RecurrenceFrequency = 'daily' | 'weekly' | 'monthly' | 'yearly'
+export type ReminderFrequency = 'once' | 'weekly' | 'monthly' | 'yearly'
+export type LoanType = 'lent' | 'borrowed'
+export type LoanStatus = 'active' | 'settled'
+export type ProcessedEmailOutcome = 'auto_registered' | 'skipped' | 'error'
+
+export interface Whitelist {
+  id: string
+  email: string
+  created_at: string
+}
 
 export interface User {
   id: string
@@ -11,11 +22,14 @@ export interface User {
   name: string | null
   avatar_url: string | null
   preferred_currency: Currency
+  gmail_refresh_token: string | null
+  gmail_connected_at: string | null
+  gmail_last_synced_at: string | null
   created_at: string
   updated_at: string
 }
 
-export type AccountType = 'bank' | 'digital' | 'crypto' | 'cash'
+export type AccountType = 'bank' | 'digital' | 'crypto' | 'cash' | 'card'
 
 export interface Account {
   id: string
@@ -24,9 +38,12 @@ export interface Account {
   type: AccountType
   currency: Currency
   balance: number
+  credit_limit: number | null
   color: string | null
   icon: string | null
+  last_four: string | null
   is_active: boolean
+  is_default: boolean
   created_at: string
   updated_at: string
 }
@@ -56,7 +73,7 @@ export interface Transaction {
   amount: number
   currency: Currency
   type: TransactionType
-  category_id: string
+  category_id: string | null
   account_id: string | null
   description: string
   date: string
@@ -68,9 +85,9 @@ export interface Transaction {
 
 export interface Category {
   id: string
-  user_id: string | null
+  user_id: string | null // null = predefined
   name: string
-  type: TransactionType
+  type: CategoryType
   icon: string | null
   color: string | null
   created_at: string
@@ -132,8 +149,66 @@ export interface Tag {
   created_at: string
 }
 
+export interface Loan {
+  id: string
+  user_id: string
+  person_name: string
+  amount: number
+  paid_amount: number
+  currency: Currency
+  account_id: string | null
+  type: LoanType
+  status: LoanStatus
+  notes: string | null
+  created_at: string
+  updated_at: string
+  settled_at: string | null
+}
+
+export interface LoanPayment {
+  id: string
+  loan_id: string
+  user_id: string
+  amount: number
+  currency: Currency
+  date: string
+  notes: string | null
+  created_at: string
+}
+
+export interface Reminder {
+  id: string
+  user_id: string
+  description: string
+  category_id: string | null
+  account_id: string | null
+  frequency: ReminderFrequency
+  day_of_week: number | null
+  day_of_month: number | null
+  month_of_year: number | null
+  specific_date: string | null
+  is_active: boolean
+  created_at: string
+}
+
+export interface ProcessedEmail {
+  gmail_message_id: string
+  user_id: string
+  outcome: ProcessedEmailOutcome
+  transaction_id: string | null
+  error_message: string | null
+  processed_at: string
+}
+
+// With relations
+
 export interface TransactionWithCategory extends Transaction {
   category: Category
+}
+
+export interface TransactionWithTags extends Transaction {
+  category: Category
+  tags?: Tag[]
 }
 
 export interface BudgetWithCategory extends Budget {
@@ -142,4 +217,12 @@ export interface BudgetWithCategory extends Budget {
 
 export interface RecurringTransactionWithCategory extends RecurringTransaction {
   category: Category
+}
+
+export interface LoanWithAccount extends Loan {
+  account: Pick<Account, 'id' | 'name' | 'currency' | 'icon'> | null
+}
+
+export interface ReminderWithCategory extends Reminder {
+  category: Category | null
 }


### PR DESCRIPTION
## Cambios

### Tipos (`types/database.types.ts`)

**5 enums nuevos:**
- `CategoryType` (`'income' | 'expense' | 'both'`)
- `LoanType` (`'lent' | 'borrowed'`)
- `LoanStatus` (`'active' | 'settled'`)
- `ReminderFrequency` (`'once' | 'weekly' | 'monthly' | 'yearly'`)
- `ProcessedEmailOutcome`

**8 interfaces nuevas:**
- `Whitelist`, `Loan`, `LoanWithAccount`, `LoanPayment`, `Reminder`, `ReminderWithCategory`, `ProcessedEmail`, `TransactionWithTags`

**Extensiones a tipos existentes:**
- `User`: añade `gmail_refresh_token`, `gmail_connected_at`, `gmail_last_synced_at`.
- `Account`: añade `credit_limit`, `last_four`, `is_default`.
- `AccountType`: añade `'card'`.
- `TransactionSource`: añade `'import' | 'gmail'`.
- `Transaction.category_id`: ahora `string | null` (puede no haber categoría).
- `Category.type`: ahora `CategoryType` (incluye `'both'`).

### Schemas Zod (`lib/validations/`)

6 archivos nuevos siguiendo el patrón del native (mensajes ES, `updateSchema = createSchema.partial()`, tipos derivados con `z.infer`):

- `budget.ts` — `createBudgetSchema`, `updateBudgetSchema`.
- `savings.ts` — `createSavingsGoalSchema`, `updateSavingsGoalSchema`, `addFundsSchema`.
- `loan.ts` — `createLoanSchema`, `updateLoanSchema`, `createLoanPaymentSchema` (último no estaba en el web).
- `tags.ts` — `createTagSchema`, `updateTagSchema`, `addTagToTransactionSchema`.
- `reminder.ts` — `createReminderSchema`, `updateReminderSchema`.
- `category.ts` — `createCategorySchema`, `updateCategorySchema` (incluye `'both'` en el enum de type).

### Fixes colaterales (`app/(dashboard)/transactions/[id].tsx`)

Al expandir `Category.type` a `CategoryType` con `'both'` y `Transaction.category_id` a nullable, dos líneas necesitaban ajuste para mantener semántica:

- Línea 117 (filtro): `c.type === type` → `c.type === type || c.type === 'both'`. Sin este fix, las categorías 'both' se filtrarían silenciosamente fuera.
- Línea 64 (carga del form): `setCategoryId(tx.category_id)` → `setCategoryId(tx.category_id ?? '')`. El state espera string.

## Por qué este orden de cambios

Tarea **T-1.1 de FASE 1** del plan de migración. Es la primera tarea porque todo lo posterior (presupuestos, metas, préstamos, tags, recordatorios) necesita estos tipos y schemas antes de que se puedan escribir acciones o UI.

Portable 1:1 desde el web porque el backend (InsForge) es compartido — mismo contrato de datos. Zod no usa APIs de browser ni RN.

## Verificación

- ✅ `npx tsc --noEmit` limpio (exit code 0).
- 🟡 Prueba en simulador iOS: pendiente (no debería haber regresiones, los cambios son aditivos en runtime).

## Testing recomendado

- [ ] App levanta en simulador iOS sin warnings nuevos.
- [ ] Crear transacción nueva — confirmar que las categorías 'both' aparecen en el picker tanto para income como expense.
- [ ] Editar transacción existente — confirmar que carga sin errores.

## Notas de aprendizaje

Bitácora completa en Obsidian: \`40 - Projects/expense-manager-native/T-1.1 — Tipos y Zod.md\`. Conceptos aplicados:

- [[Zod]] y [[Schema-first validation]] en acción.
- Insight: cuando expandís un enum existente (como `Category.type` con `'both'`), TypeScript NO advierte sobre comparadores existentes que ahora quedan incompletos. Hay que auditarlos a mano. Este PR lo hace.

## Related

Closes #44
Related to #43 (FASE 1)