### PR TITLE
feat: exchange rates actions + hook useExchangeRates (T-1.4)

### DIFF
--- a/hooks/useExchangeRates.ts
+++ b/hooks/useExchangeRates.ts
@@ -1,0 +1,52 @@
+import { useEffect, useState } from 'react'
+import { getAllRatePairs } from '@/lib/actions/exchangeRates.actions'
+import type { ExchangeRate } from '@/types/database.types'
+
+/**
+ * Caché module-level compartida entre TODOS los callers del hook.
+ * Las rates cambian 1x por día (cron en backend), suficiente cachearlas
+ * durante la sesión. Refresh on next app launch.
+ */
+let cachedRates: ExchangeRate[] | null = null
+
+/**
+ * Hook que devuelve las exchange rates más recientes con caché en memoria.
+ * Primera llamada fetchea; siguientes (en el mismo session) usan caché.
+ *
+ * @example
+ * const { rates, loading } = useExchangeRates()
+ * const usdToCop = rates.find(r => r.from_currency === 'USD' && r.to_currency === 'COP')
+ */
+export function useExchangeRates() {
+  const [rates, setRates] = useState<ExchangeRate[]>(cachedRates ?? [])
+  const [loading, setLoading] = useState(cachedRates === null)
+
+  useEffect(() => {
+    if (cachedRates !== null) return // hit de caché — no refetch
+
+    let cancelled = false
+
+    getAllRatePairs().then((result) => {
+      if (cancelled) return
+      if (result.success && result.data) {
+        cachedRates = result.data
+        setRates(result.data)
+      }
+      setLoading(false)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return { rates, loading }
+}
+
+/**
+ * Invalida la caché module-level. Llamar después de un sync manual
+ * de rates o al detectar que el día cambió.
+ */
+export function invalidateExchangeRatesCache() {
+  cachedRates = null
+}

--- a/lib/actions/exchangeRates.actions.ts
+++ b/lib/actions/exchangeRates.actions.ts
@@ -1,0 +1,104 @@
+import { insforge } from '@/lib/insforge'
+import type { Currency, ExchangeRate } from '@/types/database.types'
+
+/**
+ * Funciones read-only para exchange rates. El cron job que actualiza las rates
+ * (updateExchangeRates) vive en el backend — no se portea al native.
+ *
+ * Anon client puede SELECT en `exchange_rates` gracias a las RLS policies.
+ */
+
+interface Result<T> {
+  success: boolean
+  data?: T
+  error?: string
+}
+
+/**
+ * Devuelve las últimas 20 rates ordenadas por fecha descendente.
+ * Útil para debug o un panel admin de estado de rates.
+ */
+export async function getLatestRates(): Promise<Result<ExchangeRate[]>> {
+  try {
+    const { data, error } = await insforge.database
+      .from('exchange_rates')
+      .select('*')
+      .order('date', { ascending: false })
+      .limit(20)
+
+    if (error) throw error
+    return { success: true, data: (data ?? []) as ExchangeRate[] }
+  } catch {
+    return { success: false, error: 'Failed to fetch rates' }
+  }
+}
+
+/**
+ * Devuelve la última rate por cada par de currencies que la app maneja.
+ * 6 pares totales (USD↔COP, USD↔VES, VES↔COP en ambas direcciones).
+ *
+ * Es lo que el hook useExchangeRates va a cachear en memoria.
+ */
+export async function getAllRatePairs(): Promise<Result<ExchangeRate[]>> {
+  try {
+    const pairs: Array<{ from: Currency; to: Currency }> = [
+      { from: 'USD', to: 'COP' },
+      { from: 'COP', to: 'USD' },
+      { from: 'VES', to: 'COP' },
+      { from: 'COP', to: 'VES' },
+      { from: 'USD', to: 'VES' },
+      { from: 'VES', to: 'USD' },
+    ]
+
+    const results = await Promise.all(
+      pairs.map(({ from, to }) =>
+        insforge.database
+          .from('exchange_rates')
+          .select('*')
+          .eq('from_currency', from)
+          .eq('to_currency', to)
+          .order('date', { ascending: false })
+          .limit(1)
+          .maybeSingle()
+      )
+    )
+
+    const rates = results
+      .map((r) => r.data)
+      .filter((r): r is ExchangeRate => r != null)
+
+    return { success: true, data: rates }
+  } catch {
+    return { success: false, error: 'Failed to fetch rate pairs' }
+  }
+}
+
+/**
+ * Convierte un monto de una moneda a otra usando la última rate disponible.
+ * Si las monedas son iguales, devuelve el monto sin cambios.
+ * Si no encuentra rate, devuelve el monto sin cambios (no falla — degradación graceful).
+ */
+export async function convertCurrency(
+  amount: number,
+  from: Currency,
+  to: Currency
+): Promise<number> {
+  if (from === to) return amount
+
+  try {
+    const { data, error } = await insforge.database
+      .from('exchange_rates')
+      .select('rate')
+      .eq('from_currency', from)
+      .eq('to_currency', to)
+      .order('date', { ascending: false })
+      .limit(1)
+      .single()
+
+    if (error || !data) return amount
+
+    return amount * Number((data as { rate: number }).rate)
+  } catch {
+    return amount
+  }
+}


### PR DESCRIPTION
## Resumen

Última tarea de FASE 1. Portar las funciones read-only de \`exchangeRates\` del repo web + crear hook con caché module-level. Es la base que el dashboard, reports, budgets y cualquier vista multi-moneda van a consumir.

## Cambios

### \`lib/actions/exchangeRates.actions.ts\`

3 funciones adaptadas de \`insforgeAdmin\` → \`insforge\` (anon):

- \`getLatestRates()\` — últimas 20 rates (debug/admin).
- \`getAllRatePairs()\` — latest rate por par (6 pares totales: USD↔COP, USD↔VES, VES↔COP).
- \`convertCurrency(amount, from, to)\` — conversión one-shot. Degradación graceful: si no hay rate, devuelve el monto sin cambios.

**NO portamos \`updateExchangeRates()\`** — cron job server-side (vive en backend).

### \`hooks/useExchangeRates.ts\`

Hook con caché module-level. Patrón:

\`\`\`ts
let cachedRates: ExchangeRate[] | null = null  // ← compartida entre todos los callers

export function useExchangeRates() {
  const [rates, setRates] = useState(cachedRates ?? [])
  const [loading, setLoading] = useState(cachedRates === null)

  useEffect(() => {
    if (cachedRates !== null) return  // hit de caché

    let cancelled = false
    getAllRatePairs().then(...)
    return () => { cancelled = true }
  }, [])

  return { rates, loading }
}
\`\`\`

Las rates cambian 1x por día (cron). Cachearlas durante la sesión es suficiente. Refresh on next app launch.

Bonus: \`invalidateExchangeRatesCache()\` helper para forzar refetch.

## Decisión arquitectónica clave

Funciona con \`insforge\` (anon client) en lugar de \`insforgeAdmin\` (admin client) **gracias a las RLS policies** aplicadas en Setup - Login E2E. Anon puede SELECT en \`exchange_rates\`. Si en algún momento se restringen esas policies, esto rompería.

## Verificación

- ✅ \`npx tsc --noEmit\` limpio.
- 🟡 App levanta en simulador: pendiente. Los archivos no se usan todavía — solo se importan/exportan. Riesgo de regresión = mínimo.

## Estado de FASE 1 después de este merge

- ✅ T-1.1 — Tipos y Zod
- ✅ T-1.2 — Utilidades y hooks
- ✅ T-1.3 — Componentes UI base
- ✅ **T-1.4 — Exchange rates actions + hook** (este PR)

→ FASE 1 lista para cierre (PR \`develop → main\`).

## Conceptos en Obsidian

Bitácora: \`40 - Projects/expense-manager-native/T-1.4 — Exchange rates actions + hook.md\`. Conceptos aplicados:

- Module-level cache pattern
- Cancelable fetch (ya conocido) aplicado al hook
- Type guard en \`.filter\`
- Degradación graceful en \`convertCurrency\`

## Related

Closes #57
Related to #43 (FASE 1)