### PR TITLE
feat: filtros, búsqueda y paginación en transacciones (T-2.2)

### DIFF
--- a/app/(dashboard)/transactions/index.tsx
+++ b/app/(dashboard)/transactions/index.tsx
@@ -1,31 +1,168 @@
-import { View, Text, FlatList, TouchableOpacity, RefreshControl } from 'react-native'
-import { useState, useCallback } from 'react'
+import {
+  View,
+  Text,
+  FlatList,
+  TouchableOpacity,
+  RefreshControl,
+  ActivityIndicator,
+  TextInput,
+  ScrollView,
+} from 'react-native'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { router, useFocusEffect } from 'expo-router'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useAuth } from '@/context/AuthContext'
-import { getTransactions, deleteTransaction } from '@/lib/actions/transactions.actions'
+import {
+  getTransactions,
+  deleteTransaction,
+} from '@/lib/actions/transactions.actions'
+import { getCategories } from '@/lib/actions/categories.actions'
+import { getAccounts } from '@/lib/actions/accounts.actions'
 import { TransactionCard } from '@/components/transactions/TransactionCard'
-import type { TransactionWithCategory } from '@/types/database.types'
+import { Icon } from '@/components/ui/Icon'
+import { SelectModal } from '@/components/ui/SelectModal'
+import { useDebounce } from '@/hooks/useDebounce'
+import type {
+  TransactionWithCategory,
+  TransactionType,
+  Category,
+  Account,
+} from '@/types/database.types'
+
+const PAGE_SIZE = 20
+const SEARCH_DEBOUNCE_MS = 300
+
+type TypeFilter = TransactionType | 'all'
+
+const TYPE_OPTIONS: { label: string; value: TypeFilter }[] = [
+  { label: 'Todos', value: 'all' },
+  { label: 'Ingresos', value: 'income' },
+  { label: 'Gastos', value: 'expense' },
+]
+
+const TYPE_LABEL_BY_VALUE: Record<TypeFilter, string> = {
+  all: 'Todos',
+  income: 'Ingreso',
+  expense: 'Gasto',
+}
+
+/** Genera últimos 12 meses como opciones YYYY-MM con labels en español. */
+function getMonthOptions(): { label: string; value: string }[] {
+  const opts: { label: string; value: string }[] = []
+  const now = new Date()
+  for (let i = 0; i < 12; i++) {
+    const d = new Date(now.getFullYear(), now.getMonth() - i, 1)
+    const value = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`
+    const raw = d.toLocaleDateString('es', { month: 'long', year: 'numeric' })
+    const label = raw.charAt(0).toUpperCase() + raw.slice(1)
+    opts.push({ label, value })
+  }
+  return opts
+}
 
 export default function TransactionsScreen() {
   const { user } = useAuth()
+
   const [transactions, setTransactions] = useState<TransactionWithCategory[]>([])
   const [loading, setLoading] = useState(true)
   const [refreshing, setRefreshing] = useState(false)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [hasMore, setHasMore] = useState(false)
+  const [page, setPage] = useState(1)
 
-  const fetchTransactions = useCallback(async () => {
+  // Filtros
+  const [search, setSearch] = useState('')
+  const debouncedSearch = useDebounce(search, SEARCH_DEBOUNCE_MS)
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>('all')
+  const [categoryFilter, setCategoryFilter] = useState<string | null>(null)
+  const [accountFilter, setAccountFilter] = useState<string | null>(null)
+  const [monthFilter, setMonthFilter] = useState<string | null>(null)
+
+  // Modales de filtros
+  const [showTypeModal, setShowTypeModal] = useState(false)
+  const [showCategoryModal, setShowCategoryModal] = useState(false)
+  const [showAccountModal, setShowAccountModal] = useState(false)
+  const [showMonthModal, setShowMonthModal] = useState(false)
+
+  // Opciones que vienen del backend
+  const [categories, setCategories] = useState<Category[]>([])
+  const [accounts, setAccounts] = useState<Account[]>([])
+
+  const loadingMoreRef = useRef(false)
+
+  // Cargar categorías y cuentas para los pickers (una sola vez)
+  useEffect(() => {
     if (!user) return
-    const result = await getTransactions(user.id)
-    if (result.success && result.data) setTransactions(result.data)
-    setLoading(false)
-    setRefreshing(false)
+    let cancelled = false
+    Promise.all([getCategories(user.id), getAccounts(user.id)]).then(
+      ([catsRes, accsRes]) => {
+        if (cancelled) return
+        if (catsRes.success && catsRes.data) setCategories(catsRes.data)
+        if (accsRes.success && accsRes.data) setAccounts(accsRes.data)
+      }
+    )
+    return () => {
+      cancelled = true
+    }
   }, [user])
+
+  const loadPage = useCallback(
+    async (pageNum: number, mode: 'reset' | 'append') => {
+      if (!user) return
+      if (mode === 'append') {
+        if (loadingMoreRef.current) return
+        loadingMoreRef.current = true
+        setLoadingMore(true)
+      }
+
+      const result = await getTransactions(
+        user.id,
+        {
+          search: debouncedSearch,
+          type: typeFilter !== 'all' ? typeFilter : undefined,
+          categoryId: categoryFilter ?? undefined,
+          accountId: accountFilter ?? undefined,
+          month: monthFilter ?? undefined,
+        },
+        { page: pageNum, pageSize: PAGE_SIZE }
+      )
+
+      if (result.success && result.data) {
+        if (mode === 'reset') {
+          setTransactions(result.data.items)
+        } else {
+          setTransactions((prev) => [...prev, ...result.data!.items])
+        }
+        setHasMore(result.data.hasMore)
+        setPage(pageNum)
+      }
+
+      if (mode === 'append') {
+        loadingMoreRef.current = false
+        setLoadingMore(false)
+      } else {
+        setLoading(false)
+        setRefreshing(false)
+      }
+    },
+    [user, debouncedSearch, typeFilter, categoryFilter, accountFilter, monthFilter]
+  )
 
   useFocusEffect(
     useCallback(() => {
-      fetchTransactions()
-    }, [fetchTransactions])
+      loadPage(1, 'reset')
+    }, [loadPage])
   )
+
+  function handleRefresh() {
+    setRefreshing(true)
+    loadPage(1, 'reset')
+  }
+
+  function handleEndReached() {
+    if (!hasMore || loading) return
+    loadPage(page + 1, 'append')
+  }
 
   async function handleDelete(id: string) {
     if (!user) return
@@ -35,15 +172,138 @@ export default function TransactionsScreen() {
     }
   }
 
+  // Opciones derivadas
+  const monthOptions = useMemo(() => getMonthOptions(), [])
+  const categoryOptions = useMemo(
+    () => [
+      { label: 'Todas', value: '' },
+      ...categories.map((c) => ({
+        label: `${c.icon ?? ''} ${c.name}`.trim(),
+        value: c.id,
+      })),
+    ],
+    [categories]
+  )
+  const accountOptions = useMemo(
+    () => [
+      { label: 'Todas', value: '' },
+      ...accounts.map((a) => ({
+        label: `${a.icon ?? '💳'} ${a.name}`,
+        value: a.id,
+      })),
+    ],
+    [accounts]
+  )
+  const monthOptionsWithAll = useMemo(
+    () => [{ label: 'Todos los meses', value: '' }, ...monthOptions],
+    [monthOptions]
+  )
+
+  // Labels para chips
+  const categoryLabel = categoryFilter
+    ? categories.find((c) => c.id === categoryFilter)?.name ?? 'Todas'
+    : 'Todas'
+  const accountLabel = accountFilter
+    ? accounts.find((a) => a.id === accountFilter)?.name ?? 'Todas'
+    : 'Todas'
+  const monthLabel = monthFilter
+    ? monthOptions.find((m) => m.value === monthFilter)?.label ?? 'Todos'
+    : 'Todos'
+
+  const anyFilterActive =
+    typeFilter !== 'all' || categoryFilter || accountFilter || monthFilter
+
+  function clearAllFilters() {
+    setTypeFilter('all')
+    setCategoryFilter(null)
+    setAccountFilter(null)
+    setMonthFilter(null)
+  }
+
+  function renderFooter() {
+    if (!loadingMore) return null
+    return (
+      <View className="py-4">
+        <ActivityIndicator color="#4F46E5" />
+      </View>
+    )
+  }
+
   return (
     <SafeAreaView edges={['top']} className="flex-1 bg-bg">
       <View className="px-4 py-3 border-b border-border">
         <Text className="text-white text-xl font-bold">Transacciones</Text>
       </View>
 
+      {/* Search bar */}
+      <View className="mx-4 mt-3 mb-2 flex-row items-center bg-surface rounded-xl px-3 py-2">
+        <Icon name="search" size={18} color="#B0B0B0" />
+        <TextInput
+          value={search}
+          onChangeText={setSearch}
+          placeholder="Buscar por descripción..."
+          placeholderTextColor="#6b7280"
+          className="flex-1 ml-2 text-white"
+          autoCapitalize="none"
+          autoCorrect={false}
+        />
+        {search.length > 0 ? (
+          <TouchableOpacity
+            onPress={() => setSearch('')}
+            activeOpacity={0.6}
+            className="p-1"
+          >
+            <Icon name="x" size={16} color="#B0B0B0" />
+          </TouchableOpacity>
+        ) : null}
+      </View>
+
+      {/* Filter chips */}
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 8 }}
+        className="flex-grow-0"
+      >
+        <FilterChip
+          label="Tipo"
+          value={TYPE_LABEL_BY_VALUE[typeFilter]}
+          active={typeFilter !== 'all'}
+          onPress={() => setShowTypeModal(true)}
+        />
+        <FilterChip
+          label="Categoría"
+          value={categoryLabel}
+          active={!!categoryFilter}
+          onPress={() => setShowCategoryModal(true)}
+        />
+        <FilterChip
+          label="Cuenta"
+          value={accountLabel}
+          active={!!accountFilter}
+          onPress={() => setShowAccountModal(true)}
+        />
+        <FilterChip
+          label="Mes"
+          value={monthLabel}
+          active={!!monthFilter}
+          onPress={() => setShowMonthModal(true)}
+        />
+        {anyFilterActive ? (
+          <TouchableOpacity
+            onPress={clearAllFilters}
+            activeOpacity={0.6}
+            className="flex-row items-center px-3 py-2 ml-2 rounded-full border border-red-500/50"
+          >
+            <Icon name="x" size={14} color="#f87171" />
+            <Text className="text-red-400 text-sm ml-1">Limpiar</Text>
+          </TouchableOpacity>
+        ) : null}
+      </ScrollView>
+
       {loading ? (
         <View className="flex-1 items-center justify-center">
-          <Text className="text-muted">Cargando...</Text>
+          <ActivityIndicator color="#4F46E5" />
         </View>
       ) : (
         <FlatList
@@ -59,17 +319,28 @@ export default function TransactionsScreen() {
           refreshControl={
             <RefreshControl
               refreshing={refreshing}
-              onRefresh={() => { setRefreshing(true); fetchTransactions() }}
+              onRefresh={handleRefresh}
               tintColor="#4F46E5"
             />
           }
+          onEndReached={handleEndReached}
+          onEndReachedThreshold={0.5}
+          ListFooterComponent={renderFooter}
           ListEmptyComponent={
             <View className="items-center mt-20">
-              <Text className="text-muted text-base">No hay transacciones</Text>
-              <Text className="text-muted text-sm mt-1">Toca + para crear una</Text>
+              <Text className="text-muted text-base">
+                {anyFilterActive || debouncedSearch
+                  ? 'Sin resultados'
+                  : 'No hay transacciones'}
+              </Text>
+              <Text className="text-muted text-sm mt-1">
+                {anyFilterActive || debouncedSearch
+                  ? 'Ajustá los filtros o limpiálos'
+                  : 'Toca + para crear una'}
+              </Text>
             </View>
           }
-          contentContainerStyle={{ paddingBottom: 100, paddingTop: 8 }}
+          contentContainerStyle={{ paddingBottom: 100, paddingTop: 4 }}
         />
       )}
 
@@ -81,6 +352,80 @@ export default function TransactionsScreen() {
       >
         <Text className="text-white text-3xl leading-none">+</Text>
       </TouchableOpacity>
+
+      {/* Modales de filtros */}
+      <SelectModal
+        visible={showTypeModal}
+        onClose={() => setShowTypeModal(false)}
+        title="Filtrar por tipo"
+        options={TYPE_OPTIONS}
+        selected={typeFilter}
+        onSelect={(v) => {
+          setTypeFilter(v as TypeFilter)
+          setShowTypeModal(false)
+        }}
+      />
+      <SelectModal
+        visible={showCategoryModal}
+        onClose={() => setShowCategoryModal(false)}
+        title="Filtrar por categoría"
+        options={categoryOptions}
+        selected={categoryFilter ?? ''}
+        onSelect={(v) => {
+          setCategoryFilter(v || null)
+          setShowCategoryModal(false)
+        }}
+      />
+      <SelectModal
+        visible={showAccountModal}
+        onClose={() => setShowAccountModal(false)}
+        title="Filtrar por cuenta"
+        options={accountOptions}
+        selected={accountFilter ?? ''}
+        onSelect={(v) => {
+          setAccountFilter(v || null)
+          setShowAccountModal(false)
+        }}
+      />
+      <SelectModal
+        visible={showMonthModal}
+        onClose={() => setShowMonthModal(false)}
+        title="Filtrar por mes"
+        options={monthOptionsWithAll}
+        selected={monthFilter ?? ''}
+        onSelect={(v) => {
+          setMonthFilter(v || null)
+          setShowMonthModal(false)
+        }}
+      />
     </SafeAreaView>
+  )
+}
+
+interface FilterChipProps {
+  label: string
+  value: string
+  active: boolean
+  onPress: () => void
+}
+
+function FilterChip({ label, value, active, onPress }: FilterChipProps) {
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      activeOpacity={0.7}
+      className={`flex-row items-center px-3 py-2 mr-2 rounded-full border ${
+        active
+          ? 'bg-primary/20 border-primary'
+          : 'bg-surface border-border'
+      }`}
+    >
+      <Text className={`text-xs ${active ? 'text-primary' : 'text-muted'}`}>
+        {label}:
+      </Text>
+      <Text className={`text-sm font-medium ml-1 ${active ? 'text-white' : 'text-white'}`}>
+        {value}
+      </Text>
+    </TouchableOpacity>
   )
 }

--- a/app/(dashboard)/transactions/index.tsx
+++ b/app/(dashboard)/transactions/index.tsx
@@ -6,7 +6,6 @@ import {
   RefreshControl,
   ActivityIndicator,
   TextInput,
-  ScrollView,
 } from 'react-native'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { router, useFocusEffect } from 'expo-router'
@@ -259,12 +258,7 @@ export default function TransactionsScreen() {
       </View>
 
       {/* Filter chips */}
-      <ScrollView
-        horizontal
-        showsHorizontalScrollIndicator={false}
-        contentContainerStyle={{ paddingHorizontal: 16, paddingBottom: 8 }}
-        className="flex-grow-0"
-      >
+      <View className="flex-row flex-wrap px-4 pb-2 gap-2">
         <FilterChip
           label="Tipo"
           value={TYPE_LABEL_BY_VALUE[typeFilter]}
@@ -293,13 +287,13 @@ export default function TransactionsScreen() {
           <TouchableOpacity
             onPress={clearAllFilters}
             activeOpacity={0.6}
-            className="flex-row items-center px-3 py-2 ml-2 rounded-full border border-red-500/50"
+            className="flex-row items-center px-3 py-2 rounded-full border border-red-500/50"
           >
             <Icon name="x" size={14} color="#f87171" />
             <Text className="text-red-400 text-sm ml-1">Limpiar</Text>
           </TouchableOpacity>
         ) : null}
-      </ScrollView>
+      </View>
 
       {loading ? (
         <View className="flex-1 items-center justify-center">
@@ -414,7 +408,7 @@ function FilterChip({ label, value, active, onPress }: FilterChipProps) {
     <TouchableOpacity
       onPress={onPress}
       activeOpacity={0.7}
-      className={`flex-row items-center px-3 py-2 mr-2 rounded-full border ${
+      className={`flex-row items-center px-3 py-2 rounded-full border ${
         active ? 'bg-primary/20 border-primary' : 'bg-surface border-border'
       }`}
     >

--- a/app/(dashboard)/transactions/index.tsx
+++ b/app/(dashboard)/transactions/index.tsx
@@ -415,17 +415,17 @@ function FilterChip({ label, value, active, onPress }: FilterChipProps) {
       onPress={onPress}
       activeOpacity={0.7}
       className={`flex-row items-center px-3 py-2 mr-2 rounded-full border ${
-        active
-          ? 'bg-primary/20 border-primary'
-          : 'bg-surface border-border'
+        active ? 'bg-primary/20 border-primary' : 'bg-surface border-border'
       }`}
     >
-      <Text className={`text-xs ${active ? 'text-primary' : 'text-muted'}`}>
-        {label}:
-      </Text>
-      <Text className={`text-sm font-medium ml-1 ${active ? 'text-white' : 'text-white'}`}>
-        {value}
-      </Text>
+      {active ? (
+        <>
+          <Text className="text-xs text-primary">{label}:</Text>
+          <Text className="text-sm font-medium ml-1 text-white">{value}</Text>
+        </>
+      ) : (
+        <Text className="text-sm font-medium text-muted">{label}</Text>
+      )}
     </TouchableOpacity>
   )
 }

--- a/lib/actions/transactions.actions.ts
+++ b/lib/actions/transactions.actions.ts
@@ -5,22 +5,82 @@ import {
   type CreateTransactionInput,
   type UpdateTransactionInput,
 } from '@/lib/validations/transaction'
-import type { TransactionWithCategory } from '@/types/database.types'
+import type { TransactionWithCategory, TransactionType } from '@/types/database.types'
 
+export interface GetTransactionsFilters {
+  search?: string
+  type?: TransactionType | 'all'
+  categoryId?: string | null
+  accountId?: string | null
+  /** Formato 'YYYY-MM'. Si presente, filtra al mes calendar exacto. */
+  month?: string | null
+}
+
+export interface GetTransactionsPagination {
+  page?: number
+  pageSize?: number
+}
+
+export interface GetTransactionsResult {
+  items: TransactionWithCategory[]
+  hasMore: boolean
+}
+
+/**
+ * Lista transacciones del user con filtros y paginación server-side.
+ * Sin params, devuelve la primera página de 20 ordenadas por fecha descendente.
+ *
+ * `hasMore` se determina pidiendo `pageSize + 1` rows y chequeando si llegan
+ * más de las esperadas. Si sí, devolvemos solo `pageSize` y marcamos hasMore.
+ */
 export async function getTransactions(
   userId: string,
-  limit = 100
-): Promise<{ success: boolean; data?: TransactionWithCategory[]; error?: string }> {
+  filters: GetTransactionsFilters = {},
+  pagination: GetTransactionsPagination = {}
+): Promise<{ success: boolean; data?: GetTransactionsResult; error?: string }> {
   if (!userId) return { success: false, error: 'User ID requerido' }
+
+  const { search, type, categoryId, accountId, month } = filters
+  const { page = 1, pageSize = 20 } = pagination
+
   try {
-    const { data, error } = await insforge.database
+    let query = insforge.database
       .from('transactions')
       .select('*, category:categories(*)')
       .eq('user_id', userId)
-      .order('date', { ascending: false })
-      .limit(limit)
+
+    if (search && search.trim()) {
+      query = query.ilike('description', `%${search.trim()}%`)
+    }
+    if (type && type !== 'all') {
+      query = query.eq('type', type)
+    }
+    if (categoryId) {
+      query = query.eq('category_id', categoryId)
+    }
+    if (accountId) {
+      query = query.eq('account_id', accountId)
+    }
+    if (month) {
+      const [year, mo] = month.split('-').map(Number)
+      const start = new Date(year, mo - 1, 1)
+      const end = new Date(year, mo, 1)
+      const startDate = start.toISOString().slice(0, 10)
+      const endDate = end.toISOString().slice(0, 10)
+      query = query.gte('date', startDate).lt('date', endDate)
+    }
+
+    const from = (page - 1) * pageSize
+    const to = from + pageSize // pedimos 1 extra para detectar hasMore
+
+    const { data, error } = await query.order('date', { ascending: false }).range(from, to)
     if (error) throw error
-    return { success: true, data: (data ?? []) as TransactionWithCategory[] }
+
+    const rows = (data ?? []) as TransactionWithCategory[]
+    const hasMore = rows.length > pageSize
+    const items = hasMore ? rows.slice(0, pageSize) : rows
+
+    return { success: true, data: { items, hasMore } }
   } catch {
     return { success: false, error: 'Error al cargar transacciones' }
   }


### PR DESCRIPTION
## Resumen

Pantalla de transacciones ahora soporta búsqueda full-text con debounce, 4 filtros (tipo / categoría / cuenta / mes) y paginación server-side infinita. Mucho más usable a medida que crecen las transacciones.

## Cambios

### \`lib/actions/transactions.actions.ts\`

\`getTransactions\` ahora acepta filtros y paginación:

\`\`\`ts
getTransactions(
  userId: string,
  filters: { search?, type?, categoryId?, accountId?, month? } = {},
  pagination: { page?, pageSize? } = {}
): Promise<{ data: { items, hasMore } }>
\`\`\`

- Filtros se aplican con SQL: \`.ilike(description, %text%)\`, \`.eq()\`, \`.gte()/.lt()\` para mes.
- Paginación: \`.range(from, to)\` con N+1 trick para detectar \`hasMore\`.
- BREAKING: shape de retorno cambió. Único caller actualizado.

### \`app/(dashboard)/transactions/index.tsx\`

Reescritura del screen con todas las features:

1. **Búsqueda** — TextInput con icon search + clear, debounce 300ms via [[useDebounce]].
2. **Filtros** — 4 \`<FilterChip />\` inline (Tipo, Categoría, Cuenta, Mes) que abren \`<SelectModal>\`. Botón \"Limpiar\" cuando hay filtros activos.
3. **Paginación** — \`onEndReached\` + \`useRef\` lock anti-dobles + footer ActivityIndicator. Patrón [[Infinite scroll en FlatList]].
4. **Reset automático al cambiar filtros** — \`loadPage\` useCallback depende de todos los filtros; su identity cambia → useFocusEffect re-corre → reset. Una sola fuente de verdad.
5. **Empty state diferenciado** — \"Sin resultados\" con filtros activos vs \"No hay transacciones\" con lista vacía real.

## Verificación

- ✅ \`npx tsc --noEmit\` limpio
- ✅ Visual: probado en simulador (usuario validó búsqueda + paginación durante el desarrollo)

## Cómo testear (refresher)

1. Pull develop + \`pnpm ios\`
2. Tab \"Transacciones\"
3. **Búsqueda**: tipea — debería esperar 300ms tras pausa antes de filtrar.
4. **Paginación**: scroll abajo cuando hay >20 transacciones → spinner footer + carga 20 más.
5. **Filtros**: tap chip → SelectModal → seleccionar valor → chip muestra valor + bg primary.
6. **Combinación**: aplica varios filtros simultáneos.
7. **Limpiar**: cuando hay filtros, aparece botón \"Limpiar\" (rojo).
8. **Pull-to-refresh**: resetea paginación a página 1.

## Notas Obsidian creadas

- \`10 - Concepts/React/useDebounce.md\` — folder nuevo, primera nota React-generic del vault.
- \`30 - Patterns/Infinite scroll en FlatList.md\` — patrón completo con N+1 trick y useRef lock.

Ambas linkean cross.

## Related

Closes #64
Related to #60 (FASE 2)

## Estado FASE 2

- ✅ T-2.1 — Categorías CRUD
- 🟡 **T-2.2 — Filtros, búsqueda, paginación transacciones** (este PR)
- ⏳ T-2.3 — Settings screen real