### PR TITLE
chore: configurar bundle ID y URL schemes iOS para Google OAuth

### DIFF
--- a/app.json
+++ b/app.json
@@ -14,7 +14,17 @@
       "backgroundColor": "#0f0f14"
     },
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "bundleIdentifier": "com.sanghel.expensemanager",
+      "infoPlist": {
+        "CFBundleURLTypes": [
+          {
+            "CFBundleURLSchemes": [
+              "com.googleusercontent.apps.445491202800-b7774o1k5jpdgatul6sqjmpuqffv9mj2"
+            ]
+          }
+        ]
+      }
     },
     "android": {
       "adaptiveIcon": {

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react'
 import { router } from 'expo-router'
 import * as WebBrowser from 'expo-web-browser'
 import * as Google from 'expo-auth-session/providers/google'
-import { makeRedirectUri } from 'expo-auth-session'
 import { insforge } from '@/lib/insforge'
 import { useAuth } from '@/context/AuthContext'
 import { PrimaryButton } from '@/components/ui/PrimaryButton'
@@ -18,7 +17,6 @@ export default function LoginScreen() {
 
   const [, , promptAsync] = Google.useAuthRequest({
     iosClientId: process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID,
-    redirectUri: makeRedirectUri({ scheme: 'expensemanager' }),
   })
 
   async function handleGoogleLogin() {


### PR DESCRIPTION
## Problema

Google OAuth devuelve \`Error 400: invalid_request\` con el mensaje \"doesn't comply with Google's OAuth 2.0 policy for keeping apps secure\".

## Causa

Dos problemas combinados:

1. **redirectUri override en login.tsx** — pasar \`redirectUri: makeRedirectUri({ scheme: 'expensemanager' })\` sobrescribe la generación automática que hace \`Google.useAuthRequest({ iosClientId })\`. Los iOS Clients de Google solo aceptan el reversed-client-id format (\`com.googleusercontent.apps.XXX-YYY://\`), no custom schemes.

2. **app.json sin bundleIdentifier ni URL schemes** — sin estos, la app que se compila no matchea el iOS Client de Google Cloud (registrado con bundle ID \`com.sanghel.expensemanager\`), y iOS no sabría enrutar el callback OAuth a la app.

## Cambios

### \`app.json\`

\`\`\`diff
 \"ios\": {
-  \"supportsTablet\": true
+  \"supportsTablet\": true,
+  \"bundleIdentifier\": \"com.sanghel.expensemanager\",
+  \"infoPlist\": {
+    \"CFBundleURLTypes\": [{
+      \"CFBundleURLSchemes\": [
+        \"com.googleusercontent.apps.445491202800-b7774o1k5jpdgatul6sqjmpuqffv9mj2\"
+      ]
+    }]
+  }
 }
\`\`\`

### \`login.tsx\`

\`\`\`diff
-import { makeRedirectUri } from 'expo-auth-session'

 const [, , promptAsync] = Google.useAuthRequest({
   iosClientId: process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID,
-  redirectUri: makeRedirectUri({ scheme: 'expensemanager' }),
 })
\`\`\`

## Después del merge — qué hacer en local

Como ahora la app necesita config nativa (bundle ID + URL scheme en Info.plist), hay que generar el folder \`ios/\` con prebuild. El folder está gitignored (CNG — Continuous Native Generation), cada dev lo genera localmente.

\`\`\`bash
git checkout develop && git pull
npx expo prebuild --platform ios   # genera ios/ con la nueva config
pnpm ios                            # primera vez tarda 5-10 min (CocoaPods + Xcode build)
\`\`\`

Login debería funcionar al primer intento.

## Verificación

- ✅ \`npx tsc --noEmit\` limpio.
- ⏳ Pendiente: \`npx expo prebuild --platform ios && pnpm ios\` → login completo.

## Notas

Sobre por qué hardcodear el URL scheme: el reversed-client-id contiene el client ID, pero ambos son públicos (aparecen en cualquier dev build, decompiler los puede ver). No es un secreto. Por eso va en \`app.json\` y no en \`.env\`.

Closes #50

Stack de PRs de unblock para testing local:
- #47 (deps SDK 54) ✅ merged
- #49 (pnpm hoisting) → merge antes de este
- **Este PR** → fix OAuth
- #45 (T-1.1 tipos y Zod) → mergear cuando todo lo anterior esté