### PR TITLE
chore: add lucide-react-native icon library + Icon wrapper

### DIFF
--- a/app/(dashboard)/_layout.tsx
+++ b/app/(dashboard)/_layout.tsx
@@ -1,9 +1,9 @@
 // app/(dashboard)/_layout.tsx
 import { Tabs, router } from 'expo-router'
 import { useEffect } from 'react'
-import { Text } from 'react-native'
 import { useAuth } from '@/context/AuthContext'
 import { colors } from '@/constants/theme'
+import { Icon } from '@/components/ui/Icon'
 
 export default function DashboardLayout() {
   const { user, loading } = useAuth()
@@ -33,28 +33,36 @@ export default function DashboardLayout() {
         name="index"
         options={{
           title: 'Dashboard',
-          tabBarIcon: ({ color }) => <Text style={{ color, fontSize: 20 }}>📊</Text>,
+          tabBarIcon: ({ color, size }) => (
+            <Icon name="dashboard" color={color} size={size} />
+          ),
         }}
       />
       <Tabs.Screen
         name="transactions"
         options={{
           title: 'Transacciones',
-          tabBarIcon: ({ color }) => <Text style={{ color, fontSize: 20 }}>💸</Text>,
+          tabBarIcon: ({ color, size }) => (
+            <Icon name="transactions" color={color} size={size} />
+          ),
         }}
       />
       <Tabs.Screen
         name="accounts"
         options={{
           title: 'Cuentas',
-          tabBarIcon: ({ color }) => <Text style={{ color, fontSize: 20 }}>🏦</Text>,
+          tabBarIcon: ({ color, size }) => (
+            <Icon name="wallet" color={color} size={size} />
+          ),
         }}
       />
       <Tabs.Screen
         name="more"
         options={{
           title: 'Más',
-          tabBarIcon: ({ color }) => <Text style={{ color, fontSize: 20 }}>☰</Text>,
+          tabBarIcon: ({ color, size }) => (
+            <Icon name="menu" color={color} size={size} />
+          ),
         }}
       />
     </Tabs>

--- a/app/(dashboard)/transactions/[id].tsx
+++ b/app/(dashboard)/transactions/[id].tsx
@@ -14,6 +14,7 @@ import { getAccounts } from '@/lib/actions/accounts.actions'
 import { FormInput } from '@/components/ui/FormInput'
 import { SelectModal } from '@/components/ui/SelectModal'
 import { PrimaryButton } from '@/components/ui/PrimaryButton'
+import { Icon } from '@/components/ui/Icon'
 import type { Category, Account, Currency } from '@/types/database.types'
 
 const CURRENCY_OPTIONS = [
@@ -172,9 +173,16 @@ export default function TransactionFormScreen() {
                 type === t ? 'bg-primary border-primary' : 'bg-transparent border-border'
               }`}
             >
-              <Text className="text-white font-medium">
-                {t === 'expense' ? '🔴 Gasto' : '💚 Ingreso'}
-              </Text>
+              <View className="flex-row items-center gap-2">
+                <Icon
+                  name={t === 'expense' ? 'arrow-down-circle' : 'arrow-up-circle'}
+                  size={18}
+                  color="white"
+                />
+                <Text className="text-white font-medium">
+                  {t === 'expense' ? 'Gasto' : 'Ingreso'}
+                </Text>
+              </View>
             </TouchableOpacity>
           ))}
         </View>

--- a/components/ui/Icon.tsx
+++ b/components/ui/Icon.tsx
@@ -1,0 +1,64 @@
+import {
+  LayoutDashboard,
+  ArrowLeftRight,
+  Wallet,
+  Menu,
+  ArrowDownCircle,
+  ArrowUpCircle,
+  Repeat,
+  Plus,
+  ChevronRight,
+  X,
+  Check,
+  Trash2,
+  Pencil,
+  Search,
+  Settings,
+} from 'lucide-react-native'
+
+/**
+ * Wrapper sobre lucide-react-native. Centraliza el set de iconos usados en la app.
+ *
+ * Para añadir un icono nuevo:
+ * 1. Import desde 'lucide-react-native' arriba
+ * 2. Añadir al map `ICONS` con un nombre kebab-case descriptivo
+ * 3. Usar como `<Icon name="..." />` desde cualquier componente
+ *
+ * Catálogo completo de iconos: https://lucide.dev/icons/
+ */
+const ICONS = {
+  dashboard: LayoutDashboard,
+  transactions: ArrowLeftRight,
+  wallet: Wallet,
+  menu: Menu,
+  'arrow-down-circle': ArrowDownCircle,
+  'arrow-up-circle': ArrowUpCircle,
+  repeat: Repeat,
+  plus: Plus,
+  'chevron-right': ChevronRight,
+  x: X,
+  check: Check,
+  trash: Trash2,
+  edit: Pencil,
+  search: Search,
+  settings: Settings,
+} as const
+
+export type IconName = keyof typeof ICONS
+
+interface IconProps {
+  name: IconName
+  size?: number
+  color?: string
+  strokeWidth?: number
+}
+
+export function Icon({
+  name,
+  size = 20,
+  color = '#ffffff',
+  strokeWidth = 2,
+}: IconProps) {
+  const Component = ICONS[name]
+  return <Component size={size} color={color} strokeWidth={strokeWidth} />
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "expo-secure-store": "~15.0.8",
     "expo-status-bar": "~3.0.9",
     "expo-web-browser": "~15.0.11",
+    "lucide-react-native": "^1.16.0",
     "nativewind": "^4.2.3",
     "react": "19.1.0",
     "react-native": "0.81.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       expo-web-browser:
         specifier: ~15.0.11
         version: 15.0.11(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
+      lucide-react-native:
+        specifier: ^1.16.0
+        version: 1.16.0(react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       nativewind:
         specifier: ^4.2.3
         version: 4.2.3(react-native-reanimated@4.1.7(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.19(yaml@2.8.3))
@@ -2405,6 +2408,13 @@ packages:
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  lucide-react-native@1.16.0:
+    resolution: {integrity: sha512-clxA22OvrNUHB2tQQEvURN8KJ5/vbUV/6GSctU1aCoFlJmDwNrdo8xxNTG535tu7iOATZCth6R2AW1kbva+g6A==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-native: '*'
+      react-native-svg: ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0
 
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
@@ -6433,6 +6443,12 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react-native@1.16.0(react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
+      react-native-svg: 15.12.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
 
   makeerror@1.0.12:
     dependencies:


### PR DESCRIPTION
## Resumen

Reemplaza emojis de UI chrome (tabs, selectores de tipo) con iconos vectoriales coherentes via \`lucide-react-native\` + wrapper type-safe \`<Icon name=\"...\" />\`.

## Por qué

Los emojis se renderizan distinto entre iOS / Android / browsers, sin control de color ni tamaño. Para UI chrome (tabs, indicadores, botones) un icon lib da consistencia visual cross-platform.

User-data icons (categorías) siguen usando emoji — está bien para personalización del usuario.

## Cambios

### Nueva dep

- \`lucide-react-native ^1.16.0\` (peer dep \`react-native-svg\` ya estaba)
- Sin prebuild necesario.

### Nuevo wrapper

\`components/ui/Icon.tsx\` — single source de iconos usados en la app. Catálogo inicial con 15 iconos. Añadir un icono nuevo: import + agregar al map + usar como \`<Icon name=\"...\" />\`.

\`\`\`tsx
const ICONS = {
  dashboard: LayoutDashboard,
  transactions: ArrowLeftRight,
  wallet: Wallet,
  menu: Menu,
  'arrow-down-circle': ArrowDownCircle,
  'arrow-up-circle': ArrowUpCircle,
  // ... 15 total
} as const

export type IconName = keyof typeof ICONS
\`\`\`

### Aplicado a

| Archivo | Antes | Ahora |
|---|---|---|
| \`_layout.tsx\` (tabs) | \`📊💸🏦☰\` | \`dashboard / transactions / wallet / menu\` |
| \`transactions/[id].tsx\` (selector) | \`🔴 Gasto / 💚 Ingreso\` | \`arrow-down-circle / arrow-up-circle\` + label |

### NO tocado

- \`IconPicker.tsx\` — sigue mostrando emojis (user data, no UI chrome)
- Categorías storage en DB — siguen guardando emoji
- Pantallas con emojis incidentales (ej. en \`more.tsx\` el botón de signout) — refactor incremental

## Verificación

- ✅ \`npx tsc --noEmit\` limpio
- 🟡 Visual: pendiente que prueben en simulador

## Obsidian

\`10 - Concepts/React Native/lucide-react-native.md\` — concepto + comparación con alternativas + patrón wrapper.

## Después del merge

Vuelvo a la rama \`feature/61-categorias-crud\` (T-2.1) y aplico el wrapper al selector de tipo de categorías (también usa 🔴💚🔄 actualmente). Resumo Paso 4.