### PR TITLE
feat: presupuestos CRUD + progreso por período (T-3.1)

### DIFF
--- a/app/(dashboard)/budgets/[id].tsx
+++ b/app/(dashboard)/budgets/[id].tsx
@@ -1,0 +1,301 @@
+import { useEffect, useState } from 'react'
+import {
+  View,
+  Text,
+  ScrollView,
+  TouchableOpacity,
+  KeyboardAvoidingView,
+  Platform,
+  ActivityIndicator,
+} from 'react-native'
+import { useLocalSearchParams, router } from 'expo-router'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useAuth } from '@/context/AuthContext'
+import {
+  getBudgetById,
+  createBudget,
+  updateBudget,
+  deleteBudget,
+} from '@/lib/actions/budgets.actions'
+import { getCategories } from '@/lib/actions/categories.actions'
+import { FormInput } from '@/components/ui/FormInput'
+import { SelectModal } from '@/components/ui/SelectModal'
+import { DateInput } from '@/components/ui/DateInput'
+import { PrimaryButton } from '@/components/ui/PrimaryButton'
+import { confirmDialog } from '@/components/ui/ConfirmDialog'
+import { toast } from '@/components/ui/Toast'
+import type { BudgetPeriod, Category, Currency } from '@/types/database.types'
+
+const CURRENCY_OPTIONS = [
+  { label: 'COP — Peso Colombiano', value: 'COP' },
+  { label: 'USD — Dólar', value: 'USD' },
+  { label: 'VES — Bolívar (Bs)', value: 'VES' },
+]
+
+const PERIOD_OPTIONS: { value: BudgetPeriod; label: string }[] = [
+  { value: 'monthly', label: 'Mensual' },
+  { value: 'yearly', label: 'Anual' },
+]
+
+function todayYMD(): string {
+  return new Date().toISOString().slice(0, 10)
+}
+
+export default function BudgetFormScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>()
+  const { user } = useAuth()
+  const isNew = id === 'new'
+
+  const [initialLoading, setInitialLoading] = useState(!isNew)
+  const [saving, setSaving] = useState(false)
+  const [categories, setCategories] = useState<Category[]>([])
+
+  const [categoryId, setCategoryId] = useState('')
+  const [amount, setAmount] = useState('')
+  const [currency, setCurrency] = useState<Currency>(user?.preferred_currency ?? 'COP')
+  const [period, setPeriod] = useState<BudgetPeriod>('monthly')
+  const [startDate, setStartDate] = useState(todayYMD())
+
+  const [showCategoryPicker, setShowCategoryPicker] = useState(false)
+  const [showCurrencyPicker, setShowCurrencyPicker] = useState(false)
+
+  // Cargar categorías + budget si edit
+  useEffect(() => {
+    if (!user) return
+    let cancelled = false
+
+    getCategories(user.id).then((res) => {
+      if (cancelled) return
+      if (res.success && res.data) setCategories(res.data)
+    })
+
+    if (!isNew) {
+      getBudgetById(id, user.id).then((res) => {
+        if (cancelled) return
+        if (res.success && res.data) {
+          const b = res.data
+          setCategoryId(b.category_id)
+          setAmount(String(b.amount))
+          setCurrency(b.currency)
+          setPeriod(b.period)
+          setStartDate(b.start_date)
+        } else {
+          toast.error(res.error ?? 'Presupuesto no encontrado')
+          router.back()
+        }
+        setInitialLoading(false)
+      })
+    }
+
+    return () => {
+      cancelled = true
+    }
+  }, [user, id, isNew])
+
+  async function handleSubmit() {
+    if (!user) return
+    const parsed = parseFloat(amount)
+    if (!categoryId || !amount || isNaN(parsed) || parsed <= 0) {
+      toast.error('Completa todos los campos')
+      return
+    }
+
+    setSaving(true)
+    const input = {
+      category_id: categoryId,
+      amount: parsed,
+      currency,
+      period,
+      start_date: startDate,
+    }
+    const result = isNew
+      ? await createBudget(user.id, input)
+      : await updateBudget(id, user.id, input)
+    setSaving(false)
+
+    if (result.success) {
+      toast.success(isNew ? 'Presupuesto creado' : 'Presupuesto actualizado')
+      router.back()
+    } else {
+      toast.error(result.error ?? 'Error al guardar')
+    }
+  }
+
+  async function handleDelete() {
+    if (!user || isNew) return
+    const ok = await confirmDialog({
+      title: 'Eliminar presupuesto',
+      message: 'No se puede deshacer.',
+      confirmLabel: 'Eliminar',
+      destructive: true,
+    })
+    if (!ok) return
+
+    setSaving(true)
+    const result = await deleteBudget(id, user.id)
+    setSaving(false)
+    if (result.success) {
+      toast.success('Presupuesto eliminado')
+      router.back()
+    } else {
+      toast.error(result.error ?? 'Error al eliminar')
+    }
+  }
+
+  // Categorías filtradas: solo expense o both (no income — no se presupuesta lo que entra)
+  const filteredCategories = categories.filter(
+    (c) => c.type === 'expense' || c.type === 'both'
+  )
+  const categoryOptions = filteredCategories.map((c) => ({
+    label: `${c.icon ?? '📂'} ${c.name}`,
+    value: c.id,
+  }))
+  const selectedCategory = categories.find((c) => c.id === categoryId)
+
+  if (initialLoading) {
+    return (
+      <View className="flex-1 bg-bg items-center justify-center">
+        <ActivityIndicator color="#4F46E5" />
+      </View>
+    )
+  }
+
+  return (
+    <SafeAreaView edges={['top', 'bottom']} className="flex-1 bg-bg">
+      {/* Header */}
+      <View className="flex-row items-center justify-between px-4 py-3 border-b border-border">
+        <TouchableOpacity onPress={() => router.back()} activeOpacity={0.7}>
+          <Text className="text-primary text-base">← Volver</Text>
+        </TouchableOpacity>
+        <Text className="text-white text-base font-bold">
+          {isNew ? 'Nuevo presupuesto' : 'Editar presupuesto'}
+        </Text>
+        {!isNew ? (
+          <TouchableOpacity
+            onPress={handleDelete}
+            disabled={saving}
+            activeOpacity={0.7}
+          >
+            <Text className="text-red-400 text-sm">Eliminar</Text>
+          </TouchableOpacity>
+        ) : (
+          <View style={{ width: 60 }} />
+        )}
+      </View>
+
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        className="flex-1"
+      >
+        <ScrollView
+          className="flex-1 px-4"
+          contentContainerStyle={{ paddingVertical: 16, paddingBottom: 40 }}
+          keyboardShouldPersistTaps="handled"
+        >
+          {/* Categoría */}
+          <View className="mb-4">
+            <Text className="text-muted text-sm mb-1">Categoría *</Text>
+            <TouchableOpacity
+              onPress={() => setShowCategoryPicker(true)}
+              activeOpacity={0.7}
+              className="bg-surface border border-border rounded-xl px-4 py-3"
+            >
+              <Text className={selectedCategory ? 'text-white' : 'text-muted'}>
+                {selectedCategory
+                  ? `${selectedCategory.icon ?? '📂'} ${selectedCategory.name}`
+                  : 'Seleccionar categoría...'}
+              </Text>
+            </TouchableOpacity>
+          </View>
+
+          <FormInput
+            label="Monto *"
+            value={amount}
+            onChangeText={setAmount}
+            keyboardType="decimal-pad"
+            placeholder="0"
+          />
+
+          {/* Moneda */}
+          <View className="mb-4">
+            <Text className="text-muted text-sm mb-1">Moneda</Text>
+            <TouchableOpacity
+              onPress={() => setShowCurrencyPicker(true)}
+              activeOpacity={0.7}
+              className="bg-surface border border-border rounded-xl px-4 py-3"
+            >
+              <Text className="text-white">
+                {CURRENCY_OPTIONS.find((o) => o.value === currency)?.label ?? currency}
+              </Text>
+            </TouchableOpacity>
+          </View>
+
+          {/* Período */}
+          <View className="mb-4">
+            <Text className="text-muted text-sm mb-1">Período</Text>
+            <View className="flex-row gap-2">
+              {PERIOD_OPTIONS.map((opt) => (
+                <TouchableOpacity
+                  key={opt.value}
+                  onPress={() => setPeriod(opt.value)}
+                  activeOpacity={0.7}
+                  className={`flex-1 py-3 rounded-xl items-center border ${
+                    period === opt.value
+                      ? 'bg-primary border-primary'
+                      : 'bg-transparent border-border'
+                  }`}
+                >
+                  <Text className="text-white font-medium">{opt.label}</Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          </View>
+
+          {/* Fecha de inicio */}
+          <DateInput
+            label="Fecha de inicio *"
+            value={startDate}
+            onChange={setStartDate}
+          />
+
+          <Text className="text-muted text-xs mb-4 leading-relaxed">
+            El período {period === 'monthly' ? 'mensual' : 'anual'} se renueva el día{' '}
+            {new Date(`${startDate}T00:00:00`).getDate()} de cada{' '}
+            {period === 'monthly' ? 'mes' : 'año'}.
+          </Text>
+
+          <PrimaryButton
+            onPress={handleSubmit}
+            loading={saving}
+            disabled={!categoryId || !amount}
+          >
+            {isNew ? 'Crear presupuesto' : 'Guardar cambios'}
+          </PrimaryButton>
+        </ScrollView>
+      </KeyboardAvoidingView>
+
+      <SelectModal
+        visible={showCategoryPicker}
+        onClose={() => setShowCategoryPicker(false)}
+        title="Categoría"
+        options={categoryOptions}
+        selected={categoryId}
+        onSelect={(v) => {
+          setCategoryId(v)
+          setShowCategoryPicker(false)
+        }}
+      />
+      <SelectModal
+        visible={showCurrencyPicker}
+        onClose={() => setShowCurrencyPicker(false)}
+        title="Moneda"
+        options={CURRENCY_OPTIONS}
+        selected={currency}
+        onSelect={(v) => {
+          setCurrency(v as Currency)
+          setShowCurrencyPicker(false)
+        }}
+      />
+    </SafeAreaView>
+  )
+}

--- a/app/(dashboard)/budgets/_layout.tsx
+++ b/app/(dashboard)/budgets/_layout.tsx
@@ -1,0 +1,13 @@
+import { Stack } from 'expo-router'
+import { colors } from '@/constants/theme'
+
+export default function BudgetsLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: colors.bg },
+      }}
+    />
+  )
+}

--- a/app/(dashboard)/budgets/index.tsx
+++ b/app/(dashboard)/budgets/index.tsx
@@ -1,0 +1,174 @@
+import { useCallback, useState } from 'react'
+import {
+  View,
+  Text,
+  FlatList,
+  TouchableOpacity,
+  ActivityIndicator,
+} from 'react-native'
+import { router, useFocusEffect } from 'expo-router'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useAuth } from '@/context/AuthContext'
+import { getBudgets } from '@/lib/actions/budgets.actions'
+import { ProgressBar, defaultColor } from '@/components/ui/ProgressBar'
+import { EmptyState } from '@/components/ui/EmptyState'
+import { formatCurrency } from '@/lib/utils/currency'
+import type { BudgetWithSpent } from '@/types/database.types'
+
+const PERIOD_LABEL: Record<'monthly' | 'yearly', string> = {
+  monthly: 'Mensual',
+  yearly: 'Anual',
+}
+
+function formatShortDate(iso: string): string {
+  const d = new Date(iso)
+  return d.toLocaleDateString('es', { day: 'numeric', month: 'short' })
+}
+
+export default function BudgetsScreen() {
+  const { user } = useAuth()
+  const [budgets, setBudgets] = useState<BudgetWithSpent[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const loadBudgets = useCallback(async () => {
+    if (!user) return
+    const res = await getBudgets(user.id)
+    if (res.success && res.data) setBudgets(res.data)
+    setLoading(false)
+  }, [user])
+
+  useFocusEffect(
+    useCallback(() => {
+      let cancelled = false
+      ;(async () => {
+        await loadBudgets()
+        if (cancelled) return
+      })()
+      return () => {
+        cancelled = true
+      }
+    }, [loadBudgets])
+  )
+
+  if (loading) {
+    return (
+      <View className="flex-1 bg-bg items-center justify-center">
+        <ActivityIndicator color="#4F46E5" />
+      </View>
+    )
+  }
+
+  return (
+    <SafeAreaView edges={['top']} className="flex-1 bg-bg">
+      {/* Header */}
+      <View className="flex-row items-center justify-between px-4 py-3 border-b border-border">
+        <TouchableOpacity onPress={() => router.back()} activeOpacity={0.7}>
+          <Text className="text-primary text-base">← Volver</Text>
+        </TouchableOpacity>
+        <Text className="text-white text-base font-bold">Presupuestos</Text>
+        <View style={{ width: 60 }} />
+      </View>
+
+      <FlatList
+        data={budgets}
+        keyExtractor={(b) => b.id}
+        contentContainerStyle={
+          budgets.length === 0 ? { flex: 1 } : { paddingVertical: 12 }
+        }
+        ListEmptyComponent={
+          <EmptyState
+            icon="🎯"
+            title="Sin presupuestos"
+            description="Toca + para crear tu primer presupuesto"
+          />
+        }
+        renderItem={({ item }) => <BudgetCard budget={item} />}
+      />
+
+      {/* FAB */}
+      <TouchableOpacity
+        onPress={() => router.push('/budgets/new')}
+        activeOpacity={0.8}
+        className="absolute bottom-6 right-6 w-14 h-14 rounded-full bg-primary items-center justify-center shadow-lg"
+        style={{
+          shadowColor: '#000',
+          shadowOffset: { width: 0, height: 4 },
+          shadowOpacity: 0.3,
+          shadowRadius: 6,
+          elevation: 6,
+        }}
+      >
+        <Text className="text-white text-3xl font-bold" style={{ lineHeight: 32 }}>
+          +
+        </Text>
+      </TouchableOpacity>
+    </SafeAreaView>
+  )
+}
+
+function BudgetCard({ budget }: { budget: BudgetWithSpent }) {
+  const ratio = budget.amount > 0 ? budget.spent / budget.amount : 0
+  const color = defaultColor(ratio)
+  const exceeded = ratio >= 1
+  const remaining = budget.amount - budget.spent
+
+  return (
+    <TouchableOpacity
+      onPress={() => router.push(`/budgets/${budget.id}`)}
+      activeOpacity={0.7}
+      className="mx-4 mb-3 bg-surface border border-border rounded-2xl p-4"
+    >
+      {/* Header card */}
+      <View className="flex-row items-center mb-3">
+        <View
+          style={{ backgroundColor: budget.category.color ?? '#4F46E5' }}
+          className="w-10 h-10 rounded-full items-center justify-center mr-3"
+        >
+          <Text className="text-xl">{budget.category.icon ?? '📂'}</Text>
+        </View>
+        <View className="flex-1">
+          <Text className="text-white text-base font-semibold">
+            {budget.category.name}
+          </Text>
+          <Text className="text-muted text-xs">
+            {PERIOD_LABEL[budget.period]} · {formatShortDate(budget.periodStart)} —{' '}
+            {formatShortDate(budget.periodEnd)}
+          </Text>
+        </View>
+        <Text style={{ color }} className="text-base font-bold">
+          {Math.round(ratio * 100)}%
+        </Text>
+      </View>
+
+      <ProgressBar value={ratio} />
+
+      {/* Footer */}
+      <View className="flex-row justify-between mt-3">
+        <Text className="text-muted text-xs">
+          Gastado{' '}
+          <Text className="text-white text-sm">
+            {formatCurrency(budget.spent, budget.currency)}
+          </Text>
+        </Text>
+        <Text className="text-muted text-xs">
+          de{' '}
+          <Text className="text-white text-sm">
+            {formatCurrency(budget.amount, budget.currency)}
+          </Text>
+        </Text>
+      </View>
+
+      {exceeded ? (
+        <View className="mt-2 px-3 py-1.5 rounded-lg bg-red-500/10 border border-red-500/40">
+          <Text className="text-red-400 text-xs">
+            Excedido por {formatCurrency(budget.spent - budget.amount, budget.currency)}
+          </Text>
+        </View>
+      ) : (
+        <Text className="text-muted text-xs mt-2">
+          Restante {formatCurrency(remaining, budget.currency)}
+        </Text>
+      )}
+    </TouchableOpacity>
+  )
+}

--- a/app/(dashboard)/more.tsx
+++ b/app/(dashboard)/more.tsx
@@ -146,6 +146,11 @@ export default function MoreScreen() {
           label="Categorías"
           onPress={() => router.push('/categories')}
         />
+        <SettingsRow
+          icon="wallet"
+          label="Presupuestos"
+          onPress={() => router.push('/budgets')}
+        />
 
         {/* Sign out */}
         <View className="px-4 pt-10">

--- a/components/ui/ProgressBar.tsx
+++ b/components/ui/ProgressBar.tsx
@@ -1,0 +1,88 @@
+import { useEffect } from 'react'
+import { View } from 'react-native'
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  Easing,
+} from 'react-native-reanimated'
+
+interface ProgressBarProps {
+  /** Progreso entre 0 y 1. Valores > 1 se clampan al render (la barra llena), pero `value` puede pasarse sin clamp. */
+  value: number
+  /** Override de color de la barra. Si se omite, se elige por umbral del value. */
+  color?: string
+  /** Altura en px. Default 8. */
+  height?: number
+  /** Duración de la animación de transición. Default 400ms. */
+  duration?: number
+  /** Color del track de fondo. Default `bg-border` (#27272a). */
+  trackColor?: string
+}
+
+/**
+ * Barra de progreso animada (UI thread con reanimated).
+ *
+ * `value` puede exceder 1 (presupuesto sobrepasado). Visualmente se llena al 100%
+ * pero el caller puede usar el valor real para mostrar texto "120%" aparte.
+ *
+ * Color por defecto:
+ *   < 0.7  → verde
+ *   < 1.0  → amarillo
+ *   ≥ 1.0  → rojo (excedido)
+ */
+export function ProgressBar({
+  value,
+  color,
+  height = 8,
+  duration = 400,
+  trackColor = '#27272a',
+}: ProgressBarProps) {
+  const progress = useSharedValue(0)
+
+  useEffect(() => {
+    const clamped = Math.max(0, Math.min(value, 1))
+    progress.value = withTiming(clamped, {
+      duration,
+      easing: Easing.out(Easing.cubic),
+    })
+  }, [value, duration, progress])
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    width: `${progress.value * 100}%`,
+  }))
+
+  const resolvedColor = color ?? defaultColor(value)
+
+  return (
+    <View
+      style={{
+        height,
+        backgroundColor: trackColor,
+        borderRadius: height / 2,
+        overflow: 'hidden',
+      }}
+    >
+      <Animated.View
+        style={[
+          {
+            height: '100%',
+            backgroundColor: resolvedColor,
+            borderRadius: height / 2,
+          },
+          animatedStyle,
+        ]}
+      />
+    </View>
+  )
+}
+
+/**
+ * Mapea `value` (0..∞) a color por umbral. Exportado por si el caller quiere
+ * usar el mismo color en otro lado (badge, texto, etc.).
+ */
+export function defaultColor(value: number): string {
+  if (value >= 1) return '#ef4444' // red-500 — excedido
+  if (value >= 0.7) return '#f59e0b' // amber-500 — atención
+  return '#10b981' // emerald-500 — saludable
+}

--- a/lib/actions/budgets.actions.ts
+++ b/lib/actions/budgets.actions.ts
@@ -1,0 +1,243 @@
+import { insforge } from '@/lib/insforge'
+import {
+  createBudgetSchema,
+  type CreateBudgetInput,
+  type UpdateBudgetInput,
+} from '@/lib/validations/budget'
+import type {
+  Budget,
+  BudgetWithSpent,
+  Category,
+} from '@/types/database.types'
+
+interface Result<T = void> {
+  success: boolean
+  data?: T
+  error?: string
+}
+
+/**
+ * Calcula la ventana activa del presupuesto a partir de `start_date` y `period`.
+ *
+ * NO es mes calendar — es una ventana móvil anclada al día de inicio.
+ * Ejemplo: budget mensual creado el 15-ene → períodos sucesivos:
+ *   15-ene → 14-feb, 15-feb → 14-mar, 15-mar → 14-abr, ...
+ */
+function computeActivePeriod(
+  startDate: string,
+  period: 'monthly' | 'yearly',
+  now = new Date()
+): { periodStart: Date; periodEnd: Date } {
+  const start = new Date(startDate)
+
+  if (period === 'monthly') {
+    let monthsElapsed =
+      (now.getFullYear() - start.getFullYear()) * 12 +
+      (now.getMonth() - start.getMonth())
+    if (now.getDate() < start.getDate()) monthsElapsed--
+
+    if (monthsElapsed < 0) {
+      // Budget arranca en el futuro — no hay período activo aún
+      const periodEnd = new Date(
+        start.getFullYear(),
+        start.getMonth() + 1,
+        start.getDate() - 1,
+        23,
+        59,
+        59
+      )
+      return { periodStart: start, periodEnd }
+    }
+
+    const periodStart = new Date(
+      start.getFullYear(),
+      start.getMonth() + monthsElapsed,
+      start.getDate()
+    )
+    const periodEnd = new Date(
+      start.getFullYear(),
+      start.getMonth() + monthsElapsed + 1,
+      start.getDate() - 1,
+      23,
+      59,
+      59
+    )
+    return { periodStart, periodEnd }
+  }
+
+  // yearly
+  let yearsElapsed = now.getFullYear() - start.getFullYear()
+  const pastAnniversary =
+    now.getMonth() > start.getMonth() ||
+    (now.getMonth() === start.getMonth() && now.getDate() >= start.getDate())
+  if (!pastAnniversary) yearsElapsed--
+
+  if (yearsElapsed < 0) {
+    const periodEnd = new Date(
+      start.getFullYear() + 1,
+      start.getMonth(),
+      start.getDate() - 1,
+      23,
+      59,
+      59
+    )
+    return { periodStart: start, periodEnd }
+  }
+
+  const periodStart = new Date(
+    start.getFullYear() + yearsElapsed,
+    start.getMonth(),
+    start.getDate()
+  )
+  const periodEnd = new Date(
+    start.getFullYear() + yearsElapsed + 1,
+    start.getMonth(),
+    start.getDate() - 1,
+    23,
+    59,
+    59
+  )
+  return { periodStart, periodEnd }
+}
+
+/**
+ * Lista budgets del user con `spent` calculado para el período activo.
+ *
+ * Estrategia: 1 query a budgets + 1 query a todas las expense transactions
+ * del user. Luego filtramos en memoria. Para usuarios con miles de transacciones
+ * conviene migrar a un RPC server-side, pero por ahora es aceptable.
+ */
+export async function getBudgets(
+  userId: string
+): Promise<Result<BudgetWithSpent[]>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const { data: budgets, error: budgetError } = await insforge.database
+      .from('budgets')
+      .select('*, category:categories(*)')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+
+    if (budgetError) throw budgetError
+    if (!budgets || budgets.length === 0) {
+      return { success: true, data: [] }
+    }
+
+    const { data: transactions, error: transError } = await insforge.database
+      .from('transactions')
+      .select('category_id, amount, date, type')
+      .eq('user_id', userId)
+      .eq('type', 'expense')
+
+    if (transError) throw transError
+
+    type BudgetRow = Budget & { category: Category }
+    type TxRow = { category_id: string | null; amount: number; date: string; type: string }
+    const txs = (transactions ?? []) as TxRow[]
+
+    const result: BudgetWithSpent[] = (budgets as BudgetRow[]).map((budget) => {
+      const { periodStart, periodEnd } = computeActivePeriod(
+        budget.start_date,
+        budget.period
+      )
+
+      const spent = txs
+        .filter((t) => {
+          if (t.category_id !== budget.category_id) return false
+          const d = new Date(t.date)
+          return d >= periodStart && d <= periodEnd
+        })
+        .reduce((sum, t) => sum + Number(t.amount || 0), 0)
+
+      return {
+        ...budget,
+        spent,
+        periodStart: periodStart.toISOString().slice(0, 10),
+        periodEnd: periodEnd.toISOString().slice(0, 10),
+      }
+    })
+
+    return { success: true, data: result }
+  } catch {
+    return { success: false, error: 'Error al cargar presupuestos' }
+  }
+}
+
+export async function getBudgetById(
+  id: string,
+  userId: string
+): Promise<Result<Budget>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const { data, error } = await insforge.database
+      .from('budgets')
+      .select('*')
+      .eq('id', id)
+      .eq('user_id', userId)
+      .maybeSingle()
+    if (error) throw error
+    if (!data) return { success: false, error: 'Presupuesto no encontrado' }
+    return { success: true, data: data as Budget }
+  } catch {
+    return { success: false, error: 'Error al cargar presupuesto' }
+  }
+}
+
+export async function createBudget(
+  userId: string,
+  input: CreateBudgetInput
+): Promise<Result<Budget>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const validated = createBudgetSchema.parse(input)
+    const { data, error } = await insforge.database
+      .from('budgets')
+      .insert([{ ...validated, user_id: userId }])
+      .select()
+      .single()
+    if (error) throw error
+    return { success: true, data: data as Budget }
+  } catch {
+    return { success: false, error: 'Error al crear presupuesto' }
+  }
+}
+
+export async function updateBudget(
+  id: string,
+  userId: string,
+  input: UpdateBudgetInput
+): Promise<Result<Budget>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const validated = createBudgetSchema.partial().parse(input)
+    const { data, error } = await insforge.database
+      .from('budgets')
+      .update(validated)
+      .eq('id', id)
+      .eq('user_id', userId)
+      .select()
+      .single()
+    if (error) throw error
+    return { success: true, data: data as Budget }
+  } catch {
+    return { success: false, error: 'Error al actualizar presupuesto' }
+  }
+}
+
+export async function deleteBudget(
+  id: string,
+  userId: string
+): Promise<Result> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const { error } = await insforge.database
+      .from('budgets')
+      .delete()
+      .eq('id', id)
+      .eq('user_id', userId)
+    if (error) throw error
+    return { success: true }
+  } catch {
+    return { success: false, error: 'Error al eliminar presupuesto' }
+  }
+}

--- a/types/database.types.ts
+++ b/types/database.types.ts
@@ -215,6 +215,12 @@ export interface BudgetWithCategory extends Budget {
   category: Category
 }
 
+export interface BudgetWithSpent extends BudgetWithCategory {
+  spent: number
+  periodStart: string
+  periodEnd: string
+}
+
 export interface RecurringTransactionWithCategory extends RecurringTransaction {
   category: Category
 }


### PR DESCRIPTION
Closes #70 · Related to #69 (FASE 3)

## Cambios

### Backend
- **`lib/actions/budgets.actions.ts`** — get/create/update/delete + `getBudgetById`. La estrella es `computeActivePeriod()`: dada `start_date` + `period`, calcula la ventana **móvil** actual (no es mes calendar — un budget mensual del día 15 corre 15→14 del mes siguiente). `getBudgets` trae todos los budgets + 1 query a transactions tipo `expense`, filtra en memoria y devuelve `BudgetWithSpent[]`.
- **`types/database.types.ts`** — `BudgetWithSpent extends BudgetWithCategory { spent; periodStart; periodEnd }`.

### UI
- **`components/ui/ProgressBar.tsx`** — nuevo. Anima `width` con `withTiming + Easing.out(cubic)`. Color por umbral (verde < 70%, amarillo 70-99%, rojo ≥ 100%) o override. `defaultColor()` exportado para reusar en badges/texto.
- **`app/(dashboard)/budgets/`** — layout + lista + form `[id].tsx` (categoría filtrada a expense+both, monto, currency, período mensual/anual, fecha de inicio con texto de ayuda dinámico).
- **`more.tsx`** — link "Presupuestos" en sección Datos.

## Comportamiento visible

- Card por presupuesto: icono de categoría, % en color del umbral, `ProgressBar` animada, gastado / total, restante o badge rojo "Excedido por X" si pasa el límite.
- Período mostrado en formato corto ("15 ene — 14 feb").
- Lista vacía → EmptyState con FAB para crear el primero.

## Verificación

- [x] `npx tsc --noEmit` limpio
- [x] Crear budget mensual con categoría existente
- [x] Editar budget existente
- [x] Eliminar budget con confirmación
- [x] Spent refleja transactions reales de esa categoría

## Notas para Obsidian

- Nueva nota: [[ProgressBar]] en `10 - Concepts/React Native/`
- (Pendiente, post-merge) Bitácora `T-3.1 — Presupuestos.md`