### PR TITLE
feat: portear utilidades y hooks compartidos desde el repo web

### DIFF
--- a/hooks/useDebounce.ts
+++ b/hooks/useDebounce.ts
@@ -1,0 +1,12 @@
+import { useState, useEffect } from 'react'
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debounced, setDebounced] = useState(value)
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebounced(value), delay)
+    return () => clearTimeout(timer)
+  }, [value, delay])
+
+  return debounced
+}

--- a/hooks/useFinancialSummary.ts
+++ b/hooks/useFinancialSummary.ts
@@ -1,0 +1,64 @@
+import { useMemo } from 'react'
+import type {
+  TransactionWithCategory,
+  Currency,
+  ExchangeRate,
+} from '@/types/database.types'
+
+interface FinancialSummary {
+  totalIncome: number
+  totalExpense: number
+  balance: number
+  currency: Currency
+  transactionCount: number
+  incomeCount: number
+  expenseCount: number
+}
+
+export function useFinancialSummary(
+  transactions: TransactionWithCategory[],
+  month?: string,
+  preferredCurrency: Currency = 'COP',
+  exchangeRates: ExchangeRate[] = []
+) {
+  const summary = useMemo<FinancialSummary>(() => {
+    const filtered = month
+      ? transactions.filter((t) => t.date.startsWith(month))
+      : transactions
+
+    const getRateMultiplier = (from: Currency, to: Currency): number => {
+      if (from === to) return 1
+      const rate = exchangeRates.find(
+        (r) => r.from_currency === from && r.to_currency === to
+      )
+      return rate ? Number(rate.rate) : 1
+    }
+
+    const incomeTransactions = filtered.filter((t) => t.type === 'income')
+    const expenseTransactions = filtered.filter((t) => t.type === 'expense')
+
+    const income = incomeTransactions.reduce(
+      (sum, t) =>
+        sum + Number(t.amount) * getRateMultiplier(t.currency, preferredCurrency),
+      0
+    )
+
+    const expense = expenseTransactions.reduce(
+      (sum, t) =>
+        sum + Number(t.amount) * getRateMultiplier(t.currency, preferredCurrency),
+      0
+    )
+
+    return {
+      totalIncome: income,
+      totalExpense: expense,
+      balance: income - expense,
+      currency: preferredCurrency,
+      transactionCount: filtered.length,
+      incomeCount: incomeTransactions.length,
+      expenseCount: expenseTransactions.length,
+    }
+  }, [transactions, month, preferredCurrency, exchangeRates])
+
+  return { summary, loading: false }
+}

--- a/lib/utils/balance-updater.ts
+++ b/lib/utils/balance-updater.ts
@@ -1,0 +1,63 @@
+import { insforge } from '@/lib/insforge'
+
+/**
+ * Actualiza el balance de una cuenta sumando o restando un monto,
+ * convirtiendo monedas vía exchange rates cuando es necesario.
+ *
+ * Diferencia con el web: el web usa `insforgeAdmin` (admin client) porque
+ * corre server-side. El nativo usa `insforge` (anon client). Funciona gracias
+ * a las RLS policies de la tabla `accounts` (anon puede SELECT/UPDATE) y
+ * `exchange_rates` (anon puede SELECT).
+ *
+ * @returns mensaje de error en caso de fallo, null en caso de éxito.
+ */
+export async function applyBalanceDelta(
+  accountId: string,
+  amount: number,
+  transactionCurrency: string,
+  direction: 'add' | 'subtract'
+): Promise<string | null> {
+  const { data: account, error: fetchError } = await insforge.database
+    .from('accounts')
+    .select('balance, currency')
+    .eq('id', accountId)
+    .single()
+
+  if (fetchError || !account) {
+    return `balance-fetch-error: ${JSON.stringify(fetchError)}`
+  }
+
+  let amt = Number(amount)
+
+  if (transactionCurrency !== account.currency) {
+    const { data: rate } = await insforge.database
+      .from('exchange_rates')
+      .select('rate')
+      .eq('from_currency', transactionCurrency)
+      .eq('to_currency', account.currency)
+      .order('date', { ascending: false })
+      .limit(1)
+      .single()
+
+    if (!rate) {
+      return `no-exchange-rate from=${transactionCurrency} to=${account.currency}`
+    }
+
+    amt = amt * Number(rate.rate)
+  }
+
+  const newBalance = direction === 'add'
+    ? Number(account.balance) + amt
+    : Number(account.balance) - amt
+
+  const { error: updateError } = await insforge.database
+    .from('accounts')
+    .update({ balance: newBalance, updated_at: new Date().toISOString() })
+    .eq('id', accountId)
+
+  if (updateError) {
+    return `balance-update-error: ${JSON.stringify(updateError)}`
+  }
+
+  return null
+}

--- a/lib/utils/dates.ts
+++ b/lib/utils/dates.ts
@@ -1,0 +1,6 @@
+export function getLocalDateString(date: Date = new Date()): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}


### PR DESCRIPTION
## Cambios

Cuatro archivos portados del repo web al native como base para acciones, vistas y formularios futuros:

| Archivo | Adaptación |
|---|---|
| \`lib/utils/dates.ts\` | Copia 1:1 — \`getLocalDateString\`, función pura sin deps externas |
| \`lib/utils/balance-updater.ts\` | \`insforgeAdmin\` → \`insforge\` (anon client). Funciona gracias a las RLS policies aplicadas tras [Setup - Login E2E](https://github.com/Sanghel/expense-manager-native/pull/52) |
| \`hooks/useDebounce.ts\` | Copia 1:1 — hook genérico con \`setTimeout\` + cleanup |
| \`hooks/useFinancialSummary.ts\` | Quitada \`'use client'\` directive (Next.js-only), tipado mejor \`exchangeRates\` como \`ExchangeRate[]\` (estaba como \`any[]\`) |

## Decisión arquitectónica clave

\`balance-updater.ts\` originalmente usaba \`insforgeAdmin\` (admin client, server-side en el web). En native usamos \`insforge\` (anon client). Esto funciona porque con [Frontend-verified OAuth](https://github.com/Sanghel/expense-manager-native/pull/52) + RLS permissive en \`accounts\` y \`exchange_rates\`, anon puede hacer SELECT/UPDATE/SELECT respectivamente.

**Mismo código, distinto client, mismo backend.** La capa de datos no depende del tipo de client, depende de los permisos del rol.

## Estructura nueva

- Creada carpeta \`hooks/\` en la raíz del proyecto (no existía).

## Verificación

- ✅ \`npx tsc --noEmit\` limpio (exit code 0).
- 🟡 App levanta en simulador: pendiente confirmación. Los archivos no se usan todavía — solo se importan/exportan. Riesgo de regresión = bajo.

## Notas de aprendizaje

Bitácora completa en Obsidian: \`40 - Projects/expense-manager-native/T-1.2 — Utilidades y hooks.md\`. Conceptos aplicados:

- \`useMemo\` para memoización del summary.
- Debounce pattern (preview de lo que usaremos en T-2.2 para search).
- Diferencia admin client vs anon client → ahora sabemos que la capa de datos es agnóstica al client cuando RLS está bien configurada.

## Related

Closes #53
Related to #43 (FASE 1)