### PR TITLE
feat: categorías CRUD completo (T-2.1)

### DIFF
--- a/app/(dashboard)/categories/[id].tsx
+++ b/app/(dashboard)/categories/[id].tsx
@@ -1,0 +1,247 @@
+import { useEffect, useState } from 'react'
+import {
+  View,
+  Text,
+  ScrollView,
+  TouchableOpacity,
+  KeyboardAvoidingView,
+  Platform,
+  ActivityIndicator,
+} from 'react-native'
+import { useLocalSearchParams, router } from 'expo-router'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useAuth } from '@/context/AuthContext'
+import {
+  getCategoryById,
+  createCategory,
+  updateCategory,
+  deleteCategory,
+} from '@/lib/actions/categories.actions'
+import { FormInput } from '@/components/ui/FormInput'
+import { PrimaryButton } from '@/components/ui/PrimaryButton'
+import { IconPicker } from '@/components/ui/IconPicker'
+import { ColorPicker } from '@/components/ui/ColorPicker'
+import { confirmDialog } from '@/components/ui/ConfirmDialog'
+import { toast } from '@/components/ui/Toast'
+import { Icon, type IconName } from '@/components/ui/Icon'
+import type { CategoryType } from '@/types/database.types'
+
+const TYPE_OPTIONS: { value: CategoryType; label: string; icon: IconName }[] = [
+  { value: 'expense', label: 'Gasto', icon: 'arrow-down-circle' },
+  { value: 'income', label: 'Ingreso', icon: 'arrow-up-circle' },
+  { value: 'both', label: 'Ambos', icon: 'repeat' },
+]
+
+export default function CategoryFormScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>()
+  const { user } = useAuth()
+  const isNew = id === 'new'
+
+  const [initialLoading, setInitialLoading] = useState(!isNew)
+  const [saving, setSaving] = useState(false)
+
+  const [name, setName] = useState('')
+  const [type, setType] = useState<CategoryType>('expense')
+  const [icon, setIcon] = useState<string | null>(null)
+  const [color, setColor] = useState<string | null>(null)
+
+  const [showIconPicker, setShowIconPicker] = useState(false)
+  const [showColorPicker, setShowColorPicker] = useState(false)
+
+  useEffect(() => {
+    if (isNew || !user) return
+
+    let cancelled = false
+    getCategoryById(id, user.id).then((res) => {
+      if (cancelled) return
+      if (res.success && res.data) {
+        setName(res.data.name)
+        setType(res.data.type)
+        setIcon(res.data.icon)
+        setColor(res.data.color)
+      } else {
+        toast.error(res.error ?? 'Categoría no encontrada')
+        router.back()
+      }
+      setInitialLoading(false)
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [id, user, isNew])
+
+  async function handleSubmit() {
+    if (!user || !name.trim()) {
+      toast.error('El nombre es requerido')
+      return
+    }
+
+    setSaving(true)
+    const input = {
+      name: name.trim(),
+      type,
+      icon,
+      color,
+    }
+    const result = isNew
+      ? await createCategory(user.id, input)
+      : await updateCategory(id, user.id, input)
+
+    setSaving(false)
+    if (result.success) {
+      toast.success(isNew ? 'Categoría creada' : 'Categoría actualizada')
+      router.back()
+    } else {
+      toast.error(result.error ?? 'Error al guardar')
+    }
+  }
+
+  async function handleDelete() {
+    if (!user || isNew) return
+
+    const ok = await confirmDialog({
+      title: 'Eliminar categoría',
+      message: 'No se puede deshacer.',
+      confirmLabel: 'Eliminar',
+      destructive: true,
+    })
+    if (!ok) return
+
+    setSaving(true)
+    const result = await deleteCategory(id, user.id)
+    setSaving(false)
+    if (result.success) {
+      toast.success('Categoría eliminada')
+      router.back()
+    } else {
+      toast.error(result.error ?? 'Error al eliminar')
+    }
+  }
+
+  if (initialLoading) {
+    return (
+      <View className="flex-1 bg-bg items-center justify-center">
+        <ActivityIndicator color="#4F46E5" />
+      </View>
+    )
+  }
+
+  return (
+    <SafeAreaView edges={['top', 'bottom']} className="flex-1 bg-bg">
+      {/* Header */}
+      <View className="flex-row items-center justify-between px-4 py-3 border-b border-border">
+        <TouchableOpacity onPress={() => router.back()} activeOpacity={0.7}>
+          <Text className="text-primary text-base">← Volver</Text>
+        </TouchableOpacity>
+        <Text className="text-white text-base font-bold">
+          {isNew ? 'Nueva categoría' : 'Editar categoría'}
+        </Text>
+        {!isNew ? (
+          <TouchableOpacity
+            onPress={handleDelete}
+            disabled={saving}
+            activeOpacity={0.7}
+          >
+            <Text className="text-red-400 text-sm">Eliminar</Text>
+          </TouchableOpacity>
+        ) : (
+          <View style={{ width: 60 }} />
+        )}
+      </View>
+
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        className="flex-1"
+      >
+        <ScrollView
+          className="flex-1 px-4"
+          contentContainerStyle={{ paddingVertical: 16, paddingBottom: 40 }}
+          keyboardShouldPersistTaps="handled"
+        >
+          <FormInput
+            label="Nombre *"
+            value={name}
+            onChangeText={setName}
+            placeholder="Ej: Mercado"
+          />
+
+          {/* Tipo */}
+          <View className="mb-4">
+            <Text className="text-muted text-sm mb-1">Tipo</Text>
+            <View className="flex-row gap-2">
+              {TYPE_OPTIONS.map((opt) => (
+                <TouchableOpacity
+                  key={opt.value}
+                  onPress={() => setType(opt.value)}
+                  activeOpacity={0.7}
+                  className={`flex-1 py-3 rounded-xl items-center border ${
+                    type === opt.value
+                      ? 'bg-primary border-primary'
+                      : 'bg-transparent border-border'
+                  }`}
+                >
+                  <View className="flex-row items-center gap-2">
+                    <Icon name={opt.icon} size={18} color="white" />
+                    <Text className="text-white font-medium">{opt.label}</Text>
+                  </View>
+                </TouchableOpacity>
+              ))}
+            </View>
+          </View>
+
+          {/* Icon picker trigger */}
+          <View className="mb-4">
+            <Text className="text-muted text-sm mb-1">Icono</Text>
+            <TouchableOpacity
+              onPress={() => setShowIconPicker(true)}
+              activeOpacity={0.7}
+              className="bg-surface border border-border rounded-xl px-4 py-3 flex-row items-center justify-between"
+            >
+              <Text className="text-2xl">{icon ?? '📂'}</Text>
+              <Text className="text-muted text-sm">Cambiar</Text>
+            </TouchableOpacity>
+          </View>
+
+          {/* Color picker trigger */}
+          <View className="mb-4">
+            <Text className="text-muted text-sm mb-1">Color</Text>
+            <TouchableOpacity
+              onPress={() => setShowColorPicker(true)}
+              activeOpacity={0.7}
+              className="bg-surface border border-border rounded-xl px-4 py-3 flex-row items-center justify-between"
+            >
+              <View
+                style={{ backgroundColor: color ?? '#4F46E5' }}
+                className="w-10 h-10 rounded-full"
+              />
+              <Text className="text-muted text-sm">Cambiar</Text>
+            </TouchableOpacity>
+          </View>
+
+          <PrimaryButton
+            onPress={handleSubmit}
+            loading={saving}
+            disabled={!name.trim()}
+          >
+            {isNew ? 'Crear categoría' : 'Guardar cambios'}
+          </PrimaryButton>
+        </ScrollView>
+      </KeyboardAvoidingView>
+
+      {/* Pickers fuera del ScrollView (son Modales) */}
+      <IconPicker
+        visible={showIconPicker}
+        onClose={() => setShowIconPicker(false)}
+        selected={icon ?? undefined}
+        onSelect={setIcon}
+      />
+      <ColorPicker
+        visible={showColorPicker}
+        onClose={() => setShowColorPicker(false)}
+        selected={color ?? undefined}
+        onSelect={setColor}
+      />
+    </SafeAreaView>
+  )
+}

--- a/app/(dashboard)/categories/_layout.tsx
+++ b/app/(dashboard)/categories/_layout.tsx
@@ -1,0 +1,13 @@
+import { Stack } from 'expo-router'
+import { colors } from '@/constants/theme'
+
+export default function CategoriesLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: colors.bg },
+      }}
+    />
+  )
+}

--- a/app/(dashboard)/categories/index.tsx
+++ b/app/(dashboard)/categories/index.tsx
@@ -1,0 +1,157 @@
+import { useState, useCallback } from 'react'
+import {
+  View,
+  Text,
+  FlatList,
+  TouchableOpacity,
+  ActivityIndicator,
+} from 'react-native'
+import { router, useFocusEffect } from 'expo-router'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useAuth } from '@/context/AuthContext'
+import { getCategories } from '@/lib/actions/categories.actions'
+import { EmptyState } from '@/components/ui/EmptyState'
+import type { Category, CategoryType } from '@/types/database.types'
+
+const TYPE_LABELS: Record<CategoryType, string> = {
+  income: 'Ingreso',
+  expense: 'Gasto',
+  both: 'Ambos',
+}
+
+const TYPE_COLORS: Record<CategoryType, string> = {
+  income: 'text-green-400',
+  expense: 'text-red-400',
+  both: 'text-blue-400',
+}
+
+export default function CategoriesScreen() {
+  const { user } = useAuth()
+  const [categories, setCategories] = useState<Category[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const loadCategories = useCallback(async () => {
+    if (!user) return
+    const result = await getCategories(user.id)
+    if (result.success && result.data) {
+      setCategories(result.data)
+    }
+    setLoading(false)
+  }, [user])
+
+  useFocusEffect(
+    useCallback(() => {
+      let cancelled = false
+      ;(async () => {
+        await loadCategories()
+        if (cancelled) return
+      })()
+      return () => {
+        cancelled = true
+      }
+    }, [loadCategories])
+  )
+
+  if (loading) {
+    return (
+      <View className="flex-1 bg-bg items-center justify-center">
+        <ActivityIndicator color="#4F46E5" />
+      </View>
+    )
+  }
+
+  const userCategories = categories.filter((c) => c.user_id !== null)
+
+  return (
+    <SafeAreaView edges={['top']} className="flex-1 bg-bg">
+      {/* Header */}
+      <View className="flex-row items-center justify-between px-4 py-3 border-b border-border">
+        <TouchableOpacity onPress={() => router.back()} activeOpacity={0.7}>
+          <Text className="text-primary text-base">← Volver</Text>
+        </TouchableOpacity>
+        <Text className="text-white text-base font-bold">Categorías</Text>
+        <View style={{ width: 60 }} />
+      </View>
+
+      <FlatList
+        data={categories}
+        keyExtractor={(c) => c.id}
+        contentContainerStyle={
+          categories.length === 0
+            ? { flex: 1 }
+            : { paddingVertical: 8 }
+        }
+        ListEmptyComponent={
+          <EmptyState
+            icon="📂"
+            title="Sin categorías"
+            description="Toca + para crear tu primera categoría"
+          />
+        }
+        ListHeaderComponent={
+          userCategories.length === 0 && categories.length > 0 ? (
+            <View className="px-4 py-3">
+              <Text className="text-muted text-xs uppercase tracking-wider">
+                Categorías del sistema
+              </Text>
+            </View>
+          ) : null
+        }
+        renderItem={({ item }) => {
+          const isUserOwned = item.user_id !== null
+
+          return (
+            <TouchableOpacity
+              onPress={() => {
+                if (isUserOwned) router.push(`/categories/${item.id}`)
+              }}
+              disabled={!isUserOwned}
+              activeOpacity={isUserOwned ? 0.7 : 1}
+              className="flex-row items-center px-4 py-3 border-b border-border"
+            >
+              <View
+                style={{ backgroundColor: item.color ?? '#4F46E5' }}
+                className="w-10 h-10 rounded-full items-center justify-center mr-3"
+              >
+                <Text className="text-xl">{item.icon ?? '📂'}</Text>
+              </View>
+
+              <View className="flex-1">
+                <Text className="text-white text-base font-medium">
+                  {item.name}
+                </Text>
+                <Text className={`text-xs ${TYPE_COLORS[item.type]}`}>
+                  {TYPE_LABELS[item.type]}
+                </Text>
+              </View>
+
+              {isUserOwned ? (
+                <Text className="text-muted text-2xl">›</Text>
+              ) : (
+                <Text className="text-muted text-xs">Sistema</Text>
+              )}
+            </TouchableOpacity>
+          )
+        }}
+      />
+
+      {/* FAB — crear nueva */}
+      <TouchableOpacity
+        onPress={() => router.push('/categories/new')}
+        activeOpacity={0.8}
+        className="absolute bottom-6 right-6 w-14 h-14 rounded-full bg-primary items-center justify-center shadow-lg"
+        style={{
+          shadowColor: '#000',
+          shadowOffset: { width: 0, height: 4 },
+          shadowOpacity: 0.3,
+          shadowRadius: 6,
+          elevation: 6,
+        }}
+      >
+        <Text className="text-white text-3xl font-bold" style={{ lineHeight: 32 }}>
+          +
+        </Text>
+      </TouchableOpacity>
+    </SafeAreaView>
+  )
+}

--- a/app/(dashboard)/more.tsx
+++ b/app/(dashboard)/more.tsx
@@ -1,5 +1,6 @@
 // app/(dashboard)/more.tsx
 import { View, Text, TouchableOpacity } from 'react-native'
+import { router } from 'expo-router'
 import { useAuth } from '@/context/AuthContext'
 
 export default function MoreScreen() {
@@ -8,9 +9,18 @@ export default function MoreScreen() {
     <View className="flex-1 bg-bg items-center justify-center gap-4">
       <Text className="text-white text-xl font-bold">Más opciones</Text>
       <Text className="text-muted">Presupuestos, Metas, Reportes...</Text>
+
+      <TouchableOpacity
+        onPress={() => router.push('/categories')}
+        className="mt-4 bg-primary rounded-xl px-6 py-3"
+        activeOpacity={0.8}
+      >
+        <Text className="text-white font-semibold">Gestionar categorías</Text>
+      </TouchableOpacity>
+
       <TouchableOpacity
         onPress={signOut}
-        className="mt-8 border border-red-500 rounded-xl px-6 py-3"
+        className="mt-2 border border-red-500 rounded-xl px-6 py-3"
         activeOpacity={0.8}
       >
         <Text className="text-red-400 font-semibold">Cerrar sesión</Text>

--- a/lib/actions/categories.actions.ts
+++ b/lib/actions/categories.actions.ts
@@ -1,7 +1,23 @@
 import { insforge } from '@/lib/insforge'
 import type { Category } from '@/types/database.types'
+import {
+  createCategorySchema,
+  updateCategorySchema,
+  type CreateCategoryInput,
+  type UpdateCategoryInput,
+} from '@/lib/validations/category'
 
-export async function getCategories(userId: string): Promise<{ success: boolean; data?: Category[]; error?: string }> {
+interface Result<T = void> {
+  success: boolean
+  data?: T
+  error?: string
+}
+
+/**
+ * Lee categorías predefinidas (user_id IS NULL) + las del user.
+ * Las predefinidas vienen primero, ordenadas alfabéticamente cada grupo.
+ */
+export async function getCategories(userId: string): Promise<Result<Category[]>> {
   if (!userId) return { success: false, error: 'User ID requerido' }
   try {
     const [{ data: predefined, error: e1 }, { data: userCats, error: e2 }] = await Promise.all([
@@ -13,5 +29,147 @@ export async function getCategories(userId: string): Promise<{ success: boolean;
     return { success: true, data: [...(predefined ?? []), ...(userCats ?? [])] as Category[] }
   } catch {
     return { success: false, error: 'Error al cargar categorías' }
+  }
+}
+
+/**
+ * Lee una categoría por id. Devuelve también las predefinidas (user_id IS NULL).
+ * Bloquea acceso a categorías de otros users.
+ */
+export async function getCategoryById(
+  id: string,
+  userId: string
+): Promise<Result<Category>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const { data, error } = await insforge.database
+      .from('categories')
+      .select('*')
+      .eq('id', id)
+      .single()
+
+    if (error) throw error
+    if (!data) return { success: false, error: 'Categoría no encontrada' }
+
+    const cat = data as Category
+    if (cat.user_id !== null && cat.user_id !== userId) {
+      return { success: false, error: 'No tienes acceso a esta categoría' }
+    }
+    return { success: true, data: cat }
+  } catch {
+    return { success: false, error: 'Error al cargar categoría' }
+  }
+}
+
+/**
+ * Chequea si existe otra categoría del user con el mismo nombre (case-insensitive).
+ * Si `excludeId` se pasa, esa fila se excluye del check (útil para updates).
+ */
+async function checkDuplicateName(
+  userId: string,
+  name: string,
+  excludeId?: string
+): Promise<boolean> {
+  const { data } = await insforge.database
+    .from('categories')
+    .select('id, name')
+    .eq('user_id', userId)
+
+  if (!data) return false
+
+  return (data as Array<{ id: string; name: string }>).some((cat) => {
+    if (excludeId && cat.id === excludeId) return false
+    return cat.name.toUpperCase() === name.toUpperCase()
+  })
+}
+
+export async function createCategory(
+  userId: string,
+  input: CreateCategoryInput
+): Promise<Result<Category>> {
+  try {
+    const validated = createCategorySchema.parse(input)
+
+    const isDuplicate = await checkDuplicateName(userId, validated.name)
+    if (isDuplicate) {
+      return {
+        success: false,
+        error: `Ya existe una categoría con el nombre "${validated.name}"`,
+      }
+    }
+
+    const { data, error } = await insforge.database
+      .from('categories')
+      .insert([{ ...validated, user_id: userId }])
+      .select()
+      .single()
+
+    if (error) throw error
+    return { success: true, data: data as Category }
+  } catch {
+    return { success: false, error: 'Error al crear categoría' }
+  }
+}
+
+export async function updateCategory(
+  id: string,
+  userId: string,
+  input: UpdateCategoryInput
+): Promise<Result<Category>> {
+  try {
+    const validated = updateCategorySchema.parse(input)
+
+    if (validated.name) {
+      const isDuplicate = await checkDuplicateName(userId, validated.name, id)
+      if (isDuplicate) {
+        return {
+          success: false,
+          error: `Ya existe una categoría con el nombre "${validated.name}"`,
+        }
+      }
+    }
+
+    const { data, error } = await insforge.database
+      .from('categories')
+      .update(validated)
+      .eq('id', id)
+      .eq('user_id', userId)
+      .select()
+      .single()
+
+    if (error) throw error
+    return { success: true, data: data as Category }
+  } catch {
+    return { success: false, error: 'Error al actualizar categoría' }
+  }
+}
+
+export async function deleteCategory(id: string, userId: string): Promise<Result> {
+  try {
+    // Verificar que no haya transacciones asociadas
+    const { data: linkedTxs } = await insforge.database
+      .from('transactions')
+      .select('id')
+      .eq('category_id', id)
+      .eq('user_id', userId)
+      .limit(1)
+
+    if (linkedTxs && linkedTxs.length > 0) {
+      return {
+        success: false,
+        error: 'No se puede eliminar: la categoría tiene transacciones asociadas',
+      }
+    }
+
+    const { error } = await insforge.database
+      .from('categories')
+      .delete()
+      .eq('id', id)
+      .eq('user_id', userId)
+
+    if (error) throw error
+    return { success: true }
+  } catch {
+    return { success: false, error: 'Error al eliminar categoría' }
   }
 }


### PR DESCRIPTION
## Resumen

Primer CRUD completo de la app native. Lista + create + edit + delete de categorías. Es el banco de pruebas que valida los componentes UI de T-1.3 en producción real.

## Cambios

### \`lib/actions/categories.actions.ts\` (extender)

| Función | Para qué |
|---|---|
| \`createCategory\` | Zod validate + duplicate check case-insensitive + insert |
| \`updateCategory\` | Zod validate + duplicate (excluyendo propia) + update |
| \`deleteCategory\` | Bloquea si hay transactions ligadas (FK integrity manual) |
| \`getCategoryById\` | Helper con guard de ownership |

### \`app/(dashboard)/categories/\` (nuevo)

- \`_layout.tsx\` — Stack navigator headerless con bg dark.
- \`index.tsx\` — FlatList con dos clases visuales:
  - **Predefined** (\`user_id IS NULL\`): label \"Sistema\", tap disabled
  - **User-owned**: chevron \`›\`, tap navega a edit
  - \`<EmptyState />\` cuando no hay nada
  - **FAB** absoluto en bottom-right que abre \`/categories/new\`
- \`[id].tsx\` — form para create/edit:
  - FormInput para nombre
  - Selector horizontal de tipo (Gasto/Ingreso/Ambos) con [[Icon]] de Lucide
  - Trigger del [[IconPicker]] (modal con grid emojis)
  - Trigger del [[ColorPicker]] (modal con paleta)
  - PrimaryButton: Crear / Guardar
  - Botón \"Eliminar\" (solo edit mode) → [[ConfirmDialog]] destructive
  - [[Toast]] success/error en cada acción
  - Modales fuera del ScrollView (portal-style)

### \`app/(dashboard)/more.tsx\`

Botón \"Gestionar categorías\" que abre \`/categories\`. Cambio mínimo a propósito — **T-2.3 redesignará este screen como settings real**.

## Verificación

- ✅ \`npx tsc --noEmit\` limpio
- 🟡 Visual: pendiente — flow end-to-end en simulador iOS

## Cómo testear

1. Pull develop + checkout esta rama
2. \`pnpm ios\`
3. En la app, tap tab \"Más\" → \"Gestionar categorías\"
4. Probar:
   - Lista carga con predefined (Sistema) y user-owned mezcladas
   - FAB → \"Nueva categoría\" → llenar form → guardar → vuelves a lista
   - Tap una categoría tuya → editar → guardar
   - Botón \"Eliminar\" en edit → ConfirmDialog → confirmar → vuelves a lista
   - Toast success aparece en cada acción exitosa
   - Si intentás borrar una categoría con transacciones ligadas → toast error
   - Predefined no son tappable (correcto)

## Obsidian

Bitácora: \`40 - Projects/expense-manager-native/T-2.1 — Categorías CRUD.md\`. Conceptos aplicados + ejercicios opcionales.

**No hay notas nuevas en este PR** (T-2.1 solo aplica conceptos existentes — el Icon library se documentó en chore #62).

## Related

Closes #61
Related to #60 (FASE 2)

## Estado FASE 2

- 🟡 **T-2.1 — Categorías CRUD** (este PR)
- ⏳ T-2.2 — Filtros, búsqueda y paginación en Transacciones
- ⏳ T-2.3 — Settings screen real (reemplaza stub de More)