### PR TITLE
feat: settings screen real con perfil, preferencias, conexiones (T-2.3)

### DIFF
--- a/app/(dashboard)/more.tsx
+++ b/app/(dashboard)/more.tsx
@@ -1,30 +1,222 @@
 // app/(dashboard)/more.tsx
-import { View, Text, TouchableOpacity } from 'react-native'
+import { useState } from 'react'
+import {
+  View,
+  Text,
+  ScrollView,
+  TouchableOpacity,
+  Image,
+  ActivityIndicator,
+} from 'react-native'
 import { router } from 'expo-router'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import { useAuth } from '@/context/AuthContext'
+import { updateUser } from '@/lib/actions/users.actions'
+import { SelectModal } from '@/components/ui/SelectModal'
+import { Icon, type IconName } from '@/components/ui/Icon'
+import { toast } from '@/components/ui/Toast'
+import type { Currency } from '@/types/database.types'
+
+const CURRENCY_OPTIONS: { label: string; value: string }[] = [
+  { label: 'COP — Peso Colombiano', value: 'COP' },
+  { label: 'USD — Dólar', value: 'USD' },
+  { label: 'VES — Bolívar (Bs)', value: 'VES' },
+]
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—'
+  const d = new Date(iso)
+  return d.toLocaleDateString('es', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  })
+}
 
 export default function MoreScreen() {
-  const { signOut } = useAuth()
+  const { user, signOut, refreshUser } = useAuth()
+  const [showCurrency, setShowCurrency] = useState(false)
+  const [savingCurrency, setSavingCurrency] = useState(false)
+
+  if (!user) {
+    return (
+      <View className="flex-1 bg-bg items-center justify-center">
+        <ActivityIndicator color="#4F46E5" />
+      </View>
+    )
+  }
+
+  async function handleCurrencyChange(value: string) {
+    setShowCurrency(false)
+    if (!user || value === user.preferred_currency) return
+    setSavingCurrency(true)
+    const result = await updateUser(user.id, {
+      preferred_currency: value as Currency,
+    })
+    setSavingCurrency(false)
+    if (result.success) {
+      await refreshUser()
+      toast.success('Moneda actualizada')
+    } else {
+      toast.error(result.error ?? 'Error al actualizar moneda')
+    }
+  }
+
+  const gmailConnected = !!user.gmail_connected_at
+  const initial = (user.name ?? user.email).charAt(0).toUpperCase()
+
   return (
-    <View className="flex-1 bg-bg items-center justify-center gap-4">
-      <Text className="text-white text-xl font-bold">Más opciones</Text>
-      <Text className="text-muted">Presupuestos, Metas, Reportes...</Text>
+    <SafeAreaView edges={['top']} className="flex-1 bg-bg">
+      <View className="px-4 py-3 border-b border-border">
+        <Text className="text-white text-xl font-bold">Más opciones</Text>
+      </View>
 
-      <TouchableOpacity
-        onPress={() => router.push('/categories')}
-        className="mt-4 bg-primary rounded-xl px-6 py-3"
-        activeOpacity={0.8}
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={{ paddingBottom: 40 }}
       >
-        <Text className="text-white font-semibold">Gestionar categorías</Text>
-      </TouchableOpacity>
+        {/* Profile card */}
+        <View className="px-4 py-6 flex-row items-center border-b border-border">
+          {user.avatar_url ? (
+            <Image
+              source={{ uri: user.avatar_url }}
+              className="w-16 h-16 rounded-full mr-4"
+            />
+          ) : (
+            <View className="w-16 h-16 rounded-full bg-primary items-center justify-center mr-4">
+              <Text className="text-white text-2xl font-bold">{initial}</Text>
+            </View>
+          )}
+          <View className="flex-1">
+            {user.name ? (
+              <Text className="text-white text-lg font-semibold">
+                {user.name}
+              </Text>
+            ) : null}
+            <Text className="text-muted text-sm">{user.email}</Text>
+          </View>
+        </View>
 
-      <TouchableOpacity
-        onPress={signOut}
-        className="mt-2 border border-red-500 rounded-xl px-6 py-3"
-        activeOpacity={0.8}
-      >
-        <Text className="text-red-400 font-semibold">Cerrar sesión</Text>
-      </TouchableOpacity>
+        {/* Preferencias */}
+        <SectionHeader title="Preferencias" />
+        <SettingsRow
+          icon="wallet"
+          label="Moneda preferida"
+          value={user.preferred_currency}
+          onPress={() => setShowCurrency(true)}
+          loading={savingCurrency}
+        />
+
+        {/* Conexiones */}
+        <SectionHeader title="Conexiones" />
+        <View className="px-4 py-3 border-b border-border">
+          <View className="flex-row items-center">
+            <View className="w-9 h-9 rounded-full bg-surface items-center justify-center mr-3">
+              <Text className="text-base">✉️</Text>
+            </View>
+            <View className="flex-1">
+              <Text className="text-white text-base">Gmail</Text>
+              <Text
+                className={
+                  gmailConnected
+                    ? 'text-green-400 text-xs mt-0.5'
+                    : 'text-muted text-xs mt-0.5'
+                }
+              >
+                {gmailConnected ? 'Conectado' : 'No conectado'}
+              </Text>
+            </View>
+          </View>
+          {gmailConnected ? (
+            <View className="ml-12 mt-2 gap-0.5">
+              <Text className="text-muted text-xs">
+                Conectado el {formatDate(user.gmail_connected_at)}
+              </Text>
+              <Text className="text-muted text-xs">
+                Última sync: {formatDate(user.gmail_last_synced_at)}
+              </Text>
+            </View>
+          ) : null}
+        </View>
+
+        {/* Datos */}
+        <SectionHeader title="Datos" />
+        <SettingsRow
+          icon="dashboard"
+          label="Categorías"
+          onPress={() => router.push('/categories')}
+        />
+
+        {/* Sign out */}
+        <View className="px-4 pt-10">
+          <TouchableOpacity
+            onPress={signOut}
+            activeOpacity={0.8}
+            className="border border-red-500 rounded-xl py-3 items-center"
+          >
+            <Text className="text-red-400 font-semibold">Cerrar sesión</Text>
+          </TouchableOpacity>
+        </View>
+      </ScrollView>
+
+      <SelectModal
+        visible={showCurrency}
+        onClose={() => setShowCurrency(false)}
+        title="Moneda preferida"
+        options={CURRENCY_OPTIONS}
+        selected={user.preferred_currency}
+        onSelect={handleCurrencyChange}
+      />
+    </SafeAreaView>
+  )
+}
+
+function SectionHeader({ title }: { title: string }) {
+  return (
+    <View className="px-4 pt-6 pb-2">
+      <Text className="text-muted text-xs uppercase tracking-wider">
+        {title}
+      </Text>
     </View>
+  )
+}
+
+interface SettingsRowProps {
+  icon: IconName
+  label: string
+  value?: string
+  onPress: () => void
+  loading?: boolean
+}
+
+function SettingsRow({
+  icon,
+  label,
+  value,
+  onPress,
+  loading,
+}: SettingsRowProps) {
+  return (
+    <TouchableOpacity
+      onPress={onPress}
+      activeOpacity={0.7}
+      disabled={loading}
+      className="px-4 py-3 flex-row items-center border-b border-border"
+    >
+      <View className="w-9 h-9 rounded-full bg-surface items-center justify-center mr-3">
+        <Icon name={icon} size={18} color="#B0B0B0" />
+      </View>
+      <Text className="text-white text-base flex-1">{label}</Text>
+      {loading ? (
+        <ActivityIndicator color="#4F46E5" size="small" />
+      ) : (
+        <View className="flex-row items-center">
+          {value ? (
+            <Text className="text-muted text-sm mr-2">{value}</Text>
+          ) : null}
+          <Icon name="chevron-right" size={18} color="#6b7280" />
+        </View>
+      )}
+    </TouchableOpacity>
   )
 }

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -11,6 +11,8 @@ interface AuthState {
   loading: boolean
   onSignIn: (email: string) => Promise<void>
   signOut: () => Promise<void>
+  /** Re-carga el user actual desde DB. Usar tras actualizar el perfil. */
+  refreshUser: () => Promise<void>
 }
 
 const AuthContext = createContext<AuthState>({
@@ -18,6 +20,7 @@ const AuthContext = createContext<AuthState>({
   loading: true,
   onSignIn: async () => {},
   signOut: async () => {},
+  refreshUser: async () => {},
 })
 
 export function AuthProvider({ children }: { children: ReactNode }) {
@@ -61,8 +64,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setUser(null)
   }
 
+  async function refreshUser() {
+    const email = await SecureStore.getItemAsync(USER_EMAIL_KEY)
+    if (!email) return
+    await loadUserProfile(email)
+  }
+
   return (
-    <AuthContext.Provider value={{ user, loading, onSignIn, signOut }}>
+    <AuthContext.Provider value={{ user, loading, onSignIn, signOut, refreshUser }}>
       {children}
     </AuthContext.Provider>
   )

--- a/lib/actions/users.actions.ts
+++ b/lib/actions/users.actions.ts
@@ -1,0 +1,36 @@
+import { insforge } from '@/lib/insforge'
+import type { User } from '@/types/database.types'
+
+interface Result<T = void> {
+  success: boolean
+  data?: T
+  error?: string
+}
+
+/**
+ * Patch parcial de campos editables del user. Solo los campos que el cliente
+ * puede modificar — NO incluye id, email, created_at, gmail_* (esos cambian
+ * por otros flows server-side).
+ */
+type UpdateUserPatch = Partial<
+  Pick<User, 'name' | 'avatar_url' | 'preferred_currency'>
+>
+
+export async function updateUser(
+  userId: string,
+  patch: UpdateUserPatch
+): Promise<Result<User>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const { data, error } = await insforge.database
+      .from('users')
+      .update(patch)
+      .eq('id', userId)
+      .select()
+      .single()
+    if (error) throw error
+    return { success: true, data: data as User }
+  } catch {
+    return { success: false, error: 'Error al actualizar perfil' }
+  }
+}


### PR DESCRIPTION
## Resumen

Reemplaza el stub minimal de \`more.tsx\` con un settings screen estilo iOS con secciones agrupadas. **Última tarea de FASE 2.**

## Cambios

### \`lib/actions/users.actions.ts\` (nuevo)

\`updateUser(userId, patch)\` con \`UpdateUserPatch = Partial<Pick<User, 'name'|'avatar_url'|'preferred_currency'>>\`. Restringe a nivel tipo qué puede modificar el cliente — excluye id, email, created_at, gmail_*.

### \`context/AuthContext.tsx\`

Añadido \`refreshUser()\` al contexto. Lee email desde SecureStore (no del state, evita closure stale) + recarga profile. Cualquier componente puede llamarlo tras mutar el user.

### \`app/(dashboard)/more.tsx\` (refactor completo)

Layout estilo iOS settings:

\`\`\`
┌────────────────────────────────┐
│  Más opciones                  │
├────────────────────────────────┤
│  👤 [Avatar]  Nombre           │
│               email@gmail.com  │
├────────────────────────────────┤
│  PREFERENCIAS                  │
│  💰 Moneda preferida    COP >  │
├────────────────────────────────┤
│  CONEXIONES                    │
│  ✉️ Gmail        Conectado     │
│      Conectado el: dd MMM yyyy │
│      Última sync: dd MMM yyyy  │
├────────────────────────────────┤
│  DATOS                         │
│  📂 Categorías             >   │
├────────────────────────────────┤
│  [Cerrar sesión]               │
└────────────────────────────────┘
\`\`\`

- Avatar: \`<Image source={avatar_url}>\` con fallback a círculo con inicial del nombre/email.
- Moneda preferida: tap → SelectModal (COP/USD/VES). On change: \`updateUser\` + \`refreshUser\` + toast success.
- Gmail status: read-only. Si \`gmail_connected_at !== null\` muestra "Conectado" verde + fechas. Si null muestra "No conectado" muted.
- Categorías: link a /categories (el stub anterior solo tenía un botón centro pantalla).
- Sign out al final con border rojo.

Sub-componentes inline \`<SectionHeader />\` y \`<SettingsRow />\` (private to file).

## Verificación

- ✅ \`npx tsc --noEmit\` limpio
- 🟡 Visual: pendiente — flow completo en simulador post-merge

## Cómo testear

1. Pull develop + \`pnpm ios\`
2. Tab \"Más\"
3. Ver profile card con tu avatar + nombre + email
4. Tap \"Moneda preferida\" → SelectModal con 3 opciones → cambiar → toast success
5. Verificar que la moneda nueva queda persistida (cerrar app, abrir, sigue en la nueva)
6. Tap \"Categorías\" → navega a la lista CRUD de T-2.1
7. Tap \"Cerrar sesión\" → vuelve a login

## Notas Obsidian

**Sin notas nuevas** — todo concepto ya documentado. Bitácora actualizada en \`40 - Projects/expense-manager-native/T-2.3 — Settings screen.md\`.

## Related

Closes #66
Related to #60 (FASE 2)

## Estado FASE 2 después de este merge

- ✅ T-2.1 — Categorías CRUD
- ✅ T-2.2 — Filtros, búsqueda, paginación
- ✅ **T-2.3 — Settings screen real** (este PR)

→ FASE 2 lista para cierre (PR develop → main).