### PR TITLE
feat: préstamos (loans) + pagos con balanceDirection (T-3.3)

### DIFF
--- a/app/(dashboard)/loans/[id].tsx
+++ b/app/(dashboard)/loans/[id].tsx
@@ -1,0 +1,523 @@
+import { useEffect, useState } from 'react'
+import {
+  View,
+  Text,
+  ScrollView,
+  TouchableOpacity,
+  KeyboardAvoidingView,
+  Platform,
+  ActivityIndicator,
+} from 'react-native'
+import { useLocalSearchParams, router } from 'expo-router'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useAuth } from '@/context/AuthContext'
+import {
+  getLoanById,
+  getLoanPayments,
+  createLoan,
+  updateLoan,
+  deleteLoan,
+  addLoanPayment,
+  deleteLoanPayment,
+  settleLoan,
+} from '@/lib/actions/loans.actions'
+import { getAccounts } from '@/lib/actions/accounts.actions'
+import { FormInput } from '@/components/ui/FormInput'
+import { SelectModal } from '@/components/ui/SelectModal'
+import { PrimaryButton } from '@/components/ui/PrimaryButton'
+import { ProgressBar } from '@/components/ui/ProgressBar'
+import { confirmDialog } from '@/components/ui/ConfirmDialog'
+import { toast } from '@/components/ui/Toast'
+import { Icon } from '@/components/ui/Icon'
+import { PaymentModal } from '@/components/loans/PaymentModal'
+import { formatCurrency } from '@/lib/utils/currency'
+import type {
+  Account,
+  Currency,
+  LoanPayment,
+  LoanType,
+  LoanWithAccount,
+} from '@/types/database.types'
+
+const CURRENCY_OPTIONS = [
+  { label: 'COP — Peso Colombiano', value: 'COP' },
+  { label: 'USD — Dólar', value: 'USD' },
+  { label: 'VES — Bolívar (Bs)', value: 'VES' },
+]
+
+const TYPE_OPTIONS: { value: LoanType; label: string }[] = [
+  { value: 'lent', label: 'Le presté' },
+  { value: 'borrowed', label: 'Me prestó' },
+]
+
+function formatPaymentDate(iso: string): string {
+  return new Date(`${iso}T00:00:00`).toLocaleDateString('es', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  })
+}
+
+export default function LoanFormScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>()
+  const { user } = useAuth()
+  const isNew = id === 'new'
+
+  const [initialLoading, setInitialLoading] = useState(!isNew)
+  const [saving, setSaving] = useState(false)
+  const [accounts, setAccounts] = useState<Account[]>([])
+  const [loan, setLoan] = useState<LoanWithAccount | null>(null)
+  const [payments, setPayments] = useState<LoanPayment[]>([])
+
+  const [personName, setPersonName] = useState('')
+  const [amount, setAmount] = useState('')
+  const [currency, setCurrency] = useState<Currency>(
+    user?.preferred_currency ?? 'COP'
+  )
+  const [type, setType] = useState<LoanType>('lent')
+  const [accountId, setAccountId] = useState<string>('')
+  const [notes, setNotes] = useState('')
+
+  const [showCurrencyPicker, setShowCurrencyPicker] = useState(false)
+  const [showAccountPicker, setShowAccountPicker] = useState(false)
+  const [showPaymentModal, setShowPaymentModal] = useState(false)
+
+  useEffect(() => {
+    if (!user) return
+    let cancelled = false
+
+    getAccounts(user.id).then((res) => {
+      if (cancelled) return
+      if (res.success && res.data) setAccounts(res.data)
+    })
+
+    if (!isNew) {
+      Promise.all([
+        getLoanById(id, user.id),
+        getLoanPayments(id, user.id),
+      ]).then(([loanRes, paymentsRes]) => {
+        if (cancelled) return
+        if (loanRes.success && loanRes.data) {
+          const l = loanRes.data
+          setLoan(l)
+          setPersonName(l.person_name)
+          setAmount(String(l.amount))
+          setCurrency(l.currency)
+          setType(l.type)
+          setAccountId(l.account_id ?? '')
+          setNotes(l.notes ?? '')
+        } else {
+          toast.error(loanRes.error ?? 'Préstamo no encontrado')
+          router.back()
+        }
+        if (paymentsRes.success && paymentsRes.data) {
+          setPayments(paymentsRes.data)
+        }
+        setInitialLoading(false)
+      })
+    }
+
+    return () => {
+      cancelled = true
+    }
+  }, [user, id, isNew])
+
+  async function refreshLoanAndPayments() {
+    if (!user || isNew) return
+    const [loanRes, paymentsRes] = await Promise.all([
+      getLoanById(id, user.id),
+      getLoanPayments(id, user.id),
+    ])
+    if (loanRes.success && loanRes.data) setLoan(loanRes.data)
+    if (paymentsRes.success && paymentsRes.data) setPayments(paymentsRes.data)
+  }
+
+  async function handleSubmit() {
+    if (!user) return
+    const parsed = parseFloat(amount)
+    if (!personName.trim() || isNaN(parsed) || parsed <= 0) {
+      toast.error('Completa los campos requeridos')
+      return
+    }
+
+    setSaving(true)
+    const input = {
+      person_name: personName.trim(),
+      amount: parsed,
+      currency,
+      account_id: accountId || null,
+      type,
+      notes: notes.trim() || null,
+    }
+    const result = isNew
+      ? await createLoan(user.id, input)
+      : await updateLoan(id, user.id, input)
+    setSaving(false)
+
+    if (result.success) {
+      toast.success(isNew ? 'Préstamo creado' : 'Préstamo actualizado')
+      router.back()
+    } else {
+      toast.error(result.error ?? 'Error al guardar')
+    }
+  }
+
+  async function handleDelete() {
+    if (!user || isNew) return
+    const ok = await confirmDialog({
+      title: 'Eliminar préstamo',
+      message:
+        loan?.status === 'active'
+          ? 'Se revertirá el impacto en la cuenta.'
+          : 'No se puede deshacer.',
+      confirmLabel: 'Eliminar',
+      destructive: true,
+    })
+    if (!ok) return
+
+    setSaving(true)
+    const result = await deleteLoan(id, user.id)
+    setSaving(false)
+    if (result.success) {
+      toast.success('Préstamo eliminado')
+      router.back()
+    } else {
+      toast.error(result.error ?? 'Error al eliminar')
+    }
+  }
+
+  async function handlePayment(input: {
+    amount: number
+    date: string
+    notes: string | null
+    currency: Currency
+  }) {
+    if (!user || !loan) return
+    const result = await addLoanPayment(loan.id, user.id, {
+      amount: input.amount,
+      currency: input.currency,
+      date: input.date,
+      notes: input.notes,
+    })
+    if (result.success && result.data) {
+      setShowPaymentModal(false)
+      if (result.data.settled) {
+        toast.success('¡Préstamo saldado! 🎉')
+      } else {
+        toast.success(loan.type === 'lent' ? 'Cobro registrado' : 'Pago registrado')
+      }
+      await refreshLoanAndPayments()
+    } else {
+      toast.error(result.error ?? 'Error al registrar')
+    }
+  }
+
+  async function handleDeletePayment(payment: LoanPayment) {
+    if (!user) return
+    const ok = await confirmDialog({
+      title: 'Eliminar pago',
+      message: 'Se revertirá el impacto en la cuenta y se reabrirá el préstamo si estaba saldado.',
+      confirmLabel: 'Eliminar',
+      destructive: true,
+    })
+    if (!ok) return
+
+    const result = await deleteLoanPayment(payment.id, user.id)
+    if (result.success) {
+      toast.success('Pago eliminado')
+      await refreshLoanAndPayments()
+    } else {
+      toast.error(result.error ?? 'Error al eliminar pago')
+    }
+  }
+
+  async function handleSettleAll() {
+    if (!user || !loan) return
+    const ok = await confirmDialog({
+      title: 'Saldar préstamo',
+      message: 'Se creará un pago final por el saldo restante e impactará la cuenta.',
+      confirmLabel: 'Saldar',
+    })
+    if (!ok) return
+
+    const result = await settleLoan(loan.id, user.id)
+    if (result.success) {
+      toast.success('Préstamo saldado')
+      await refreshLoanAndPayments()
+    } else {
+      toast.error(result.error ?? 'Error al saldar')
+    }
+  }
+
+  if (initialLoading) {
+    return (
+      <View className="flex-1 bg-bg items-center justify-center">
+        <ActivityIndicator color="#4F46E5" />
+      </View>
+    )
+  }
+
+  // Derivados
+  const amountNum = loan ? Number(loan.amount) : 0
+  const paidNum = loan ? Number(loan.paid_amount) : 0
+  const ratio = amountNum > 0 ? paidNum / amountNum : 0
+  const settled = loan?.status === 'settled'
+  const isLent = type === 'lent'
+
+  const accountOptions = [
+    { label: 'Sin cuenta', value: '' },
+    ...accounts.map((a) => ({
+      label: `${a.icon ?? '💳'} ${a.name} (${a.currency})`,
+      value: a.id,
+    })),
+  ]
+  const selectedAccount = accounts.find((a) => a.id === accountId) ?? null
+
+  return (
+    <SafeAreaView edges={['top', 'bottom']} className="flex-1 bg-bg">
+      {/* Header */}
+      <View className="flex-row items-center justify-between px-4 py-3 border-b border-border">
+        <TouchableOpacity onPress={() => router.back()} activeOpacity={0.7}>
+          <Text className="text-primary text-base">← Volver</Text>
+        </TouchableOpacity>
+        <Text className="text-white text-base font-bold">
+          {isNew ? 'Nuevo préstamo' : settled ? 'Préstamo saldado' : 'Editar préstamo'}
+        </Text>
+        {!isNew ? (
+          <TouchableOpacity
+            onPress={handleDelete}
+            disabled={saving}
+            activeOpacity={0.7}
+          >
+            <Text className="text-red-400 text-sm">Eliminar</Text>
+          </TouchableOpacity>
+        ) : (
+          <View style={{ width: 60 }} />
+        )}
+      </View>
+
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        className="flex-1"
+      >
+        <ScrollView
+          className="flex-1 px-4"
+          contentContainerStyle={{ paddingVertical: 16, paddingBottom: 40 }}
+          keyboardShouldPersistTaps="handled"
+        >
+          {/* Resumen en edit */}
+          {loan ? (
+            <View className="mb-6 bg-surface border border-border rounded-2xl p-4">
+              <View className="flex-row items-center mb-3">
+                <Text className="text-muted text-xs uppercase tracking-wider flex-1">
+                  Progreso
+                </Text>
+                {settled ? (
+                  <View className="px-2 py-0.5 rounded-full bg-green-500/15 border border-green-500/40">
+                    <Text className="text-green-400 text-xs font-semibold">
+                      Saldado
+                    </Text>
+                  </View>
+                ) : null}
+              </View>
+              <ProgressBar value={ratio} color="#10b981" />
+              <View className="flex-row justify-between mt-3">
+                <Text className="text-muted text-xs">
+                  {loan.type === 'lent' ? 'Cobrado ' : 'Pagado '}
+                  <Text className="text-white text-sm">
+                    {formatCurrency(paidNum, loan.currency)}
+                  </Text>
+                </Text>
+                <Text className="text-muted text-xs">
+                  de{' '}
+                  <Text className="text-white text-sm">
+                    {formatCurrency(amountNum, loan.currency)}
+                  </Text>
+                </Text>
+              </View>
+
+              {!settled ? (
+                <View className="mt-4 gap-2">
+                  <PrimaryButton onPress={() => setShowPaymentModal(true)}>
+                    {loan.type === 'lent' ? 'Registrar cobro' : 'Registrar pago'}
+                  </PrimaryButton>
+                  <TouchableOpacity
+                    onPress={handleSettleAll}
+                    activeOpacity={0.7}
+                    className="border border-green-500/60 rounded-xl py-3 items-center"
+                  >
+                    <Text className="text-green-400 font-semibold">
+                      Saldar completo
+                    </Text>
+                  </TouchableOpacity>
+                </View>
+              ) : null}
+            </View>
+          ) : null}
+
+          {/* Pagos en edit */}
+          {!isNew && payments.length > 0 ? (
+            <View className="mb-6">
+              <Text className="text-muted text-xs uppercase tracking-wider mb-2 px-1">
+                Historial de pagos ({payments.length})
+              </Text>
+              <View className="bg-surface border border-border rounded-2xl overflow-hidden">
+                {payments.map((p, idx) => (
+                  <View
+                    key={p.id}
+                    className={`flex-row items-center px-4 py-3 ${
+                      idx < payments.length - 1 ? 'border-b border-border' : ''
+                    }`}
+                  >
+                    <View className="flex-1">
+                      <Text className="text-white text-sm font-medium">
+                        {formatCurrency(Number(p.amount), p.currency)}
+                      </Text>
+                      <Text className="text-muted text-xs mt-0.5">
+                        {formatPaymentDate(p.date)}
+                        {p.notes ? ` · ${p.notes}` : ''}
+                      </Text>
+                    </View>
+                    {!settled ? (
+                      <TouchableOpacity
+                        onPress={() => handleDeletePayment(p)}
+                        activeOpacity={0.6}
+                        className="px-2 py-2"
+                      >
+                        <Icon name="trash" size={16} color="#f87171" />
+                      </TouchableOpacity>
+                    ) : null}
+                  </View>
+                ))}
+              </View>
+            </View>
+          ) : null}
+
+          {/* Form fields (deshabilitados si settled) */}
+          <View pointerEvents={settled ? 'none' : 'auto'} style={{ opacity: settled ? 0.5 : 1 }}>
+            {/* Tipo */}
+            <View className="mb-4">
+              <Text className="text-muted text-sm mb-1">Tipo</Text>
+              <View className="flex-row gap-2">
+                {TYPE_OPTIONS.map((opt) => (
+                  <TouchableOpacity
+                    key={opt.value}
+                    onPress={() => setType(opt.value)}
+                    activeOpacity={0.7}
+                    className={`flex-1 py-3 rounded-xl items-center border ${
+                      type === opt.value
+                        ? 'bg-primary border-primary'
+                        : 'bg-transparent border-border'
+                    }`}
+                  >
+                    <Text className="text-white font-medium">{opt.label}</Text>
+                  </TouchableOpacity>
+                ))}
+              </View>
+            </View>
+
+            <FormInput
+              label="Persona *"
+              value={personName}
+              onChangeText={setPersonName}
+              placeholder="Ej: Juan"
+            />
+
+            <FormInput
+              label="Monto *"
+              value={amount}
+              onChangeText={setAmount}
+              keyboardType="decimal-pad"
+              placeholder="0"
+            />
+
+            <View className="mb-4">
+              <Text className="text-muted text-sm mb-1">Moneda</Text>
+              <TouchableOpacity
+                onPress={() => setShowCurrencyPicker(true)}
+                activeOpacity={0.7}
+                className="bg-surface border border-border rounded-xl px-4 py-3"
+              >
+                <Text className="text-white">
+                  {CURRENCY_OPTIONS.find((o) => o.value === currency)?.label ?? currency}
+                </Text>
+              </TouchableOpacity>
+            </View>
+
+            <View className="mb-4">
+              <Text className="text-muted text-sm mb-1">Cuenta (opcional)</Text>
+              <TouchableOpacity
+                onPress={() => setShowAccountPicker(true)}
+                activeOpacity={0.7}
+                className="bg-surface border border-border rounded-xl px-4 py-3"
+              >
+                <Text className="text-white">
+                  {selectedAccount
+                    ? `${selectedAccount.icon ?? '💳'} ${selectedAccount.name}`
+                    : 'Sin cuenta'}
+                </Text>
+              </TouchableOpacity>
+              <Text className="text-muted text-xs mt-1">
+                {isLent
+                  ? 'Si eliges una cuenta, se descontará al crear y se devolverá al cobrar.'
+                  : 'Si eliges una cuenta, se sumará al crear y se descontará al pagar.'}
+              </Text>
+            </View>
+
+            <FormInput
+              label="Notas (opcional)"
+              value={notes}
+              onChangeText={setNotes}
+              placeholder="Notas adicionales..."
+              multiline
+              numberOfLines={2}
+              style={{ minHeight: 60, textAlignVertical: 'top' }}
+            />
+
+            {!settled ? (
+              <PrimaryButton
+                onPress={handleSubmit}
+                loading={saving}
+                disabled={!personName.trim() || !amount}
+              >
+                {isNew ? 'Crear préstamo' : 'Guardar cambios'}
+              </PrimaryButton>
+            ) : null}
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+
+      <SelectModal
+        visible={showCurrencyPicker}
+        onClose={() => setShowCurrencyPicker(false)}
+        title="Moneda"
+        options={CURRENCY_OPTIONS}
+        selected={currency}
+        onSelect={(v) => {
+          setCurrency(v as Currency)
+          setShowCurrencyPicker(false)
+        }}
+      />
+      <SelectModal
+        visible={showAccountPicker}
+        onClose={() => setShowAccountPicker(false)}
+        title="Cuenta"
+        options={accountOptions}
+        selected={accountId}
+        onSelect={(v) => {
+          setAccountId(v)
+          setShowAccountPicker(false)
+        }}
+      />
+
+      {loan ? (
+        <PaymentModal
+          visible={showPaymentModal}
+          onClose={() => setShowPaymentModal(false)}
+          loan={loan}
+          onSubmit={handlePayment}
+        />
+      ) : null}
+    </SafeAreaView>
+  )
+}

--- a/app/(dashboard)/loans/_layout.tsx
+++ b/app/(dashboard)/loans/_layout.tsx
@@ -1,0 +1,13 @@
+import { Stack } from 'expo-router'
+import { colors } from '@/constants/theme'
+
+export default function LoansLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: colors.bg },
+      }}
+    />
+  )
+}

--- a/app/(dashboard)/loans/index.tsx
+++ b/app/(dashboard)/loans/index.tsx
@@ -1,0 +1,187 @@
+import { useCallback, useMemo, useState } from 'react'
+import {
+  View,
+  Text,
+  SectionList,
+  TouchableOpacity,
+  ActivityIndicator,
+} from 'react-native'
+import { router, useFocusEffect } from 'expo-router'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useAuth } from '@/context/AuthContext'
+import { getLoans } from '@/lib/actions/loans.actions'
+import { ProgressBar } from '@/components/ui/ProgressBar'
+import { EmptyState } from '@/components/ui/EmptyState'
+import { formatCurrency } from '@/lib/utils/currency'
+import type { LoanWithAccount } from '@/types/database.types'
+
+type Section = {
+  title: string
+  data: LoanWithAccount[]
+}
+
+export default function LoansScreen() {
+  const { user } = useAuth()
+  const [loans, setLoans] = useState<LoanWithAccount[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const loadLoans = useCallback(async () => {
+    if (!user) return
+    const res = await getLoans(user.id)
+    if (res.success && res.data) setLoans(res.data)
+    setLoading(false)
+  }, [user])
+
+  useFocusEffect(
+    useCallback(() => {
+      let cancelled = false
+      ;(async () => {
+        await loadLoans()
+        if (cancelled) return
+      })()
+      return () => {
+        cancelled = true
+      }
+    }, [loadLoans])
+  )
+
+  const sections: Section[] = useMemo(() => {
+    const lent = loans.filter((l) => l.type === 'lent' && l.status === 'active')
+    const borrowed = loans.filter(
+      (l) => l.type === 'borrowed' && l.status === 'active'
+    )
+    const settled = loans.filter((l) => l.status === 'settled')
+    const out: Section[] = []
+    if (lent.length) out.push({ title: 'Por cobrar', data: lent })
+    if (borrowed.length) out.push({ title: 'Por pagar', data: borrowed })
+    if (settled.length) out.push({ title: 'Saldados', data: settled })
+    return out
+  }, [loans])
+
+  if (loading) {
+    return (
+      <View className="flex-1 bg-bg items-center justify-center">
+        <ActivityIndicator color="#4F46E5" />
+      </View>
+    )
+  }
+
+  return (
+    <SafeAreaView edges={['top']} className="flex-1 bg-bg">
+      {/* Header */}
+      <View className="flex-row items-center justify-between px-4 py-3 border-b border-border">
+        <TouchableOpacity onPress={() => router.back()} activeOpacity={0.7}>
+          <Text className="text-primary text-base">← Volver</Text>
+        </TouchableOpacity>
+        <Text className="text-white text-base font-bold">Préstamos</Text>
+        <View style={{ width: 60 }} />
+      </View>
+
+      <SectionList
+        sections={sections}
+        keyExtractor={(item) => item.id}
+        contentContainerStyle={
+          sections.length === 0 ? { flex: 1 } : { paddingVertical: 12 }
+        }
+        ListEmptyComponent={
+          <EmptyState
+            icon="🤝"
+            title="Sin préstamos"
+            description="Toca + para registrar tu primer préstamo o deuda"
+          />
+        }
+        renderSectionHeader={({ section }) => (
+          <View className="px-4 pt-4 pb-2">
+            <Text className="text-muted text-xs uppercase tracking-wider">
+              {section.title}
+            </Text>
+          </View>
+        )}
+        renderItem={({ item }) => <LoanCard loan={item} />}
+        stickySectionHeadersEnabled={false}
+      />
+
+      {/* FAB */}
+      <TouchableOpacity
+        onPress={() => router.push('/loans/new')}
+        activeOpacity={0.8}
+        className="absolute bottom-6 right-6 w-14 h-14 rounded-full bg-primary items-center justify-center shadow-lg"
+        style={{
+          shadowColor: '#000',
+          shadowOffset: { width: 0, height: 4 },
+          shadowOpacity: 0.3,
+          shadowRadius: 6,
+          elevation: 6,
+        }}
+      >
+        <Text className="text-white text-3xl font-bold" style={{ lineHeight: 32 }}>
+          +
+        </Text>
+      </TouchableOpacity>
+    </SafeAreaView>
+  )
+}
+
+function LoanCard({ loan }: { loan: LoanWithAccount }) {
+  const amount = Number(loan.amount)
+  const paid = Number(loan.paid_amount)
+  const ratio = amount > 0 ? paid / amount : 0
+  const remaining = Math.max(0, amount - paid)
+  const settled = loan.status === 'settled'
+  const isLent = loan.type === 'lent'
+
+  return (
+    <TouchableOpacity
+      onPress={() => router.push(`/loans/${loan.id}`)}
+      activeOpacity={0.7}
+      className="mx-4 mb-3 bg-surface border border-border rounded-2xl p-4"
+    >
+      <View className="flex-row items-center mb-2">
+        <View
+          className={`w-10 h-10 rounded-full items-center justify-center mr-3 ${
+            isLent ? 'bg-green-500/15' : 'bg-amber-500/15'
+          }`}
+        >
+          <Text className="text-xl">{isLent ? '⬇️' : '⬆️'}</Text>
+        </View>
+        <View className="flex-1">
+          <Text className="text-white text-base font-semibold">
+            {loan.person_name}
+          </Text>
+          <Text className="text-muted text-xs">
+            {isLent ? 'Le presté' : 'Me prestó'}{' '}
+            {loan.account ? `· ${loan.account.name}` : ''}
+          </Text>
+        </View>
+        <Text
+          className={
+            settled
+              ? 'text-green-400 text-xs font-semibold'
+              : 'text-muted text-xs'
+          }
+        >
+          {settled ? 'Saldado' : `${Math.round(ratio * 100)}%`}
+        </Text>
+      </View>
+
+      {!settled ? <ProgressBar value={ratio} color="#10b981" /> : null}
+
+      <View className="flex-row justify-between mt-3">
+        <Text className="text-muted text-xs">
+          {settled ? 'Total ' : 'Pagado '}
+          <Text className="text-white text-sm">
+            {formatCurrency(settled ? amount : paid, loan.currency)}
+          </Text>
+        </Text>
+        <Text className="text-muted text-xs">
+          {settled ? '' : 'Saldo '}
+          <Text className="text-white text-sm">
+            {settled
+              ? formatCurrency(amount, loan.currency)
+              : formatCurrency(remaining, loan.currency)}
+          </Text>
+        </Text>
+      </View>
+    </TouchableOpacity>
+  )
+}

--- a/app/(dashboard)/more.tsx
+++ b/app/(dashboard)/more.tsx
@@ -156,6 +156,11 @@ export default function MoreScreen() {
           label="Metas de ahorro"
           onPress={() => router.push('/savings')}
         />
+        <SettingsRow
+          icon="repeat"
+          label="Préstamos"
+          onPress={() => router.push('/loans')}
+        />
 
         {/* Sign out */}
         <View className="px-4 pt-10">

--- a/components/loans/PaymentModal.tsx
+++ b/components/loans/PaymentModal.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useState } from 'react'
+import { View, Text } from 'react-native'
+import { FormDialog } from '@/components/ui/FormDialog'
+import { FormInput } from '@/components/ui/FormInput'
+import { DateInput } from '@/components/ui/DateInput'
+import { PrimaryButton } from '@/components/ui/PrimaryButton'
+import { toast } from '@/components/ui/Toast'
+import { formatCurrency } from '@/lib/utils/currency'
+import type { Currency, LoanWithAccount } from '@/types/database.types'
+
+interface PaymentModalProps {
+  visible: boolean
+  onClose: () => void
+  loan: LoanWithAccount
+  onSubmit: (input: {
+    amount: number
+    date: string
+    notes: string | null
+    currency: Currency
+  }) => Promise<void>
+}
+
+/**
+ * Modal para registrar un pago contra un préstamo. La currency se hereda
+ * del préstamo (no se puede pagar en otra moneda — al menos por ahora).
+ */
+export function PaymentModal({
+  visible,
+  onClose,
+  loan,
+  onSubmit,
+}: PaymentModalProps) {
+  const [amount, setAmount] = useState('')
+  const [date, setDate] = useState(new Date().toISOString().slice(0, 10))
+  const [notes, setNotes] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    if (!visible) {
+      setAmount('')
+      setDate(new Date().toISOString().slice(0, 10))
+      setNotes('')
+      setSubmitting(false)
+    }
+  }, [visible])
+
+  const remaining = Math.max(
+    0,
+    Number(loan.amount) - Number(loan.paid_amount)
+  )
+
+  async function handleConfirm() {
+    const parsed = parseFloat(amount)
+    if (isNaN(parsed) || parsed <= 0) {
+      toast.error('Ingresa un monto válido')
+      return
+    }
+    if (parsed > remaining) {
+      toast.error(`El pago no puede exceder el saldo: ${formatCurrency(remaining, loan.currency)}`)
+      return
+    }
+    setSubmitting(true)
+    try {
+      await onSubmit({
+        amount: parsed,
+        date,
+        notes: notes.trim() || null,
+        currency: loan.currency,
+      })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const isLent = loan.type === 'lent'
+
+  return (
+    <FormDialog
+      visible={visible}
+      onClose={onClose}
+      title={isLent ? 'Registrar cobro' : 'Registrar pago'}
+      footer={
+        <PrimaryButton
+          onPress={handleConfirm}
+          loading={submitting}
+          disabled={!amount}
+        >
+          {isLent ? 'Confirmar cobro' : 'Confirmar pago'}
+        </PrimaryButton>
+      }
+    >
+      <View className="mb-4 px-4 py-3 rounded-xl bg-surface border border-border">
+        <Text className="text-muted text-xs">
+          {isLent
+            ? `Cobro a ${loan.person_name}. Saldo pendiente: `
+            : `Pago a ${loan.person_name}. Saldo pendiente: `}
+          <Text className="text-white text-sm">
+            {formatCurrency(remaining, loan.currency)}
+          </Text>
+        </Text>
+        {loan.account ? (
+          <Text className="text-muted text-xs mt-1">
+            Impactará la cuenta{' '}
+            <Text className="text-white text-sm">
+              {loan.account.icon ?? '💳'} {loan.account.name}
+            </Text>
+            : {isLent ? 'entrará' : 'saldrá'} el monto del pago.
+          </Text>
+        ) : null}
+      </View>
+
+      <FormInput
+        label="Monto *"
+        value={amount}
+        onChangeText={setAmount}
+        keyboardType="decimal-pad"
+        placeholder="0"
+      />
+
+      <DateInput label="Fecha *" value={date} onChange={setDate} />
+
+      <FormInput
+        label="Notas (opcional)"
+        value={notes}
+        onChangeText={setNotes}
+        placeholder="Ej: Pago primera quincena"
+        multiline
+        numberOfLines={2}
+        style={{ minHeight: 60, textAlignVertical: 'top' }}
+      />
+    </FormDialog>
+  )
+}

--- a/lib/actions/loans.actions.ts
+++ b/lib/actions/loans.actions.ts
@@ -1,0 +1,432 @@
+import { insforge } from '@/lib/insforge'
+import { applyBalanceDelta } from '@/lib/utils/balance-updater'
+import {
+  createLoanSchema,
+  updateLoanSchema,
+  createLoanPaymentSchema,
+  type CreateLoanInput,
+  type UpdateLoanInput,
+  type CreateLoanPaymentInput,
+} from '@/lib/validations/loan'
+import type {
+  Loan,
+  LoanPayment,
+  LoanType,
+  LoanWithAccount,
+} from '@/types/database.types'
+
+interface Result<T = void> {
+  success: boolean
+  data?: T
+  error?: string
+}
+
+/**
+ * Dirección del delta de balance según el tipo de préstamo y la operación.
+ *
+ *                | create | payment | reverse
+ *   -------------+--------+---------+---------
+ *   lent         |  -     |   +     |   +     (presté → me devuelven → reverso: vuelve el "salió")
+ *   borrowed     |  +     |   -     |   -     (me prestaron → devuelvo → reverso: vuelve el "entró")
+ *
+ * "reverse" se usa al editar/borrar para revertir el efecto original del create.
+ */
+type BalanceOp = 'create' | 'payment' | 'reverse'
+function balanceDirection(
+  type: LoanType,
+  op: BalanceOp
+): 'add' | 'subtract' {
+  if (type === 'lent') {
+    return op === 'create' ? 'subtract' : 'add'
+  }
+  // borrowed
+  return op === 'create' ? 'add' : 'subtract'
+}
+
+export async function getLoans(
+  userId: string
+): Promise<Result<LoanWithAccount[]>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const { data, error } = await insforge.database
+      .from('loans')
+      .select('*, account:accounts(id, name, currency, icon)')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+    if (error) throw error
+    return { success: true, data: (data ?? []) as LoanWithAccount[] }
+  } catch {
+    return { success: false, error: 'Error al cargar préstamos' }
+  }
+}
+
+export async function getLoanById(
+  id: string,
+  userId: string
+): Promise<Result<LoanWithAccount>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const { data, error } = await insforge.database
+      .from('loans')
+      .select('*, account:accounts(id, name, currency, icon)')
+      .eq('id', id)
+      .eq('user_id', userId)
+      .maybeSingle()
+    if (error) throw error
+    if (!data) return { success: false, error: 'Préstamo no encontrado' }
+    return { success: true, data: data as LoanWithAccount }
+  } catch {
+    return { success: false, error: 'Error al cargar préstamo' }
+  }
+}
+
+export async function getLoanPayments(
+  loanId: string,
+  userId: string
+): Promise<Result<LoanPayment[]>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const { data, error } = await insforge.database
+      .from('loan_payments')
+      .select('*')
+      .eq('loan_id', loanId)
+      .eq('user_id', userId)
+      .order('date', { ascending: false })
+    if (error) throw error
+    return { success: true, data: (data ?? []) as LoanPayment[] }
+  } catch {
+    return { success: false, error: 'Error al cargar pagos' }
+  }
+}
+
+export async function createLoan(
+  userId: string,
+  input: CreateLoanInput
+): Promise<Result<Loan>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const validated = createLoanSchema.parse(input)
+    const { data, error } = await insforge.database
+      .from('loans')
+      .insert([{ ...validated, user_id: userId }])
+      .select()
+      .single()
+    if (error) throw error
+
+    if (validated.account_id) {
+      await applyBalanceDelta(
+        validated.account_id,
+        validated.amount,
+        validated.currency,
+        balanceDirection(validated.type, 'create')
+      )
+    }
+    return { success: true, data: data as Loan }
+  } catch {
+    return { success: false, error: 'Error al crear préstamo' }
+  }
+}
+
+export async function updateLoan(
+  id: string,
+  userId: string,
+  input: UpdateLoanInput
+): Promise<Result<Loan>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const validated = updateLoanSchema.parse(input)
+
+    const { data: old, error: fetchError } = await insforge.database
+      .from('loans')
+      .select('*')
+      .eq('id', id)
+      .eq('user_id', userId)
+      .single()
+    if (fetchError) throw fetchError
+    if (!old) return { success: false, error: 'Préstamo no encontrado' }
+    if (old.status === 'settled') {
+      return {
+        success: false,
+        error: 'No se puede editar un préstamo saldado',
+      }
+    }
+
+    // Revertir balance del estado anterior
+    if (old.account_id) {
+      await applyBalanceDelta(
+        old.account_id,
+        Number(old.amount),
+        old.currency,
+        balanceDirection(old.type as LoanType, 'reverse')
+      )
+    }
+
+    // Aplicar balance del nuevo estado
+    const next = {
+      person_name: validated.person_name ?? old.person_name,
+      amount: validated.amount ?? Number(old.amount),
+      currency: validated.currency ?? old.currency,
+      account_id: validated.account_id ?? old.account_id,
+      type: validated.type ?? (old.type as LoanType),
+      notes: validated.notes ?? old.notes,
+    }
+    if (next.account_id) {
+      await applyBalanceDelta(
+        next.account_id,
+        next.amount,
+        next.currency,
+        balanceDirection(next.type, 'create')
+      )
+    }
+
+    const { data, error } = await insforge.database
+      .from('loans')
+      .update({ ...next, updated_at: new Date().toISOString() })
+      .eq('id', id)
+      .eq('user_id', userId)
+      .select()
+      .single()
+    if (error) throw error
+    return { success: true, data: data as Loan }
+  } catch {
+    return { success: false, error: 'Error al actualizar préstamo' }
+  }
+}
+
+export async function deleteLoan(
+  id: string,
+  userId: string
+): Promise<Result> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const { data: loan, error: fetchError } = await insforge.database
+      .from('loans')
+      .select('*')
+      .eq('id', id)
+      .eq('user_id', userId)
+      .single()
+    if (fetchError) throw fetchError
+    if (!loan) return { success: false, error: 'Préstamo no encontrado' }
+
+    // Solo revertir si está activo (settled ya cuadró todos los pagos)
+    if (loan.status === 'active' && loan.account_id) {
+      await applyBalanceDelta(
+        loan.account_id,
+        Number(loan.amount),
+        loan.currency,
+        balanceDirection(loan.type as LoanType, 'reverse')
+      )
+    }
+
+    const { error } = await insforge.database
+      .from('loans')
+      .delete()
+      .eq('id', id)
+      .eq('user_id', userId)
+    if (error) throw error
+    return { success: true }
+  } catch {
+    return { success: false, error: 'Error al eliminar préstamo' }
+  }
+}
+
+/**
+ * Registra un pago contra un préstamo. Multi-step similar a addFundsToGoal:
+ *
+ *   1. Fetch loan + verifica que no esté saldado
+ *   2. Impactar balance (lent → suma, borrowed → resta)
+ *   3. Insert payment row
+ *   4. Update loan.paid_amount; si paid >= amount → status='settled' + settled_at
+ *
+ * Ver [[Acciones multi-step sin transacciones]] para garantías.
+ */
+export async function addLoanPayment(
+  loanId: string,
+  userId: string,
+  input: CreateLoanPaymentInput
+): Promise<Result<{ loan: Loan; settled: boolean }>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const validated = createLoanPaymentSchema.parse(input)
+
+    const { data: loan, error: fetchError } = await insforge.database
+      .from('loans')
+      .select('*')
+      .eq('id', loanId)
+      .eq('user_id', userId)
+      .single()
+    if (fetchError) throw fetchError
+    if (!loan) return { success: false, error: 'Préstamo no encontrado' }
+    if (loan.status === 'settled') {
+      return { success: false, error: 'El préstamo ya está saldado' }
+    }
+
+    // Impactar balance
+    if (loan.account_id) {
+      await applyBalanceDelta(
+        loan.account_id,
+        validated.amount,
+        validated.currency,
+        balanceDirection(loan.type as LoanType, 'payment')
+      )
+    }
+
+    // Insert payment
+    await insforge.database.from('loan_payments').insert([
+      {
+        loan_id: loanId,
+        user_id: userId,
+        amount: validated.amount,
+        currency: validated.currency,
+        date: validated.date,
+        notes: validated.notes ?? null,
+      },
+    ])
+
+    // Update loan totals
+    const currentPaid = Number(loan.paid_amount ?? 0)
+    const loanAmount = Number(loan.amount)
+    const newPaid = currentPaid + validated.amount
+    const isSettled = newPaid >= loanAmount
+
+    const { data: updated, error: updateError } = await insforge.database
+      .from('loans')
+      .update({
+        paid_amount: isSettled ? loanAmount : newPaid,
+        status: isSettled ? 'settled' : 'active',
+        ...(isSettled ? { settled_at: new Date().toISOString() } : {}),
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', loanId)
+      .eq('user_id', userId)
+      .select()
+      .single()
+    if (updateError) throw updateError
+
+    return { success: true, data: { loan: updated as Loan, settled: isSettled } }
+  } catch {
+    return { success: false, error: 'Error al registrar pago' }
+  }
+}
+
+export async function deleteLoanPayment(
+  paymentId: string,
+  userId: string
+): Promise<Result> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    // Fetch payment + loan join
+    const { data: payment, error: fetchError } = await insforge.database
+      .from('loan_payments')
+      .select('*, loan:loans(*)')
+      .eq('id', paymentId)
+      .eq('user_id', userId)
+      .single()
+    if (fetchError) throw fetchError
+    if (!payment) return { success: false, error: 'Pago no encontrado' }
+
+    const loan = (payment as { loan: Loan }).loan
+    if (!loan) return { success: false, error: 'Préstamo no encontrado' }
+
+    // Revertir balance del payment
+    if (loan.account_id) {
+      // El opuesto de 'payment' es 'create' para fines de signo
+      await applyBalanceDelta(
+        loan.account_id,
+        Number(payment.amount),
+        payment.currency,
+        balanceDirection(loan.type, 'create')
+      )
+    }
+
+    // Reducir paid_amount, reabrir si estaba settled
+    const newPaid = Math.max(
+      0,
+      Number(loan.paid_amount) - Number(payment.amount)
+    )
+    await insforge.database
+      .from('loans')
+      .update({
+        paid_amount: newPaid,
+        status: 'active',
+        settled_at: null,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', loan.id)
+      .eq('user_id', userId)
+
+    const { error } = await insforge.database
+      .from('loan_payments')
+      .delete()
+      .eq('id', paymentId)
+      .eq('user_id', userId)
+    if (error) throw error
+    return { success: true }
+  } catch {
+    return { success: false, error: 'Error al eliminar pago' }
+  }
+}
+
+/**
+ * Liquida el préstamo: crea un pago final por el saldo restante e impacta
+ * el balance. Si ya estaba saldado, retorna error.
+ */
+export async function settleLoan(
+  loanId: string,
+  userId: string
+): Promise<Result> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const { data: loan, error: fetchError } = await insforge.database
+      .from('loans')
+      .select('*')
+      .eq('id', loanId)
+      .eq('user_id', userId)
+      .single()
+    if (fetchError) throw fetchError
+    if (!loan) return { success: false, error: 'Préstamo no encontrado' }
+    if (loan.status === 'settled') {
+      return { success: false, error: 'Ya está saldado' }
+    }
+
+    const remaining = Number(loan.amount) - Number(loan.paid_amount ?? 0)
+
+    if (loan.account_id && remaining > 0) {
+      await applyBalanceDelta(
+        loan.account_id,
+        remaining,
+        loan.currency,
+        balanceDirection(loan.type as LoanType, 'payment')
+      )
+    }
+
+    if (remaining > 0) {
+      await insforge.database.from('loan_payments').insert([
+        {
+          loan_id: loanId,
+          user_id: userId,
+          amount: remaining,
+          currency: loan.currency,
+          date: new Date().toISOString().slice(0, 10),
+          notes: 'Saldo final',
+        },
+      ])
+    }
+
+    const { error } = await insforge.database
+      .from('loans')
+      .update({
+        paid_amount: Number(loan.amount),
+        status: 'settled',
+        settled_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', loanId)
+      .eq('user_id', userId)
+    if (error) throw error
+
+    return { success: true }
+  } catch {
+    return { success: false, error: 'Error al saldar préstamo' }
+  }
+}


### PR DESCRIPTION
Closes #74 · Related to #69 (FASE 3) · **Última tarea de FASE 3**

## Cambios

### Backend
- **`lib/actions/loans.actions.ts`** — get/getById/create/update/delete + getLoanPayments + addLoanPayment + deleteLoanPayment + settleLoan. Helper interno `balanceDirection(type, op)` con tabla de verdad documentada centraliza la dirección del delta del balance en sus **4 call sites**.
- `updateLoan` revierte el balance del estado anterior y aplica del nuevo.
- `deleteLoan` solo revierte si está `active` (settled ya cuadró todos los pagos).
- `settleLoan` crea un pago final por el saldo restante con notes='Saldo final'.
- `deleteLoanPayment` revierte el balance del pago **y reabre el loan** si estaba settled (paid_amount baja, status vuelve a active, settled_at = null).

### UI
- **`app/(dashboard)/loans/`** — primera `SectionList` del proyecto, segmentada en "Por cobrar" / "Por pagar" / "Saldados". LoanCard con icon direccional, ProgressBar verde, badge Saldado.
- **`[id].tsx`** — bloque de progreso + historial de pagos (eliminar individual) + botones "Registrar pago/cobro" y "Saldar completo". Form deshabilitado si settled vía `pointerEvents='none'` + `opacity: 0.5`.
- **`components/loans/PaymentModal.tsx`** — gemelo de `DepositModal`. Currency heredada del loan, valida que el monto no exceda el saldo restante.
- **`more.tsx`** — link "Préstamos" en Datos.

## Comportamiento visible

- Crear loan `lent` → la cuenta se descuenta. Crear `borrowed` → la cuenta se suma.
- Registrar cobro a un loan `lent` → la cuenta se suma. Registrar pago a un `borrowed` → la cuenta se descuenta.
- Si el pago completa el monto, toast "¡Préstamo saldado! 🎉" + badge "Saldado" en la card.
- Eliminar un pago revierte la cuenta y reabre el loan si estaba settled.
- "Saldar completo" crea un pago por el saldo restante con notes="Saldo final".
- Form bloqueado si el loan está settled (con opacity reducida para feedback visual).

## Verificación

- [x] `npx tsc --noEmit` limpio
- [x] Crear loan lent con cuenta → balance baja
- [x] Crear loan borrowed con cuenta → balance sube
- [x] Pago parcial → ProgressBar actualizada, status sigue active
- [x] Pago que completa → status settled, settled_at set, form bloqueado
- [x] Eliminar pago de loan settled → reabre como active
- [x] Saldar completo de loan con saldo restante > 0 → crea pago final
- [x] Eliminar loan active → revierte balance
- [x] Eliminar loan settled → NO revierte (los pagos ya cuadraron)

## Notas para Obsidian

- 🆕 [[Dirección de balance por type y operación]] en `30 - Patterns/`
- Bitácora `T-3.3 — Préstamos.md`

## Cierre de FASE 3

Después del merge: PR `develop → main` con título `FASE 3: Planificación financiera` y stop+aprobación según `rules/github-flow.md`.