### PR TITLE
chore: add .npmrc with node-linker=hoisted for nativewind compat

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,8 @@
+# pnpm: usar estructura flat de node_modules (como npm/yarn) para que paquetes
+# que asumen hoisting (nativewind, react-native-css-interop, libs nativas RN)
+# encuentren sus deps al nivel esperado. Sin esto, Metro falla al resolver
+# imports inyectados por Babel (ej. "react-native-css-interop/jsx-runtime").
+#
+# Mantiene el cache content-addressable de pnpm (rápido y eficiente en disco),
+# solo cambia la forma en que node_modules se construye en cada proyecto.
+node-linker=hoisted


### PR DESCRIPTION
## Problema

Tras consolidar el proyecto en pnpm (#47), Metro falla al bundlear con:

\`\`\`
Unable to resolve \"react-native-css-interop/jsx-runtime\"
from \"app/(dashboard)/accounts/_layout.tsx\"
\`\`\`

## Causa

NativeWind 4 inyecta via babel preset (\`jsxImportSource: 'nativewind'\`) un import a \`react-native-css-interop/jsx-runtime\`. Ese paquete es transitive dep de nativewind y vive en \`node_modules/.pnpm/\`, pero NO en \`node_modules/\` top-level cuando pnpm usa su estructura simbólica estricta. Metro lo busca al nivel raíz y no lo encuentra.

## Solución

\`.npmrc\` con \`node-linker=hoisted\` → pnpm genera \`node_modules\` flat (como npm/yarn) manteniendo su cache eficiente. Aplica a este caso y previene issues similares en fases posteriores con otras libs RN (victory-native, react-native-calendars, expo-notifications) que asumen hoisting.

## Verificación local

\`\`\`bash
rm -rf node_modules && pnpm install
ls node_modules/react-native-css-interop  # debe existir
\`\`\`

## Testing recomendado

- [ ] Mergear este PR.
- [ ] En develop local: \`pnpm install\` (regenera node_modules con la nueva config).
- [ ] \`pnpm ios\` → Metro bundlea sin el error de resolución.
- [ ] App levanta y muestra pantalla de login.

## Notas

Closes #48