### PR TITLE
FASE 3: Planificación financiera

### DIFF
--- a/app/(dashboard)/budgets/[id].tsx
+++ b/app/(dashboard)/budgets/[id].tsx
@@ -1,0 +1,301 @@
+import { useEffect, useState } from 'react'
+import {
+  View,
+  Text,
+  ScrollView,
+  TouchableOpacity,
+  KeyboardAvoidingView,
+  Platform,
+  ActivityIndicator,
+} from 'react-native'
+import { useLocalSearchParams, router } from 'expo-router'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useAuth } from '@/context/AuthContext'
+import {
+  getBudgetById,
+  createBudget,
+  updateBudget,
+  deleteBudget,
+} from '@/lib/actions/budgets.actions'
+import { getCategories } from '@/lib/actions/categories.actions'
+import { FormInput } from '@/components/ui/FormInput'
+import { SelectModal } from '@/components/ui/SelectModal'
+import { DateInput } from '@/components/ui/DateInput'
+import { PrimaryButton } from '@/components/ui/PrimaryButton'
+import { confirmDialog } from '@/components/ui/ConfirmDialog'
+import { toast } from '@/components/ui/Toast'
+import type { BudgetPeriod, Category, Currency } from '@/types/database.types'
+
+const CURRENCY_OPTIONS = [
+  { label: 'COP — Peso Colombiano', value: 'COP' },
+  { label: 'USD — Dólar', value: 'USD' },
+  { label: 'VES — Bolívar (Bs)', value: 'VES' },
+]
+
+const PERIOD_OPTIONS: { value: BudgetPeriod; label: string }[] = [
+  { value: 'monthly', label: 'Mensual' },
+  { value: 'yearly', label: 'Anual' },
+]
+
+function todayYMD(): string {
+  return new Date().toISOString().slice(0, 10)
+}
+
+export default function BudgetFormScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>()
+  const { user } = useAuth()
+  const isNew = id === 'new'
+
+  const [initialLoading, setInitialLoading] = useState(!isNew)
+  const [saving, setSaving] = useState(false)
+  const [categories, setCategories] = useState<Category[]>([])
+
+  const [categoryId, setCategoryId] = useState('')
+  const [amount, setAmount] = useState('')
+  const [currency, setCurrency] = useState<Currency>(user?.preferred_currency ?? 'COP')
+  const [period, setPeriod] = useState<BudgetPeriod>('monthly')
+  const [startDate, setStartDate] = useState(todayYMD())
+
+  const [showCategoryPicker, setShowCategoryPicker] = useState(false)
+  const [showCurrencyPicker, setShowCurrencyPicker] = useState(false)
+
+  // Cargar categorías + budget si edit
+  useEffect(() => {
+    if (!user) return
+    let cancelled = false
+
+    getCategories(user.id).then((res) => {
+      if (cancelled) return
+      if (res.success && res.data) setCategories(res.data)
+    })
+
+    if (!isNew) {
+      getBudgetById(id, user.id).then((res) => {
+        if (cancelled) return
+        if (res.success && res.data) {
+          const b = res.data
+          setCategoryId(b.category_id)
+          setAmount(String(b.amount))
+          setCurrency(b.currency)
+          setPeriod(b.period)
+          setStartDate(b.start_date)
+        } else {
+          toast.error(res.error ?? 'Presupuesto no encontrado')
+          router.back()
+        }
+        setInitialLoading(false)
+      })
+    }
+
+    return () => {
+      cancelled = true
+    }
+  }, [user, id, isNew])
+
+  async function handleSubmit() {
+    if (!user) return
+    const parsed = parseFloat(amount)
+    if (!categoryId || !amount || isNaN(parsed) || parsed <= 0) {
+      toast.error('Completa todos los campos')
+      return
+    }
+
+    setSaving(true)
+    const input = {
+      category_id: categoryId,
+      amount: parsed,
+      currency,
+      period,
+      start_date: startDate,
+    }
+    const result = isNew
+      ? await createBudget(user.id, input)
+      : await updateBudget(id, user.id, input)
+    setSaving(false)
+
+    if (result.success) {
+      toast.success(isNew ? 'Presupuesto creado' : 'Presupuesto actualizado')
+      router.back()
+    } else {
+      toast.error(result.error ?? 'Error al guardar')
+    }
+  }
+
+  async function handleDelete() {
+    if (!user || isNew) return
+    const ok = await confirmDialog({
+      title: 'Eliminar presupuesto',
+      message: 'No se puede deshacer.',
+      confirmLabel: 'Eliminar',
+      destructive: true,
+    })
+    if (!ok) return
+
+    setSaving(true)
+    const result = await deleteBudget(id, user.id)
+    setSaving(false)
+    if (result.success) {
+      toast.success('Presupuesto eliminado')
+      router.back()
+    } else {
+      toast.error(result.error ?? 'Error al eliminar')
+    }
+  }
+
+  // Categorías filtradas: solo expense o both (no income — no se presupuesta lo que entra)
+  const filteredCategories = categories.filter(
+    (c) => c.type === 'expense' || c.type === 'both'
+  )
+  const categoryOptions = filteredCategories.map((c) => ({
+    label: `${c.icon ?? '📂'} ${c.name}`,
+    value: c.id,
+  }))
+  const selectedCategory = categories.find((c) => c.id === categoryId)
+
+  if (initialLoading) {
+    return (
+      <View className="flex-1 bg-bg items-center justify-center">
+        <ActivityIndicator color="#4F46E5" />
+      </View>
+    )
+  }
+
+  return (
+    <SafeAreaView edges={['top', 'bottom']} className="flex-1 bg-bg">
+      {/* Header */}
+      <View className="flex-row items-center justify-between px-4 py-3 border-b border-border">
+        <TouchableOpacity onPress={() => router.back()} activeOpacity={0.7}>
+          <Text className="text-primary text-base">← Volver</Text>
+        </TouchableOpacity>
+        <Text className="text-white text-base font-bold">
+          {isNew ? 'Nuevo presupuesto' : 'Editar presupuesto'}
+        </Text>
+        {!isNew ? (
+          <TouchableOpacity
+            onPress={handleDelete}
+            disabled={saving}
+            activeOpacity={0.7}
+          >
+            <Text className="text-red-400 text-sm">Eliminar</Text>
+          </TouchableOpacity>
+        ) : (
+          <View style={{ width: 60 }} />
+        )}
+      </View>
+
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        className="flex-1"
+      >
+        <ScrollView
+          className="flex-1 px-4"
+          contentContainerStyle={{ paddingVertical: 16, paddingBottom: 40 }}
+          keyboardShouldPersistTaps="handled"
+        >
+          {/* Categoría */}
+          <View className="mb-4">
+            <Text className="text-muted text-sm mb-1">Categoría *</Text>
+            <TouchableOpacity
+              onPress={() => setShowCategoryPicker(true)}
+              activeOpacity={0.7}
+              className="bg-surface border border-border rounded-xl px-4 py-3"
+            >
+              <Text className={selectedCategory ? 'text-white' : 'text-muted'}>
+                {selectedCategory
+                  ? `${selectedCategory.icon ?? '📂'} ${selectedCategory.name}`
+                  : 'Seleccionar categoría...'}
+              </Text>
+            </TouchableOpacity>
+          </View>
+
+          <FormInput
+            label="Monto *"
+            value={amount}
+            onChangeText={setAmount}
+            keyboardType="decimal-pad"
+            placeholder="0"
+          />
+
+          {/* Moneda */}
+          <View className="mb-4">
+            <Text className="text-muted text-sm mb-1">Moneda</Text>
+            <TouchableOpacity
+              onPress={() => setShowCurrencyPicker(true)}
+              activeOpacity={0.7}
+              className="bg-surface border border-border rounded-xl px-4 py-3"
+            >
+              <Text className="text-white">
+                {CURRENCY_OPTIONS.find((o) => o.value === currency)?.label ?? currency}
+              </Text>
+            </TouchableOpacity>
+          </View>
+
+          {/* Período */}
+          <View className="mb-4">
+            <Text className="text-muted text-sm mb-1">Período</Text>
+            <View className="flex-row gap-2">
+              {PERIOD_OPTIONS.map((opt) => (
+                <TouchableOpacity
+                  key={opt.value}
+                  onPress={() => setPeriod(opt.value)}
+                  activeOpacity={0.7}
+                  className={`flex-1 py-3 rounded-xl items-center border ${
+                    period === opt.value
+                      ? 'bg-primary border-primary'
+                      : 'bg-transparent border-border'
+                  }`}
+                >
+                  <Text className="text-white font-medium">{opt.label}</Text>
+                </TouchableOpacity>
+              ))}
+            </View>
+          </View>
+
+          {/* Fecha de inicio */}
+          <DateInput
+            label="Fecha de inicio *"
+            value={startDate}
+            onChange={setStartDate}
+          />
+
+          <Text className="text-muted text-xs mb-4 leading-relaxed">
+            El período {period === 'monthly' ? 'mensual' : 'anual'} se renueva el día{' '}
+            {new Date(`${startDate}T00:00:00`).getDate()} de cada{' '}
+            {period === 'monthly' ? 'mes' : 'año'}.
+          </Text>
+
+          <PrimaryButton
+            onPress={handleSubmit}
+            loading={saving}
+            disabled={!categoryId || !amount}
+          >
+            {isNew ? 'Crear presupuesto' : 'Guardar cambios'}
+          </PrimaryButton>
+        </ScrollView>
+      </KeyboardAvoidingView>
+
+      <SelectModal
+        visible={showCategoryPicker}
+        onClose={() => setShowCategoryPicker(false)}
+        title="Categoría"
+        options={categoryOptions}
+        selected={categoryId}
+        onSelect={(v) => {
+          setCategoryId(v)
+          setShowCategoryPicker(false)
+        }}
+      />
+      <SelectModal
+        visible={showCurrencyPicker}
+        onClose={() => setShowCurrencyPicker(false)}
+        title="Moneda"
+        options={CURRENCY_OPTIONS}
+        selected={currency}
+        onSelect={(v) => {
+          setCurrency(v as Currency)
+          setShowCurrencyPicker(false)
+        }}
+      />
+    </SafeAreaView>
+  )
+}

--- a/app/(dashboard)/budgets/_layout.tsx
+++ b/app/(dashboard)/budgets/_layout.tsx
@@ -1,0 +1,13 @@
+import { Stack } from 'expo-router'
+import { colors } from '@/constants/theme'
+
+export default function BudgetsLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: colors.bg },
+      }}
+    />
+  )
+}

--- a/app/(dashboard)/budgets/index.tsx
+++ b/app/(dashboard)/budgets/index.tsx
@@ -1,0 +1,174 @@
+import { useCallback, useState } from 'react'
+import {
+  View,
+  Text,
+  FlatList,
+  TouchableOpacity,
+  ActivityIndicator,
+} from 'react-native'
+import { router, useFocusEffect } from 'expo-router'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useAuth } from '@/context/AuthContext'
+import { getBudgets } from '@/lib/actions/budgets.actions'
+import { ProgressBar, defaultColor } from '@/components/ui/ProgressBar'
+import { EmptyState } from '@/components/ui/EmptyState'
+import { formatCurrency } from '@/lib/utils/currency'
+import type { BudgetWithSpent } from '@/types/database.types'
+
+const PERIOD_LABEL: Record<'monthly' | 'yearly', string> = {
+  monthly: 'Mensual',
+  yearly: 'Anual',
+}
+
+function formatShortDate(iso: string): string {
+  const d = new Date(iso)
+  return d.toLocaleDateString('es', { day: 'numeric', month: 'short' })
+}
+
+export default function BudgetsScreen() {
+  const { user } = useAuth()
+  const [budgets, setBudgets] = useState<BudgetWithSpent[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const loadBudgets = useCallback(async () => {
+    if (!user) return
+    const res = await getBudgets(user.id)
+    if (res.success && res.data) setBudgets(res.data)
+    setLoading(false)
+  }, [user])
+
+  useFocusEffect(
+    useCallback(() => {
+      let cancelled = false
+      ;(async () => {
+        await loadBudgets()
+        if (cancelled) return
+      })()
+      return () => {
+        cancelled = true
+      }
+    }, [loadBudgets])
+  )
+
+  if (loading) {
+    return (
+      <View className="flex-1 bg-bg items-center justify-center">
+        <ActivityIndicator color="#4F46E5" />
+      </View>
+    )
+  }
+
+  return (
+    <SafeAreaView edges={['top']} className="flex-1 bg-bg">
+      {/* Header */}
+      <View className="flex-row items-center justify-between px-4 py-3 border-b border-border">
+        <TouchableOpacity onPress={() => router.back()} activeOpacity={0.7}>
+          <Text className="text-primary text-base">← Volver</Text>
+        </TouchableOpacity>
+        <Text className="text-white text-base font-bold">Presupuestos</Text>
+        <View style={{ width: 60 }} />
+      </View>
+
+      <FlatList
+        data={budgets}
+        keyExtractor={(b) => b.id}
+        contentContainerStyle={
+          budgets.length === 0 ? { flex: 1 } : { paddingVertical: 12 }
+        }
+        ListEmptyComponent={
+          <EmptyState
+            icon="🎯"
+            title="Sin presupuestos"
+            description="Toca + para crear tu primer presupuesto"
+          />
+        }
+        renderItem={({ item }) => <BudgetCard budget={item} />}
+      />
+
+      {/* FAB */}
+      <TouchableOpacity
+        onPress={() => router.push('/budgets/new')}
+        activeOpacity={0.8}
+        className="absolute bottom-6 right-6 w-14 h-14 rounded-full bg-primary items-center justify-center shadow-lg"
+        style={{
+          shadowColor: '#000',
+          shadowOffset: { width: 0, height: 4 },
+          shadowOpacity: 0.3,
+          shadowRadius: 6,
+          elevation: 6,
+        }}
+      >
+        <Text className="text-white text-3xl font-bold" style={{ lineHeight: 32 }}>
+          +
+        </Text>
+      </TouchableOpacity>
+    </SafeAreaView>
+  )
+}
+
+function BudgetCard({ budget }: { budget: BudgetWithSpent }) {
+  const ratio = budget.amount > 0 ? budget.spent / budget.amount : 0
+  const color = defaultColor(ratio)
+  const exceeded = ratio >= 1
+  const remaining = budget.amount - budget.spent
+
+  return (
+    <TouchableOpacity
+      onPress={() => router.push(`/budgets/${budget.id}`)}
+      activeOpacity={0.7}
+      className="mx-4 mb-3 bg-surface border border-border rounded-2xl p-4"
+    >
+      {/* Header card */}
+      <View className="flex-row items-center mb-3">
+        <View
+          style={{ backgroundColor: budget.category.color ?? '#4F46E5' }}
+          className="w-10 h-10 rounded-full items-center justify-center mr-3"
+        >
+          <Text className="text-xl">{budget.category.icon ?? '📂'}</Text>
+        </View>
+        <View className="flex-1">
+          <Text className="text-white text-base font-semibold">
+            {budget.category.name}
+          </Text>
+          <Text className="text-muted text-xs">
+            {PERIOD_LABEL[budget.period]} · {formatShortDate(budget.periodStart)} —{' '}
+            {formatShortDate(budget.periodEnd)}
+          </Text>
+        </View>
+        <Text style={{ color }} className="text-base font-bold">
+          {Math.round(ratio * 100)}%
+        </Text>
+      </View>
+
+      <ProgressBar value={ratio} />
+
+      {/* Footer */}
+      <View className="flex-row justify-between mt-3">
+        <Text className="text-muted text-xs">
+          Gastado{' '}
+          <Text className="text-white text-sm">
+            {formatCurrency(budget.spent, budget.currency)}
+          </Text>
+        </Text>
+        <Text className="text-muted text-xs">
+          de{' '}
+          <Text className="text-white text-sm">
+            {formatCurrency(budget.amount, budget.currency)}
+          </Text>
+        </Text>
+      </View>
+
+      {exceeded ? (
+        <View className="mt-2 px-3 py-1.5 rounded-lg bg-red-500/10 border border-red-500/40">
+          <Text className="text-red-400 text-xs">
+            Excedido por {formatCurrency(budget.spent - budget.amount, budget.currency)}
+          </Text>
+        </View>
+      ) : (
+        <Text className="text-muted text-xs mt-2">
+          Restante {formatCurrency(remaining, budget.currency)}
+        </Text>
+      )}
+    </TouchableOpacity>
+  )
+}

--- a/app/(dashboard)/loans/[id].tsx
+++ b/app/(dashboard)/loans/[id].tsx
@@ -1,0 +1,523 @@
+import { useEffect, useState } from 'react'
+import {
+  View,
+  Text,
+  ScrollView,
+  TouchableOpacity,
+  KeyboardAvoidingView,
+  Platform,
+  ActivityIndicator,
+} from 'react-native'
+import { useLocalSearchParams, router } from 'expo-router'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useAuth } from '@/context/AuthContext'
+import {
+  getLoanById,
+  getLoanPayments,
+  createLoan,
+  updateLoan,
+  deleteLoan,
+  addLoanPayment,
+  deleteLoanPayment,
+  settleLoan,
+} from '@/lib/actions/loans.actions'
+import { getAccounts } from '@/lib/actions/accounts.actions'
+import { FormInput } from '@/components/ui/FormInput'
+import { SelectModal } from '@/components/ui/SelectModal'
+import { PrimaryButton } from '@/components/ui/PrimaryButton'
+import { ProgressBar } from '@/components/ui/ProgressBar'
+import { confirmDialog } from '@/components/ui/ConfirmDialog'
+import { toast } from '@/components/ui/Toast'
+import { Icon } from '@/components/ui/Icon'
+import { PaymentModal } from '@/components/loans/PaymentModal'
+import { formatCurrency } from '@/lib/utils/currency'
+import type {
+  Account,
+  Currency,
+  LoanPayment,
+  LoanType,
+  LoanWithAccount,
+} from '@/types/database.types'
+
+const CURRENCY_OPTIONS = [
+  { label: 'COP — Peso Colombiano', value: 'COP' },
+  { label: 'USD — Dólar', value: 'USD' },
+  { label: 'VES — Bolívar (Bs)', value: 'VES' },
+]
+
+const TYPE_OPTIONS: { value: LoanType; label: string }[] = [
+  { value: 'lent', label: 'Le presté' },
+  { value: 'borrowed', label: 'Me prestó' },
+]
+
+function formatPaymentDate(iso: string): string {
+  return new Date(`${iso}T00:00:00`).toLocaleDateString('es', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  })
+}
+
+export default function LoanFormScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>()
+  const { user } = useAuth()
+  const isNew = id === 'new'
+
+  const [initialLoading, setInitialLoading] = useState(!isNew)
+  const [saving, setSaving] = useState(false)
+  const [accounts, setAccounts] = useState<Account[]>([])
+  const [loan, setLoan] = useState<LoanWithAccount | null>(null)
+  const [payments, setPayments] = useState<LoanPayment[]>([])
+
+  const [personName, setPersonName] = useState('')
+  const [amount, setAmount] = useState('')
+  const [currency, setCurrency] = useState<Currency>(
+    user?.preferred_currency ?? 'COP'
+  )
+  const [type, setType] = useState<LoanType>('lent')
+  const [accountId, setAccountId] = useState<string>('')
+  const [notes, setNotes] = useState('')
+
+  const [showCurrencyPicker, setShowCurrencyPicker] = useState(false)
+  const [showAccountPicker, setShowAccountPicker] = useState(false)
+  const [showPaymentModal, setShowPaymentModal] = useState(false)
+
+  useEffect(() => {
+    if (!user) return
+    let cancelled = false
+
+    getAccounts(user.id).then((res) => {
+      if (cancelled) return
+      if (res.success && res.data) setAccounts(res.data)
+    })
+
+    if (!isNew) {
+      Promise.all([
+        getLoanById(id, user.id),
+        getLoanPayments(id, user.id),
+      ]).then(([loanRes, paymentsRes]) => {
+        if (cancelled) return
+        if (loanRes.success && loanRes.data) {
+          const l = loanRes.data
+          setLoan(l)
+          setPersonName(l.person_name)
+          setAmount(String(l.amount))
+          setCurrency(l.currency)
+          setType(l.type)
+          setAccountId(l.account_id ?? '')
+          setNotes(l.notes ?? '')
+        } else {
+          toast.error(loanRes.error ?? 'Préstamo no encontrado')
+          router.back()
+        }
+        if (paymentsRes.success && paymentsRes.data) {
+          setPayments(paymentsRes.data)
+        }
+        setInitialLoading(false)
+      })
+    }
+
+    return () => {
+      cancelled = true
+    }
+  }, [user, id, isNew])
+
+  async function refreshLoanAndPayments() {
+    if (!user || isNew) return
+    const [loanRes, paymentsRes] = await Promise.all([
+      getLoanById(id, user.id),
+      getLoanPayments(id, user.id),
+    ])
+    if (loanRes.success && loanRes.data) setLoan(loanRes.data)
+    if (paymentsRes.success && paymentsRes.data) setPayments(paymentsRes.data)
+  }
+
+  async function handleSubmit() {
+    if (!user) return
+    const parsed = parseFloat(amount)
+    if (!personName.trim() || isNaN(parsed) || parsed <= 0) {
+      toast.error('Completa los campos requeridos')
+      return
+    }
+
+    setSaving(true)
+    const input = {
+      person_name: personName.trim(),
+      amount: parsed,
+      currency,
+      account_id: accountId || null,
+      type,
+      notes: notes.trim() || null,
+    }
+    const result = isNew
+      ? await createLoan(user.id, input)
+      : await updateLoan(id, user.id, input)
+    setSaving(false)
+
+    if (result.success) {
+      toast.success(isNew ? 'Préstamo creado' : 'Préstamo actualizado')
+      router.back()
+    } else {
+      toast.error(result.error ?? 'Error al guardar')
+    }
+  }
+
+  async function handleDelete() {
+    if (!user || isNew) return
+    const ok = await confirmDialog({
+      title: 'Eliminar préstamo',
+      message:
+        loan?.status === 'active'
+          ? 'Se revertirá el impacto en la cuenta.'
+          : 'No se puede deshacer.',
+      confirmLabel: 'Eliminar',
+      destructive: true,
+    })
+    if (!ok) return
+
+    setSaving(true)
+    const result = await deleteLoan(id, user.id)
+    setSaving(false)
+    if (result.success) {
+      toast.success('Préstamo eliminado')
+      router.back()
+    } else {
+      toast.error(result.error ?? 'Error al eliminar')
+    }
+  }
+
+  async function handlePayment(input: {
+    amount: number
+    date: string
+    notes: string | null
+    currency: Currency
+  }) {
+    if (!user || !loan) return
+    const result = await addLoanPayment(loan.id, user.id, {
+      amount: input.amount,
+      currency: input.currency,
+      date: input.date,
+      notes: input.notes,
+    })
+    if (result.success && result.data) {
+      setShowPaymentModal(false)
+      if (result.data.settled) {
+        toast.success('¡Préstamo saldado! 🎉')
+      } else {
+        toast.success(loan.type === 'lent' ? 'Cobro registrado' : 'Pago registrado')
+      }
+      await refreshLoanAndPayments()
+    } else {
+      toast.error(result.error ?? 'Error al registrar')
+    }
+  }
+
+  async function handleDeletePayment(payment: LoanPayment) {
+    if (!user) return
+    const ok = await confirmDialog({
+      title: 'Eliminar pago',
+      message: 'Se revertirá el impacto en la cuenta y se reabrirá el préstamo si estaba saldado.',
+      confirmLabel: 'Eliminar',
+      destructive: true,
+    })
+    if (!ok) return
+
+    const result = await deleteLoanPayment(payment.id, user.id)
+    if (result.success) {
+      toast.success('Pago eliminado')
+      await refreshLoanAndPayments()
+    } else {
+      toast.error(result.error ?? 'Error al eliminar pago')
+    }
+  }
+
+  async function handleSettleAll() {
+    if (!user || !loan) return
+    const ok = await confirmDialog({
+      title: 'Saldar préstamo',
+      message: 'Se creará un pago final por el saldo restante e impactará la cuenta.',
+      confirmLabel: 'Saldar',
+    })
+    if (!ok) return
+
+    const result = await settleLoan(loan.id, user.id)
+    if (result.success) {
+      toast.success('Préstamo saldado')
+      await refreshLoanAndPayments()
+    } else {
+      toast.error(result.error ?? 'Error al saldar')
+    }
+  }
+
+  if (initialLoading) {
+    return (
+      <View className="flex-1 bg-bg items-center justify-center">
+        <ActivityIndicator color="#4F46E5" />
+      </View>
+    )
+  }
+
+  // Derivados
+  const amountNum = loan ? Number(loan.amount) : 0
+  const paidNum = loan ? Number(loan.paid_amount) : 0
+  const ratio = amountNum > 0 ? paidNum / amountNum : 0
+  const settled = loan?.status === 'settled'
+  const isLent = type === 'lent'
+
+  const accountOptions = [
+    { label: 'Sin cuenta', value: '' },
+    ...accounts.map((a) => ({
+      label: `${a.icon ?? '💳'} ${a.name} (${a.currency})`,
+      value: a.id,
+    })),
+  ]
+  const selectedAccount = accounts.find((a) => a.id === accountId) ?? null
+
+  return (
+    <SafeAreaView edges={['top', 'bottom']} className="flex-1 bg-bg">
+      {/* Header */}
+      <View className="flex-row items-center justify-between px-4 py-3 border-b border-border">
+        <TouchableOpacity onPress={() => router.back()} activeOpacity={0.7}>
+          <Text className="text-primary text-base">← Volver</Text>
+        </TouchableOpacity>
+        <Text className="text-white text-base font-bold">
+          {isNew ? 'Nuevo préstamo' : settled ? 'Préstamo saldado' : 'Editar préstamo'}
+        </Text>
+        {!isNew ? (
+          <TouchableOpacity
+            onPress={handleDelete}
+            disabled={saving}
+            activeOpacity={0.7}
+          >
+            <Text className="text-red-400 text-sm">Eliminar</Text>
+          </TouchableOpacity>
+        ) : (
+          <View style={{ width: 60 }} />
+        )}
+      </View>
+
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        className="flex-1"
+      >
+        <ScrollView
+          className="flex-1 px-4"
+          contentContainerStyle={{ paddingVertical: 16, paddingBottom: 40 }}
+          keyboardShouldPersistTaps="handled"
+        >
+          {/* Resumen en edit */}
+          {loan ? (
+            <View className="mb-6 bg-surface border border-border rounded-2xl p-4">
+              <View className="flex-row items-center mb-3">
+                <Text className="text-muted text-xs uppercase tracking-wider flex-1">
+                  Progreso
+                </Text>
+                {settled ? (
+                  <View className="px-2 py-0.5 rounded-full bg-green-500/15 border border-green-500/40">
+                    <Text className="text-green-400 text-xs font-semibold">
+                      Saldado
+                    </Text>
+                  </View>
+                ) : null}
+              </View>
+              <ProgressBar value={ratio} color="#10b981" />
+              <View className="flex-row justify-between mt-3">
+                <Text className="text-muted text-xs">
+                  {loan.type === 'lent' ? 'Cobrado ' : 'Pagado '}
+                  <Text className="text-white text-sm">
+                    {formatCurrency(paidNum, loan.currency)}
+                  </Text>
+                </Text>
+                <Text className="text-muted text-xs">
+                  de{' '}
+                  <Text className="text-white text-sm">
+                    {formatCurrency(amountNum, loan.currency)}
+                  </Text>
+                </Text>
+              </View>
+
+              {!settled ? (
+                <View className="mt-4 gap-2">
+                  <PrimaryButton onPress={() => setShowPaymentModal(true)}>
+                    {loan.type === 'lent' ? 'Registrar cobro' : 'Registrar pago'}
+                  </PrimaryButton>
+                  <TouchableOpacity
+                    onPress={handleSettleAll}
+                    activeOpacity={0.7}
+                    className="border border-green-500/60 rounded-xl py-3 items-center"
+                  >
+                    <Text className="text-green-400 font-semibold">
+                      Saldar completo
+                    </Text>
+                  </TouchableOpacity>
+                </View>
+              ) : null}
+            </View>
+          ) : null}
+
+          {/* Pagos en edit */}
+          {!isNew && payments.length > 0 ? (
+            <View className="mb-6">
+              <Text className="text-muted text-xs uppercase tracking-wider mb-2 px-1">
+                Historial de pagos ({payments.length})
+              </Text>
+              <View className="bg-surface border border-border rounded-2xl overflow-hidden">
+                {payments.map((p, idx) => (
+                  <View
+                    key={p.id}
+                    className={`flex-row items-center px-4 py-3 ${
+                      idx < payments.length - 1 ? 'border-b border-border' : ''
+                    }`}
+                  >
+                    <View className="flex-1">
+                      <Text className="text-white text-sm font-medium">
+                        {formatCurrency(Number(p.amount), p.currency)}
+                      </Text>
+                      <Text className="text-muted text-xs mt-0.5">
+                        {formatPaymentDate(p.date)}
+                        {p.notes ? ` · ${p.notes}` : ''}
+                      </Text>
+                    </View>
+                    {!settled ? (
+                      <TouchableOpacity
+                        onPress={() => handleDeletePayment(p)}
+                        activeOpacity={0.6}
+                        className="px-2 py-2"
+                      >
+                        <Icon name="trash" size={16} color="#f87171" />
+                      </TouchableOpacity>
+                    ) : null}
+                  </View>
+                ))}
+              </View>
+            </View>
+          ) : null}
+
+          {/* Form fields (deshabilitados si settled) */}
+          <View pointerEvents={settled ? 'none' : 'auto'} style={{ opacity: settled ? 0.5 : 1 }}>
+            {/* Tipo */}
+            <View className="mb-4">
+              <Text className="text-muted text-sm mb-1">Tipo</Text>
+              <View className="flex-row gap-2">
+                {TYPE_OPTIONS.map((opt) => (
+                  <TouchableOpacity
+                    key={opt.value}
+                    onPress={() => setType(opt.value)}
+                    activeOpacity={0.7}
+                    className={`flex-1 py-3 rounded-xl items-center border ${
+                      type === opt.value
+                        ? 'bg-primary border-primary'
+                        : 'bg-transparent border-border'
+                    }`}
+                  >
+                    <Text className="text-white font-medium">{opt.label}</Text>
+                  </TouchableOpacity>
+                ))}
+              </View>
+            </View>
+
+            <FormInput
+              label="Persona *"
+              value={personName}
+              onChangeText={setPersonName}
+              placeholder="Ej: Juan"
+            />
+
+            <FormInput
+              label="Monto *"
+              value={amount}
+              onChangeText={setAmount}
+              keyboardType="decimal-pad"
+              placeholder="0"
+            />
+
+            <View className="mb-4">
+              <Text className="text-muted text-sm mb-1">Moneda</Text>
+              <TouchableOpacity
+                onPress={() => setShowCurrencyPicker(true)}
+                activeOpacity={0.7}
+                className="bg-surface border border-border rounded-xl px-4 py-3"
+              >
+                <Text className="text-white">
+                  {CURRENCY_OPTIONS.find((o) => o.value === currency)?.label ?? currency}
+                </Text>
+              </TouchableOpacity>
+            </View>
+
+            <View className="mb-4">
+              <Text className="text-muted text-sm mb-1">Cuenta (opcional)</Text>
+              <TouchableOpacity
+                onPress={() => setShowAccountPicker(true)}
+                activeOpacity={0.7}
+                className="bg-surface border border-border rounded-xl px-4 py-3"
+              >
+                <Text className="text-white">
+                  {selectedAccount
+                    ? `${selectedAccount.icon ?? '💳'} ${selectedAccount.name}`
+                    : 'Sin cuenta'}
+                </Text>
+              </TouchableOpacity>
+              <Text className="text-muted text-xs mt-1">
+                {isLent
+                  ? 'Si eliges una cuenta, se descontará al crear y se devolverá al cobrar.'
+                  : 'Si eliges una cuenta, se sumará al crear y se descontará al pagar.'}
+              </Text>
+            </View>
+
+            <FormInput
+              label="Notas (opcional)"
+              value={notes}
+              onChangeText={setNotes}
+              placeholder="Notas adicionales..."
+              multiline
+              numberOfLines={2}
+              style={{ minHeight: 60, textAlignVertical: 'top' }}
+            />
+
+            {!settled ? (
+              <PrimaryButton
+                onPress={handleSubmit}
+                loading={saving}
+                disabled={!personName.trim() || !amount}
+              >
+                {isNew ? 'Crear préstamo' : 'Guardar cambios'}
+              </PrimaryButton>
+            ) : null}
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+
+      <SelectModal
+        visible={showCurrencyPicker}
+        onClose={() => setShowCurrencyPicker(false)}
+        title="Moneda"
+        options={CURRENCY_OPTIONS}
+        selected={currency}
+        onSelect={(v) => {
+          setCurrency(v as Currency)
+          setShowCurrencyPicker(false)
+        }}
+      />
+      <SelectModal
+        visible={showAccountPicker}
+        onClose={() => setShowAccountPicker(false)}
+        title="Cuenta"
+        options={accountOptions}
+        selected={accountId}
+        onSelect={(v) => {
+          setAccountId(v)
+          setShowAccountPicker(false)
+        }}
+      />
+
+      {loan ? (
+        <PaymentModal
+          visible={showPaymentModal}
+          onClose={() => setShowPaymentModal(false)}
+          loan={loan}
+          onSubmit={handlePayment}
+        />
+      ) : null}
+    </SafeAreaView>
+  )
+}

--- a/app/(dashboard)/loans/_layout.tsx
+++ b/app/(dashboard)/loans/_layout.tsx
@@ -1,0 +1,13 @@
+import { Stack } from 'expo-router'
+import { colors } from '@/constants/theme'
+
+export default function LoansLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: colors.bg },
+      }}
+    />
+  )
+}

--- a/app/(dashboard)/loans/index.tsx
+++ b/app/(dashboard)/loans/index.tsx
@@ -1,0 +1,187 @@
+import { useCallback, useMemo, useState } from 'react'
+import {
+  View,
+  Text,
+  SectionList,
+  TouchableOpacity,
+  ActivityIndicator,
+} from 'react-native'
+import { router, useFocusEffect } from 'expo-router'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useAuth } from '@/context/AuthContext'
+import { getLoans } from '@/lib/actions/loans.actions'
+import { ProgressBar } from '@/components/ui/ProgressBar'
+import { EmptyState } from '@/components/ui/EmptyState'
+import { formatCurrency } from '@/lib/utils/currency'
+import type { LoanWithAccount } from '@/types/database.types'
+
+type Section = {
+  title: string
+  data: LoanWithAccount[]
+}
+
+export default function LoansScreen() {
+  const { user } = useAuth()
+  const [loans, setLoans] = useState<LoanWithAccount[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const loadLoans = useCallback(async () => {
+    if (!user) return
+    const res = await getLoans(user.id)
+    if (res.success && res.data) setLoans(res.data)
+    setLoading(false)
+  }, [user])
+
+  useFocusEffect(
+    useCallback(() => {
+      let cancelled = false
+      ;(async () => {
+        await loadLoans()
+        if (cancelled) return
+      })()
+      return () => {
+        cancelled = true
+      }
+    }, [loadLoans])
+  )
+
+  const sections: Section[] = useMemo(() => {
+    const lent = loans.filter((l) => l.type === 'lent' && l.status === 'active')
+    const borrowed = loans.filter(
+      (l) => l.type === 'borrowed' && l.status === 'active'
+    )
+    const settled = loans.filter((l) => l.status === 'settled')
+    const out: Section[] = []
+    if (lent.length) out.push({ title: 'Por cobrar', data: lent })
+    if (borrowed.length) out.push({ title: 'Por pagar', data: borrowed })
+    if (settled.length) out.push({ title: 'Saldados', data: settled })
+    return out
+  }, [loans])
+
+  if (loading) {
+    return (
+      <View className="flex-1 bg-bg items-center justify-center">
+        <ActivityIndicator color="#4F46E5" />
+      </View>
+    )
+  }
+
+  return (
+    <SafeAreaView edges={['top']} className="flex-1 bg-bg">
+      {/* Header */}
+      <View className="flex-row items-center justify-between px-4 py-3 border-b border-border">
+        <TouchableOpacity onPress={() => router.back()} activeOpacity={0.7}>
+          <Text className="text-primary text-base">← Volver</Text>
+        </TouchableOpacity>
+        <Text className="text-white text-base font-bold">Préstamos</Text>
+        <View style={{ width: 60 }} />
+      </View>
+
+      <SectionList
+        sections={sections}
+        keyExtractor={(item) => item.id}
+        contentContainerStyle={
+          sections.length === 0 ? { flex: 1 } : { paddingVertical: 12 }
+        }
+        ListEmptyComponent={
+          <EmptyState
+            icon="🤝"
+            title="Sin préstamos"
+            description="Toca + para registrar tu primer préstamo o deuda"
+          />
+        }
+        renderSectionHeader={({ section }) => (
+          <View className="px-4 pt-4 pb-2">
+            <Text className="text-muted text-xs uppercase tracking-wider">
+              {section.title}
+            </Text>
+          </View>
+        )}
+        renderItem={({ item }) => <LoanCard loan={item} />}
+        stickySectionHeadersEnabled={false}
+      />
+
+      {/* FAB */}
+      <TouchableOpacity
+        onPress={() => router.push('/loans/new')}
+        activeOpacity={0.8}
+        className="absolute bottom-6 right-6 w-14 h-14 rounded-full bg-primary items-center justify-center shadow-lg"
+        style={{
+          shadowColor: '#000',
+          shadowOffset: { width: 0, height: 4 },
+          shadowOpacity: 0.3,
+          shadowRadius: 6,
+          elevation: 6,
+        }}
+      >
+        <Text className="text-white text-3xl font-bold" style={{ lineHeight: 32 }}>
+          +
+        </Text>
+      </TouchableOpacity>
+    </SafeAreaView>
+  )
+}
+
+function LoanCard({ loan }: { loan: LoanWithAccount }) {
+  const amount = Number(loan.amount)
+  const paid = Number(loan.paid_amount)
+  const ratio = amount > 0 ? paid / amount : 0
+  const remaining = Math.max(0, amount - paid)
+  const settled = loan.status === 'settled'
+  const isLent = loan.type === 'lent'
+
+  return (
+    <TouchableOpacity
+      onPress={() => router.push(`/loans/${loan.id}`)}
+      activeOpacity={0.7}
+      className="mx-4 mb-3 bg-surface border border-border rounded-2xl p-4"
+    >
+      <View className="flex-row items-center mb-2">
+        <View
+          className={`w-10 h-10 rounded-full items-center justify-center mr-3 ${
+            isLent ? 'bg-green-500/15' : 'bg-amber-500/15'
+          }`}
+        >
+          <Text className="text-xl">{isLent ? '⬇️' : '⬆️'}</Text>
+        </View>
+        <View className="flex-1">
+          <Text className="text-white text-base font-semibold">
+            {loan.person_name}
+          </Text>
+          <Text className="text-muted text-xs">
+            {isLent ? 'Le presté' : 'Me prestó'}{' '}
+            {loan.account ? `· ${loan.account.name}` : ''}
+          </Text>
+        </View>
+        <Text
+          className={
+            settled
+              ? 'text-green-400 text-xs font-semibold'
+              : 'text-muted text-xs'
+          }
+        >
+          {settled ? 'Saldado' : `${Math.round(ratio * 100)}%`}
+        </Text>
+      </View>
+
+      {!settled ? <ProgressBar value={ratio} color="#10b981" /> : null}
+
+      <View className="flex-row justify-between mt-3">
+        <Text className="text-muted text-xs">
+          {settled ? 'Total ' : 'Pagado '}
+          <Text className="text-white text-sm">
+            {formatCurrency(settled ? amount : paid, loan.currency)}
+          </Text>
+        </Text>
+        <Text className="text-muted text-xs">
+          {settled ? '' : 'Saldo '}
+          <Text className="text-white text-sm">
+            {settled
+              ? formatCurrency(amount, loan.currency)
+              : formatCurrency(remaining, loan.currency)}
+          </Text>
+        </Text>
+      </View>
+    </TouchableOpacity>
+  )
+}

--- a/app/(dashboard)/more.tsx
+++ b/app/(dashboard)/more.tsx
@@ -151,6 +151,11 @@ export default function MoreScreen() {
           label="Presupuestos"
           onPress={() => router.push('/budgets')}
         />
+        <SettingsRow
+          icon="arrow-up-circle"
+          label="Metas de ahorro"
+          onPress={() => router.push('/savings')}
+        />
 
         {/* Sign out */}
         <View className="px-4 pt-10">

--- a/app/(dashboard)/more.tsx
+++ b/app/(dashboard)/more.tsx
@@ -146,6 +146,11 @@ export default function MoreScreen() {
           label="Categorías"
           onPress={() => router.push('/categories')}
         />
+        <SettingsRow
+          icon="wallet"
+          label="Presupuestos"
+          onPress={() => router.push('/budgets')}
+        />
 
         {/* Sign out */}
         <View className="px-4 pt-10">

--- a/app/(dashboard)/more.tsx
+++ b/app/(dashboard)/more.tsx
@@ -156,6 +156,11 @@ export default function MoreScreen() {
           label="Metas de ahorro"
           onPress={() => router.push('/savings')}
         />
+        <SettingsRow
+          icon="repeat"
+          label="Préstamos"
+          onPress={() => router.push('/loans')}
+        />
 
         {/* Sign out */}
         <View className="px-4 pt-10">

--- a/app/(dashboard)/savings/[id].tsx
+++ b/app/(dashboard)/savings/[id].tsx
@@ -1,0 +1,308 @@
+import { useEffect, useState } from 'react'
+import {
+  View,
+  Text,
+  ScrollView,
+  TouchableOpacity,
+  KeyboardAvoidingView,
+  Platform,
+  ActivityIndicator,
+} from 'react-native'
+import { useLocalSearchParams, router } from 'expo-router'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useAuth } from '@/context/AuthContext'
+import {
+  getSavingsGoalById,
+  createSavingsGoal,
+  updateSavingsGoal,
+  deleteSavingsGoal,
+  addFundsToGoal,
+} from '@/lib/actions/savings.actions'
+import { getAccounts } from '@/lib/actions/accounts.actions'
+import { FormInput } from '@/components/ui/FormInput'
+import { SelectModal } from '@/components/ui/SelectModal'
+import { DateInput } from '@/components/ui/DateInput'
+import { PrimaryButton } from '@/components/ui/PrimaryButton'
+import { ProgressBar } from '@/components/ui/ProgressBar'
+import { confirmDialog } from '@/components/ui/ConfirmDialog'
+import { toast } from '@/components/ui/Toast'
+import { DepositModal } from '@/components/savings/DepositModal'
+import { formatCurrency } from '@/lib/utils/currency'
+import type { Account, Currency, SavingsGoal } from '@/types/database.types'
+
+const CURRENCY_OPTIONS = [
+  { label: 'COP — Peso Colombiano', value: 'COP' },
+  { label: 'USD — Dólar', value: 'USD' },
+  { label: 'VES — Bolívar (Bs)', value: 'VES' },
+]
+
+export default function SavingsGoalFormScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>()
+  const { user } = useAuth()
+  const isNew = id === 'new'
+
+  const [initialLoading, setInitialLoading] = useState(!isNew)
+  const [saving, setSaving] = useState(false)
+  const [accounts, setAccounts] = useState<Account[]>([])
+  const [goal, setGoal] = useState<SavingsGoal | null>(null)
+
+  const [name, setName] = useState('')
+  const [targetAmount, setTargetAmount] = useState('')
+  const [currency, setCurrency] = useState<Currency>(
+    user?.preferred_currency ?? 'COP'
+  )
+  const [deadline, setDeadline] = useState<string>('')
+
+  const [showCurrencyPicker, setShowCurrencyPicker] = useState(false)
+  const [showDepositModal, setShowDepositModal] = useState(false)
+
+  useEffect(() => {
+    if (!user) return
+    let cancelled = false
+
+    getAccounts(user.id).then((res) => {
+      if (cancelled) return
+      if (res.success && res.data) setAccounts(res.data)
+    })
+
+    if (!isNew) {
+      getSavingsGoalById(id, user.id).then((res) => {
+        if (cancelled) return
+        if (res.success && res.data) {
+          const g = res.data
+          setGoal(g)
+          setName(g.name)
+          setTargetAmount(String(g.target_amount))
+          setCurrency(g.currency)
+          setDeadline(g.deadline ?? '')
+        } else {
+          toast.error(res.error ?? 'Meta no encontrada')
+          router.back()
+        }
+        setInitialLoading(false)
+      })
+    }
+
+    return () => {
+      cancelled = true
+    }
+  }, [user, id, isNew])
+
+  async function handleSubmit() {
+    if (!user) return
+    const parsed = parseFloat(targetAmount)
+    if (!name.trim() || isNaN(parsed) || parsed <= 0) {
+      toast.error('Completa los campos requeridos')
+      return
+    }
+
+    setSaving(true)
+    const input = {
+      name: name.trim(),
+      target_amount: parsed,
+      currency,
+      deadline: deadline || null,
+    }
+    const result = isNew
+      ? await createSavingsGoal(user.id, input)
+      : await updateSavingsGoal(id, user.id, input)
+    setSaving(false)
+
+    if (result.success) {
+      toast.success(isNew ? 'Meta creada' : 'Meta actualizada')
+      router.back()
+    } else {
+      toast.error(result.error ?? 'Error al guardar')
+    }
+  }
+
+  async function handleDelete() {
+    if (!user || isNew) return
+    const ok = await confirmDialog({
+      title: 'Eliminar meta',
+      message: 'No se puede deshacer.',
+      confirmLabel: 'Eliminar',
+      destructive: true,
+    })
+    if (!ok) return
+
+    setSaving(true)
+    const result = await deleteSavingsGoal(id, user.id)
+    setSaving(false)
+    if (result.success) {
+      toast.success('Meta eliminada')
+      router.back()
+    } else {
+      toast.error(result.error ?? 'Error al eliminar')
+    }
+  }
+
+  async function handleDeposit(input: {
+    amount: number
+    account_id: string | null
+    currency: Currency
+  }) {
+    if (!user || !goal) return
+    const result = await addFundsToGoal(goal.id, user.id, {
+      amount: input.amount,
+      account_id: input.account_id,
+      currency: input.currency,
+    })
+    if (result.success && result.data) {
+      setGoal(result.data)
+      setShowDepositModal(false)
+      if (result.data.is_completed) {
+        toast.success('¡Meta completada! 🎉')
+      } else {
+        toast.success('Depósito registrado')
+      }
+    } else {
+      toast.error(result.error ?? 'Error al depositar')
+    }
+  }
+
+  if (initialLoading) {
+    return (
+      <View className="flex-1 bg-bg items-center justify-center">
+        <ActivityIndicator color="#4F46E5" />
+      </View>
+    )
+  }
+
+  // Progreso visible (solo cuando editando)
+  const target = goal ? Number(goal.target_amount) : 0
+  const current = goal ? Number(goal.current_amount) : 0
+  const ratio = target > 0 ? current / target : 0
+  const completed = goal?.is_completed || ratio >= 1
+
+  return (
+    <SafeAreaView edges={['top', 'bottom']} className="flex-1 bg-bg">
+      {/* Header */}
+      <View className="flex-row items-center justify-between px-4 py-3 border-b border-border">
+        <TouchableOpacity onPress={() => router.back()} activeOpacity={0.7}>
+          <Text className="text-primary text-base">← Volver</Text>
+        </TouchableOpacity>
+        <Text className="text-white text-base font-bold">
+          {isNew ? 'Nueva meta' : 'Editar meta'}
+        </Text>
+        {!isNew ? (
+          <TouchableOpacity
+            onPress={handleDelete}
+            disabled={saving}
+            activeOpacity={0.7}
+          >
+            <Text className="text-red-400 text-sm">Eliminar</Text>
+          </TouchableOpacity>
+        ) : (
+          <View style={{ width: 60 }} />
+        )}
+      </View>
+
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        className="flex-1"
+      >
+        <ScrollView
+          className="flex-1 px-4"
+          contentContainerStyle={{ paddingVertical: 16, paddingBottom: 40 }}
+          keyboardShouldPersistTaps="handled"
+        >
+          {/* Resumen si edit */}
+          {goal ? (
+            <View className="mb-6 bg-surface border border-border rounded-2xl p-4">
+              <Text className="text-muted text-xs uppercase tracking-wider mb-2">
+                Progreso
+              </Text>
+              <ProgressBar value={ratio} color="#10b981" />
+              <View className="flex-row justify-between mt-3">
+                <Text className="text-muted text-xs">
+                  {formatCurrency(current, goal.currency)} de{' '}
+                  {formatCurrency(target, goal.currency)}
+                </Text>
+                <Text className="text-green-400 text-sm font-semibold">
+                  {Math.round(ratio * 100)}%
+                </Text>
+              </View>
+
+              <View className="mt-4">
+                <PrimaryButton
+                  onPress={() => setShowDepositModal(true)}
+                  disabled={completed}
+                >
+                  {completed ? 'Meta completada' : 'Depositar fondos'}
+                </PrimaryButton>
+              </View>
+            </View>
+          ) : null}
+
+          {/* Form fields */}
+          <FormInput
+            label="Nombre *"
+            value={name}
+            onChangeText={setName}
+            placeholder="Ej: Viaje a Japón"
+          />
+
+          <FormInput
+            label="Monto objetivo *"
+            value={targetAmount}
+            onChangeText={setTargetAmount}
+            keyboardType="decimal-pad"
+            placeholder="0"
+          />
+
+          <View className="mb-4">
+            <Text className="text-muted text-sm mb-1">Moneda</Text>
+            <TouchableOpacity
+              onPress={() => setShowCurrencyPicker(true)}
+              activeOpacity={0.7}
+              className="bg-surface border border-border rounded-xl px-4 py-3"
+            >
+              <Text className="text-white">
+                {CURRENCY_OPTIONS.find((o) => o.value === currency)?.label ??
+                  currency}
+              </Text>
+            </TouchableOpacity>
+          </View>
+
+          <DateInput
+            label="Fecha límite (opcional)"
+            value={deadline}
+            onChange={setDeadline}
+            placeholder="Sin fecha límite"
+          />
+
+          <PrimaryButton
+            onPress={handleSubmit}
+            loading={saving}
+            disabled={!name.trim() || !targetAmount}
+          >
+            {isNew ? 'Crear meta' : 'Guardar cambios'}
+          </PrimaryButton>
+        </ScrollView>
+      </KeyboardAvoidingView>
+
+      <SelectModal
+        visible={showCurrencyPicker}
+        onClose={() => setShowCurrencyPicker(false)}
+        title="Moneda"
+        options={CURRENCY_OPTIONS}
+        selected={currency}
+        onSelect={(v) => {
+          setCurrency(v as Currency)
+          setShowCurrencyPicker(false)
+        }}
+      />
+
+      {goal ? (
+        <DepositModal
+          visible={showDepositModal}
+          onClose={() => setShowDepositModal(false)}
+          goal={goal}
+          accounts={accounts}
+          onSubmit={handleDeposit}
+        />
+      ) : null}
+    </SafeAreaView>
+  )
+}

--- a/app/(dashboard)/savings/_layout.tsx
+++ b/app/(dashboard)/savings/_layout.tsx
@@ -1,0 +1,13 @@
+import { Stack } from 'expo-router'
+import { colors } from '@/constants/theme'
+
+export default function SavingsLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: colors.bg },
+      }}
+    />
+  )
+}

--- a/app/(dashboard)/savings/index.tsx
+++ b/app/(dashboard)/savings/index.tsx
@@ -1,0 +1,185 @@
+import { useCallback, useState } from 'react'
+import {
+  View,
+  Text,
+  FlatList,
+  TouchableOpacity,
+  ActivityIndicator,
+} from 'react-native'
+import { router, useFocusEffect } from 'expo-router'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useAuth } from '@/context/AuthContext'
+import { getSavingsGoals } from '@/lib/actions/savings.actions'
+import { ProgressBar } from '@/components/ui/ProgressBar'
+import { EmptyState } from '@/components/ui/EmptyState'
+import { formatCurrency } from '@/lib/utils/currency'
+import type { SavingsGoal } from '@/types/database.types'
+
+/** Devuelve "Faltan X días", "Vence hoy", "Vencida hace Y días", o null si no hay deadline. */
+function formatDeadline(deadline: string | null): {
+  text: string
+  overdue: boolean
+} | null {
+  if (!deadline) return null
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  const target = new Date(`${deadline}T00:00:00`)
+  const diffMs = target.getTime() - today.getTime()
+  const days = Math.round(diffMs / (1000 * 60 * 60 * 24))
+
+  if (days === 0) return { text: 'Vence hoy', overdue: false }
+  if (days > 0) return { text: `Faltan ${days} días`, overdue: false }
+  return { text: `Vencida hace ${Math.abs(days)} días`, overdue: true }
+}
+
+export default function SavingsScreen() {
+  const { user } = useAuth()
+  const [goals, setGoals] = useState<SavingsGoal[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const loadGoals = useCallback(async () => {
+    if (!user) return
+    const res = await getSavingsGoals(user.id)
+    if (res.success && res.data) setGoals(res.data)
+    setLoading(false)
+  }, [user])
+
+  useFocusEffect(
+    useCallback(() => {
+      let cancelled = false
+      ;(async () => {
+        await loadGoals()
+        if (cancelled) return
+      })()
+      return () => {
+        cancelled = true
+      }
+    }, [loadGoals])
+  )
+
+  if (loading) {
+    return (
+      <View className="flex-1 bg-bg items-center justify-center">
+        <ActivityIndicator color="#4F46E5" />
+      </View>
+    )
+  }
+
+  return (
+    <SafeAreaView edges={['top']} className="flex-1 bg-bg">
+      {/* Header */}
+      <View className="flex-row items-center justify-between px-4 py-3 border-b border-border">
+        <TouchableOpacity onPress={() => router.back()} activeOpacity={0.7}>
+          <Text className="text-primary text-base">← Volver</Text>
+        </TouchableOpacity>
+        <Text className="text-white text-base font-bold">Metas de ahorro</Text>
+        <View style={{ width: 60 }} />
+      </View>
+
+      <FlatList
+        data={goals}
+        keyExtractor={(g) => g.id}
+        contentContainerStyle={
+          goals.length === 0 ? { flex: 1 } : { paddingVertical: 12 }
+        }
+        ListEmptyComponent={
+          <EmptyState
+            icon="🐖"
+            title="Sin metas"
+            description="Toca + para crear tu primera meta de ahorro"
+          />
+        }
+        renderItem={({ item }) => <GoalCard goal={item} />}
+      />
+
+      {/* FAB */}
+      <TouchableOpacity
+        onPress={() => router.push('/savings/new')}
+        activeOpacity={0.8}
+        className="absolute bottom-6 right-6 w-14 h-14 rounded-full bg-primary items-center justify-center shadow-lg"
+        style={{
+          shadowColor: '#000',
+          shadowOffset: { width: 0, height: 4 },
+          shadowOpacity: 0.3,
+          shadowRadius: 6,
+          elevation: 6,
+        }}
+      >
+        <Text className="text-white text-3xl font-bold" style={{ lineHeight: 32 }}>
+          +
+        </Text>
+      </TouchableOpacity>
+    </SafeAreaView>
+  )
+}
+
+function GoalCard({ goal }: { goal: SavingsGoal }) {
+  const target = Number(goal.target_amount)
+  const current = Number(goal.current_amount)
+  const ratio = target > 0 ? current / target : 0
+  const remaining = Math.max(0, target - current)
+  const deadline = formatDeadline(goal.deadline)
+  const completed = goal.is_completed || ratio >= 1
+
+  return (
+    <TouchableOpacity
+      onPress={() => router.push(`/savings/${goal.id}`)}
+      activeOpacity={0.7}
+      className="mx-4 mb-3 bg-surface border border-border rounded-2xl p-4"
+    >
+      <View className="flex-row items-center mb-3">
+        <View className="flex-1">
+          <View className="flex-row items-center gap-2">
+            <Text className="text-white text-base font-semibold">
+              {goal.name}
+            </Text>
+            {completed ? (
+              <View className="px-2 py-0.5 rounded-full bg-green-500/15 border border-green-500/40">
+                <Text className="text-green-400 text-xs font-semibold">
+                  Completada
+                </Text>
+              </View>
+            ) : null}
+          </View>
+          {deadline ? (
+            <Text
+              className={
+                deadline.overdue
+                  ? 'text-red-400 text-xs mt-0.5'
+                  : 'text-muted text-xs mt-0.5'
+              }
+            >
+              {deadline.text}
+            </Text>
+          ) : null}
+        </View>
+        <Text className="text-green-400 text-base font-bold">
+          {Math.round(ratio * 100)}%
+        </Text>
+      </View>
+
+      <ProgressBar value={ratio} color="#10b981" />
+
+      <View className="flex-row justify-between mt-3">
+        <Text className="text-muted text-xs">
+          Ahorrado{' '}
+          <Text className="text-white text-sm">
+            {formatCurrency(current, goal.currency)}
+          </Text>
+        </Text>
+        <Text className="text-muted text-xs">
+          de{' '}
+          <Text className="text-white text-sm">
+            {formatCurrency(target, goal.currency)}
+          </Text>
+        </Text>
+      </View>
+
+      {!completed ? (
+        <Text className="text-muted text-xs mt-2">
+          Restante {formatCurrency(remaining, goal.currency)}
+        </Text>
+      ) : null}
+    </TouchableOpacity>
+  )
+}

--- a/components/loans/PaymentModal.tsx
+++ b/components/loans/PaymentModal.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useState } from 'react'
+import { View, Text } from 'react-native'
+import { FormDialog } from '@/components/ui/FormDialog'
+import { FormInput } from '@/components/ui/FormInput'
+import { DateInput } from '@/components/ui/DateInput'
+import { PrimaryButton } from '@/components/ui/PrimaryButton'
+import { toast } from '@/components/ui/Toast'
+import { formatCurrency } from '@/lib/utils/currency'
+import type { Currency, LoanWithAccount } from '@/types/database.types'
+
+interface PaymentModalProps {
+  visible: boolean
+  onClose: () => void
+  loan: LoanWithAccount
+  onSubmit: (input: {
+    amount: number
+    date: string
+    notes: string | null
+    currency: Currency
+  }) => Promise<void>
+}
+
+/**
+ * Modal para registrar un pago contra un préstamo. La currency se hereda
+ * del préstamo (no se puede pagar en otra moneda — al menos por ahora).
+ */
+export function PaymentModal({
+  visible,
+  onClose,
+  loan,
+  onSubmit,
+}: PaymentModalProps) {
+  const [amount, setAmount] = useState('')
+  const [date, setDate] = useState(new Date().toISOString().slice(0, 10))
+  const [notes, setNotes] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    if (!visible) {
+      setAmount('')
+      setDate(new Date().toISOString().slice(0, 10))
+      setNotes('')
+      setSubmitting(false)
+    }
+  }, [visible])
+
+  const remaining = Math.max(
+    0,
+    Number(loan.amount) - Number(loan.paid_amount)
+  )
+
+  async function handleConfirm() {
+    const parsed = parseFloat(amount)
+    if (isNaN(parsed) || parsed <= 0) {
+      toast.error('Ingresa un monto válido')
+      return
+    }
+    if (parsed > remaining) {
+      toast.error(`El pago no puede exceder el saldo: ${formatCurrency(remaining, loan.currency)}`)
+      return
+    }
+    setSubmitting(true)
+    try {
+      await onSubmit({
+        amount: parsed,
+        date,
+        notes: notes.trim() || null,
+        currency: loan.currency,
+      })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const isLent = loan.type === 'lent'
+
+  return (
+    <FormDialog
+      visible={visible}
+      onClose={onClose}
+      title={isLent ? 'Registrar cobro' : 'Registrar pago'}
+      footer={
+        <PrimaryButton
+          onPress={handleConfirm}
+          loading={submitting}
+          disabled={!amount}
+        >
+          {isLent ? 'Confirmar cobro' : 'Confirmar pago'}
+        </PrimaryButton>
+      }
+    >
+      <View className="mb-4 px-4 py-3 rounded-xl bg-surface border border-border">
+        <Text className="text-muted text-xs">
+          {isLent
+            ? `Cobro a ${loan.person_name}. Saldo pendiente: `
+            : `Pago a ${loan.person_name}. Saldo pendiente: `}
+          <Text className="text-white text-sm">
+            {formatCurrency(remaining, loan.currency)}
+          </Text>
+        </Text>
+        {loan.account ? (
+          <Text className="text-muted text-xs mt-1">
+            Impactará la cuenta{' '}
+            <Text className="text-white text-sm">
+              {loan.account.icon ?? '💳'} {loan.account.name}
+            </Text>
+            : {isLent ? 'entrará' : 'saldrá'} el monto del pago.
+          </Text>
+        ) : null}
+      </View>
+
+      <FormInput
+        label="Monto *"
+        value={amount}
+        onChangeText={setAmount}
+        keyboardType="decimal-pad"
+        placeholder="0"
+      />
+
+      <DateInput label="Fecha *" value={date} onChange={setDate} />
+
+      <FormInput
+        label="Notas (opcional)"
+        value={notes}
+        onChangeText={setNotes}
+        placeholder="Ej: Pago primera quincena"
+        multiline
+        numberOfLines={2}
+        style={{ minHeight: 60, textAlignVertical: 'top' }}
+      />
+    </FormDialog>
+  )
+}

--- a/components/savings/DepositModal.tsx
+++ b/components/savings/DepositModal.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useState } from 'react'
+import { View, Text, TouchableOpacity } from 'react-native'
+import { FormDialog } from '@/components/ui/FormDialog'
+import { FormInput } from '@/components/ui/FormInput'
+import { SelectModal } from '@/components/ui/SelectModal'
+import { PrimaryButton } from '@/components/ui/PrimaryButton'
+import { toast } from '@/components/ui/Toast'
+import type { Account, Currency, SavingsGoal } from '@/types/database.types'
+
+interface DepositModalProps {
+  visible: boolean
+  onClose: () => void
+  goal: SavingsGoal
+  accounts: Account[]
+  /** Llamado con (amount, accountId|null) cuando el user confirma. */
+  onSubmit: (input: {
+    amount: number
+    account_id: string | null
+    currency: Currency
+  }) => Promise<void>
+}
+
+/**
+ * Modal de depósito a una meta. Reusa FormDialog (modal full-screen),
+ * con un mini-form: monto + cuenta opcional.
+ *
+ * La currency se infiere de la cuenta seleccionada (o de la meta si no hay
+ * cuenta). El llamante recibe ambos en onSubmit.
+ */
+export function DepositModal({
+  visible,
+  onClose,
+  goal,
+  accounts,
+  onSubmit,
+}: DepositModalProps) {
+  const [amount, setAmount] = useState('')
+  const [accountId, setAccountId] = useState<string>('')
+  const [showAccountPicker, setShowAccountPicker] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+
+  // Resetear al cerrar/abrir
+  useEffect(() => {
+    if (!visible) {
+      setAmount('')
+      setAccountId('')
+      setSubmitting(false)
+    }
+  }, [visible])
+
+  const selectedAccount = accounts.find((a) => a.id === accountId) ?? null
+  const currency: Currency = selectedAccount?.currency ?? goal.currency
+
+  const remaining = Math.max(
+    0,
+    Number(goal.target_amount) - Number(goal.current_amount)
+  )
+
+  async function handleConfirm() {
+    const parsed = parseFloat(amount)
+    if (isNaN(parsed) || parsed <= 0) {
+      toast.error('Ingresa un monto válido')
+      return
+    }
+    setSubmitting(true)
+    try {
+      await onSubmit({
+        amount: parsed,
+        account_id: accountId || null,
+        currency,
+      })
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const accountOptions = [
+    { label: 'Sin cuenta (solo registrar)', value: '' },
+    ...accounts.map((a) => ({
+      label: `${a.icon ?? '💳'} ${a.name} (${a.currency})`,
+      value: a.id,
+    })),
+  ]
+
+  return (
+    <FormDialog
+      visible={visible}
+      onClose={onClose}
+      title={`Depositar en ${goal.name}`}
+      footer={
+        <PrimaryButton
+          onPress={handleConfirm}
+          loading={submitting}
+          disabled={!amount}
+        >
+          Depositar
+        </PrimaryButton>
+      }
+    >
+      <FormInput
+        label="Monto *"
+        value={amount}
+        onChangeText={setAmount}
+        keyboardType="decimal-pad"
+        placeholder="0"
+      />
+
+      <View className="mb-4">
+        <Text className="text-muted text-sm mb-1">Desde cuenta (opcional)</Text>
+        <TouchableOpacity
+          onPress={() => setShowAccountPicker(true)}
+          activeOpacity={0.7}
+          className="bg-surface border border-border rounded-xl px-4 py-3"
+        >
+          <Text className="text-white">
+            {selectedAccount
+              ? `${selectedAccount.icon ?? '💳'} ${selectedAccount.name} (${selectedAccount.currency})`
+              : 'Sin cuenta (solo registrar)'}
+          </Text>
+        </TouchableOpacity>
+        <Text className="text-muted text-xs mt-1">
+          Si eliges una cuenta, el monto se descuenta de su balance.
+        </Text>
+      </View>
+
+      <View className="mt-2 px-4 py-3 rounded-xl bg-surface border border-border">
+        <Text className="text-muted text-xs">
+          Currency:{' '}
+          <Text className="text-white text-sm">{currency}</Text>
+        </Text>
+        <Text className="text-muted text-xs mt-1">
+          Restante para completar:{' '}
+          <Text className="text-white text-sm">
+            {remaining.toLocaleString()} {goal.currency}
+          </Text>
+        </Text>
+      </View>
+
+      <SelectModal
+        visible={showAccountPicker}
+        onClose={() => setShowAccountPicker(false)}
+        title="Cuenta"
+        options={accountOptions}
+        selected={accountId}
+        onSelect={(v) => {
+          setAccountId(v)
+          setShowAccountPicker(false)
+        }}
+      />
+    </FormDialog>
+  )
+}

--- a/components/ui/ProgressBar.tsx
+++ b/components/ui/ProgressBar.tsx
@@ -1,0 +1,88 @@
+import { useEffect } from 'react'
+import { View } from 'react-native'
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  Easing,
+} from 'react-native-reanimated'
+
+interface ProgressBarProps {
+  /** Progreso entre 0 y 1. Valores > 1 se clampan al render (la barra llena), pero `value` puede pasarse sin clamp. */
+  value: number
+  /** Override de color de la barra. Si se omite, se elige por umbral del value. */
+  color?: string
+  /** Altura en px. Default 8. */
+  height?: number
+  /** Duración de la animación de transición. Default 400ms. */
+  duration?: number
+  /** Color del track de fondo. Default `bg-border` (#27272a). */
+  trackColor?: string
+}
+
+/**
+ * Barra de progreso animada (UI thread con reanimated).
+ *
+ * `value` puede exceder 1 (presupuesto sobrepasado). Visualmente se llena al 100%
+ * pero el caller puede usar el valor real para mostrar texto "120%" aparte.
+ *
+ * Color por defecto:
+ *   < 0.7  → verde
+ *   < 1.0  → amarillo
+ *   ≥ 1.0  → rojo (excedido)
+ */
+export function ProgressBar({
+  value,
+  color,
+  height = 8,
+  duration = 400,
+  trackColor = '#27272a',
+}: ProgressBarProps) {
+  const progress = useSharedValue(0)
+
+  useEffect(() => {
+    const clamped = Math.max(0, Math.min(value, 1))
+    progress.value = withTiming(clamped, {
+      duration,
+      easing: Easing.out(Easing.cubic),
+    })
+  }, [value, duration, progress])
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    width: `${progress.value * 100}%`,
+  }))
+
+  const resolvedColor = color ?? defaultColor(value)
+
+  return (
+    <View
+      style={{
+        height,
+        backgroundColor: trackColor,
+        borderRadius: height / 2,
+        overflow: 'hidden',
+      }}
+    >
+      <Animated.View
+        style={[
+          {
+            height: '100%',
+            backgroundColor: resolvedColor,
+            borderRadius: height / 2,
+          },
+          animatedStyle,
+        ]}
+      />
+    </View>
+  )
+}
+
+/**
+ * Mapea `value` (0..∞) a color por umbral. Exportado por si el caller quiere
+ * usar el mismo color en otro lado (badge, texto, etc.).
+ */
+export function defaultColor(value: number): string {
+  if (value >= 1) return '#ef4444' // red-500 — excedido
+  if (value >= 0.7) return '#f59e0b' // amber-500 — atención
+  return '#10b981' // emerald-500 — saludable
+}

--- a/lib/actions/budgets.actions.ts
+++ b/lib/actions/budgets.actions.ts
@@ -1,0 +1,243 @@
+import { insforge } from '@/lib/insforge'
+import {
+  createBudgetSchema,
+  type CreateBudgetInput,
+  type UpdateBudgetInput,
+} from '@/lib/validations/budget'
+import type {
+  Budget,
+  BudgetWithSpent,
+  Category,
+} from '@/types/database.types'
+
+interface Result<T = void> {
+  success: boolean
+  data?: T
+  error?: string
+}
+
+/**
+ * Calcula la ventana activa del presupuesto a partir de `start_date` y `period`.
+ *
+ * NO es mes calendar — es una ventana móvil anclada al día de inicio.
+ * Ejemplo: budget mensual creado el 15-ene → períodos sucesivos:
+ *   15-ene → 14-feb, 15-feb → 14-mar, 15-mar → 14-abr, ...
+ */
+function computeActivePeriod(
+  startDate: string,
+  period: 'monthly' | 'yearly',
+  now = new Date()
+): { periodStart: Date; periodEnd: Date } {
+  const start = new Date(startDate)
+
+  if (period === 'monthly') {
+    let monthsElapsed =
+      (now.getFullYear() - start.getFullYear()) * 12 +
+      (now.getMonth() - start.getMonth())
+    if (now.getDate() < start.getDate()) monthsElapsed--
+
+    if (monthsElapsed < 0) {
+      // Budget arranca en el futuro — no hay período activo aún
+      const periodEnd = new Date(
+        start.getFullYear(),
+        start.getMonth() + 1,
+        start.getDate() - 1,
+        23,
+        59,
+        59
+      )
+      return { periodStart: start, periodEnd }
+    }
+
+    const periodStart = new Date(
+      start.getFullYear(),
+      start.getMonth() + monthsElapsed,
+      start.getDate()
+    )
+    const periodEnd = new Date(
+      start.getFullYear(),
+      start.getMonth() + monthsElapsed + 1,
+      start.getDate() - 1,
+      23,
+      59,
+      59
+    )
+    return { periodStart, periodEnd }
+  }
+
+  // yearly
+  let yearsElapsed = now.getFullYear() - start.getFullYear()
+  const pastAnniversary =
+    now.getMonth() > start.getMonth() ||
+    (now.getMonth() === start.getMonth() && now.getDate() >= start.getDate())
+  if (!pastAnniversary) yearsElapsed--
+
+  if (yearsElapsed < 0) {
+    const periodEnd = new Date(
+      start.getFullYear() + 1,
+      start.getMonth(),
+      start.getDate() - 1,
+      23,
+      59,
+      59
+    )
+    return { periodStart: start, periodEnd }
+  }
+
+  const periodStart = new Date(
+    start.getFullYear() + yearsElapsed,
+    start.getMonth(),
+    start.getDate()
+  )
+  const periodEnd = new Date(
+    start.getFullYear() + yearsElapsed + 1,
+    start.getMonth(),
+    start.getDate() - 1,
+    23,
+    59,
+    59
+  )
+  return { periodStart, periodEnd }
+}
+
+/**
+ * Lista budgets del user con `spent` calculado para el período activo.
+ *
+ * Estrategia: 1 query a budgets + 1 query a todas las expense transactions
+ * del user. Luego filtramos en memoria. Para usuarios con miles de transacciones
+ * conviene migrar a un RPC server-side, pero por ahora es aceptable.
+ */
+export async function getBudgets(
+  userId: string
+): Promise<Result<BudgetWithSpent[]>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const { data: budgets, error: budgetError } = await insforge.database
+      .from('budgets')
+      .select('*, category:categories(*)')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+
+    if (budgetError) throw budgetError
+    if (!budgets || budgets.length === 0) {
+      return { success: true, data: [] }
+    }
+
+    const { data: transactions, error: transError } = await insforge.database
+      .from('transactions')
+      .select('category_id, amount, date, type')
+      .eq('user_id', userId)
+      .eq('type', 'expense')
+
+    if (transError) throw transError
+
+    type BudgetRow = Budget & { category: Category }
+    type TxRow = { category_id: string | null; amount: number; date: string; type: string }
+    const txs = (transactions ?? []) as TxRow[]
+
+    const result: BudgetWithSpent[] = (budgets as BudgetRow[]).map((budget) => {
+      const { periodStart, periodEnd } = computeActivePeriod(
+        budget.start_date,
+        budget.period
+      )
+
+      const spent = txs
+        .filter((t) => {
+          if (t.category_id !== budget.category_id) return false
+          const d = new Date(t.date)
+          return d >= periodStart && d <= periodEnd
+        })
+        .reduce((sum, t) => sum + Number(t.amount || 0), 0)
+
+      return {
+        ...budget,
+        spent,
+        periodStart: periodStart.toISOString().slice(0, 10),
+        periodEnd: periodEnd.toISOString().slice(0, 10),
+      }
+    })
+
+    return { success: true, data: result }
+  } catch {
+    return { success: false, error: 'Error al cargar presupuestos' }
+  }
+}
+
+export async function getBudgetById(
+  id: string,
+  userId: string
+): Promise<Result<Budget>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const { data, error } = await insforge.database
+      .from('budgets')
+      .select('*')
+      .eq('id', id)
+      .eq('user_id', userId)
+      .maybeSingle()
+    if (error) throw error
+    if (!data) return { success: false, error: 'Presupuesto no encontrado' }
+    return { success: true, data: data as Budget }
+  } catch {
+    return { success: false, error: 'Error al cargar presupuesto' }
+  }
+}
+
+export async function createBudget(
+  userId: string,
+  input: CreateBudgetInput
+): Promise<Result<Budget>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const validated = createBudgetSchema.parse(input)
+    const { data, error } = await insforge.database
+      .from('budgets')
+      .insert([{ ...validated, user_id: userId }])
+      .select()
+      .single()
+    if (error) throw error
+    return { success: true, data: data as Budget }
+  } catch {
+    return { success: false, error: 'Error al crear presupuesto' }
+  }
+}
+
+export async function updateBudget(
+  id: string,
+  userId: string,
+  input: UpdateBudgetInput
+): Promise<Result<Budget>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const validated = createBudgetSchema.partial().parse(input)
+    const { data, error } = await insforge.database
+      .from('budgets')
+      .update(validated)
+      .eq('id', id)
+      .eq('user_id', userId)
+      .select()
+      .single()
+    if (error) throw error
+    return { success: true, data: data as Budget }
+  } catch {
+    return { success: false, error: 'Error al actualizar presupuesto' }
+  }
+}
+
+export async function deleteBudget(
+  id: string,
+  userId: string
+): Promise<Result> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const { error } = await insforge.database
+      .from('budgets')
+      .delete()
+      .eq('id', id)
+      .eq('user_id', userId)
+    if (error) throw error
+    return { success: true }
+  } catch {
+    return { success: false, error: 'Error al eliminar presupuesto' }
+  }
+}

--- a/lib/actions/loans.actions.ts
+++ b/lib/actions/loans.actions.ts
@@ -1,0 +1,432 @@
+import { insforge } from '@/lib/insforge'
+import { applyBalanceDelta } from '@/lib/utils/balance-updater'
+import {
+  createLoanSchema,
+  updateLoanSchema,
+  createLoanPaymentSchema,
+  type CreateLoanInput,
+  type UpdateLoanInput,
+  type CreateLoanPaymentInput,
+} from '@/lib/validations/loan'
+import type {
+  Loan,
+  LoanPayment,
+  LoanType,
+  LoanWithAccount,
+} from '@/types/database.types'
+
+interface Result<T = void> {
+  success: boolean
+  data?: T
+  error?: string
+}
+
+/**
+ * Dirección del delta de balance según el tipo de préstamo y la operación.
+ *
+ *                | create | payment | reverse
+ *   -------------+--------+---------+---------
+ *   lent         |  -     |   +     |   +     (presté → me devuelven → reverso: vuelve el "salió")
+ *   borrowed     |  +     |   -     |   -     (me prestaron → devuelvo → reverso: vuelve el "entró")
+ *
+ * "reverse" se usa al editar/borrar para revertir el efecto original del create.
+ */
+type BalanceOp = 'create' | 'payment' | 'reverse'
+function balanceDirection(
+  type: LoanType,
+  op: BalanceOp
+): 'add' | 'subtract' {
+  if (type === 'lent') {
+    return op === 'create' ? 'subtract' : 'add'
+  }
+  // borrowed
+  return op === 'create' ? 'add' : 'subtract'
+}
+
+export async function getLoans(
+  userId: string
+): Promise<Result<LoanWithAccount[]>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const { data, error } = await insforge.database
+      .from('loans')
+      .select('*, account:accounts(id, name, currency, icon)')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+    if (error) throw error
+    return { success: true, data: (data ?? []) as LoanWithAccount[] }
+  } catch {
+    return { success: false, error: 'Error al cargar préstamos' }
+  }
+}
+
+export async function getLoanById(
+  id: string,
+  userId: string
+): Promise<Result<LoanWithAccount>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const { data, error } = await insforge.database
+      .from('loans')
+      .select('*, account:accounts(id, name, currency, icon)')
+      .eq('id', id)
+      .eq('user_id', userId)
+      .maybeSingle()
+    if (error) throw error
+    if (!data) return { success: false, error: 'Préstamo no encontrado' }
+    return { success: true, data: data as LoanWithAccount }
+  } catch {
+    return { success: false, error: 'Error al cargar préstamo' }
+  }
+}
+
+export async function getLoanPayments(
+  loanId: string,
+  userId: string
+): Promise<Result<LoanPayment[]>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const { data, error } = await insforge.database
+      .from('loan_payments')
+      .select('*')
+      .eq('loan_id', loanId)
+      .eq('user_id', userId)
+      .order('date', { ascending: false })
+    if (error) throw error
+    return { success: true, data: (data ?? []) as LoanPayment[] }
+  } catch {
+    return { success: false, error: 'Error al cargar pagos' }
+  }
+}
+
+export async function createLoan(
+  userId: string,
+  input: CreateLoanInput
+): Promise<Result<Loan>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const validated = createLoanSchema.parse(input)
+    const { data, error } = await insforge.database
+      .from('loans')
+      .insert([{ ...validated, user_id: userId }])
+      .select()
+      .single()
+    if (error) throw error
+
+    if (validated.account_id) {
+      await applyBalanceDelta(
+        validated.account_id,
+        validated.amount,
+        validated.currency,
+        balanceDirection(validated.type, 'create')
+      )
+    }
+    return { success: true, data: data as Loan }
+  } catch {
+    return { success: false, error: 'Error al crear préstamo' }
+  }
+}
+
+export async function updateLoan(
+  id: string,
+  userId: string,
+  input: UpdateLoanInput
+): Promise<Result<Loan>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const validated = updateLoanSchema.parse(input)
+
+    const { data: old, error: fetchError } = await insforge.database
+      .from('loans')
+      .select('*')
+      .eq('id', id)
+      .eq('user_id', userId)
+      .single()
+    if (fetchError) throw fetchError
+    if (!old) return { success: false, error: 'Préstamo no encontrado' }
+    if (old.status === 'settled') {
+      return {
+        success: false,
+        error: 'No se puede editar un préstamo saldado',
+      }
+    }
+
+    // Revertir balance del estado anterior
+    if (old.account_id) {
+      await applyBalanceDelta(
+        old.account_id,
+        Number(old.amount),
+        old.currency,
+        balanceDirection(old.type as LoanType, 'reverse')
+      )
+    }
+
+    // Aplicar balance del nuevo estado
+    const next = {
+      person_name: validated.person_name ?? old.person_name,
+      amount: validated.amount ?? Number(old.amount),
+      currency: validated.currency ?? old.currency,
+      account_id: validated.account_id ?? old.account_id,
+      type: validated.type ?? (old.type as LoanType),
+      notes: validated.notes ?? old.notes,
+    }
+    if (next.account_id) {
+      await applyBalanceDelta(
+        next.account_id,
+        next.amount,
+        next.currency,
+        balanceDirection(next.type, 'create')
+      )
+    }
+
+    const { data, error } = await insforge.database
+      .from('loans')
+      .update({ ...next, updated_at: new Date().toISOString() })
+      .eq('id', id)
+      .eq('user_id', userId)
+      .select()
+      .single()
+    if (error) throw error
+    return { success: true, data: data as Loan }
+  } catch {
+    return { success: false, error: 'Error al actualizar préstamo' }
+  }
+}
+
+export async function deleteLoan(
+  id: string,
+  userId: string
+): Promise<Result> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const { data: loan, error: fetchError } = await insforge.database
+      .from('loans')
+      .select('*')
+      .eq('id', id)
+      .eq('user_id', userId)
+      .single()
+    if (fetchError) throw fetchError
+    if (!loan) return { success: false, error: 'Préstamo no encontrado' }
+
+    // Solo revertir si está activo (settled ya cuadró todos los pagos)
+    if (loan.status === 'active' && loan.account_id) {
+      await applyBalanceDelta(
+        loan.account_id,
+        Number(loan.amount),
+        loan.currency,
+        balanceDirection(loan.type as LoanType, 'reverse')
+      )
+    }
+
+    const { error } = await insforge.database
+      .from('loans')
+      .delete()
+      .eq('id', id)
+      .eq('user_id', userId)
+    if (error) throw error
+    return { success: true }
+  } catch {
+    return { success: false, error: 'Error al eliminar préstamo' }
+  }
+}
+
+/**
+ * Registra un pago contra un préstamo. Multi-step similar a addFundsToGoal:
+ *
+ *   1. Fetch loan + verifica que no esté saldado
+ *   2. Impactar balance (lent → suma, borrowed → resta)
+ *   3. Insert payment row
+ *   4. Update loan.paid_amount; si paid >= amount → status='settled' + settled_at
+ *
+ * Ver [[Acciones multi-step sin transacciones]] para garantías.
+ */
+export async function addLoanPayment(
+  loanId: string,
+  userId: string,
+  input: CreateLoanPaymentInput
+): Promise<Result<{ loan: Loan; settled: boolean }>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const validated = createLoanPaymentSchema.parse(input)
+
+    const { data: loan, error: fetchError } = await insforge.database
+      .from('loans')
+      .select('*')
+      .eq('id', loanId)
+      .eq('user_id', userId)
+      .single()
+    if (fetchError) throw fetchError
+    if (!loan) return { success: false, error: 'Préstamo no encontrado' }
+    if (loan.status === 'settled') {
+      return { success: false, error: 'El préstamo ya está saldado' }
+    }
+
+    // Impactar balance
+    if (loan.account_id) {
+      await applyBalanceDelta(
+        loan.account_id,
+        validated.amount,
+        validated.currency,
+        balanceDirection(loan.type as LoanType, 'payment')
+      )
+    }
+
+    // Insert payment
+    await insforge.database.from('loan_payments').insert([
+      {
+        loan_id: loanId,
+        user_id: userId,
+        amount: validated.amount,
+        currency: validated.currency,
+        date: validated.date,
+        notes: validated.notes ?? null,
+      },
+    ])
+
+    // Update loan totals
+    const currentPaid = Number(loan.paid_amount ?? 0)
+    const loanAmount = Number(loan.amount)
+    const newPaid = currentPaid + validated.amount
+    const isSettled = newPaid >= loanAmount
+
+    const { data: updated, error: updateError } = await insforge.database
+      .from('loans')
+      .update({
+        paid_amount: isSettled ? loanAmount : newPaid,
+        status: isSettled ? 'settled' : 'active',
+        ...(isSettled ? { settled_at: new Date().toISOString() } : {}),
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', loanId)
+      .eq('user_id', userId)
+      .select()
+      .single()
+    if (updateError) throw updateError
+
+    return { success: true, data: { loan: updated as Loan, settled: isSettled } }
+  } catch {
+    return { success: false, error: 'Error al registrar pago' }
+  }
+}
+
+export async function deleteLoanPayment(
+  paymentId: string,
+  userId: string
+): Promise<Result> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    // Fetch payment + loan join
+    const { data: payment, error: fetchError } = await insforge.database
+      .from('loan_payments')
+      .select('*, loan:loans(*)')
+      .eq('id', paymentId)
+      .eq('user_id', userId)
+      .single()
+    if (fetchError) throw fetchError
+    if (!payment) return { success: false, error: 'Pago no encontrado' }
+
+    const loan = (payment as { loan: Loan }).loan
+    if (!loan) return { success: false, error: 'Préstamo no encontrado' }
+
+    // Revertir balance del payment
+    if (loan.account_id) {
+      // El opuesto de 'payment' es 'create' para fines de signo
+      await applyBalanceDelta(
+        loan.account_id,
+        Number(payment.amount),
+        payment.currency,
+        balanceDirection(loan.type, 'create')
+      )
+    }
+
+    // Reducir paid_amount, reabrir si estaba settled
+    const newPaid = Math.max(
+      0,
+      Number(loan.paid_amount) - Number(payment.amount)
+    )
+    await insforge.database
+      .from('loans')
+      .update({
+        paid_amount: newPaid,
+        status: 'active',
+        settled_at: null,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', loan.id)
+      .eq('user_id', userId)
+
+    const { error } = await insforge.database
+      .from('loan_payments')
+      .delete()
+      .eq('id', paymentId)
+      .eq('user_id', userId)
+    if (error) throw error
+    return { success: true }
+  } catch {
+    return { success: false, error: 'Error al eliminar pago' }
+  }
+}
+
+/**
+ * Liquida el préstamo: crea un pago final por el saldo restante e impacta
+ * el balance. Si ya estaba saldado, retorna error.
+ */
+export async function settleLoan(
+  loanId: string,
+  userId: string
+): Promise<Result> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const { data: loan, error: fetchError } = await insforge.database
+      .from('loans')
+      .select('*')
+      .eq('id', loanId)
+      .eq('user_id', userId)
+      .single()
+    if (fetchError) throw fetchError
+    if (!loan) return { success: false, error: 'Préstamo no encontrado' }
+    if (loan.status === 'settled') {
+      return { success: false, error: 'Ya está saldado' }
+    }
+
+    const remaining = Number(loan.amount) - Number(loan.paid_amount ?? 0)
+
+    if (loan.account_id && remaining > 0) {
+      await applyBalanceDelta(
+        loan.account_id,
+        remaining,
+        loan.currency,
+        balanceDirection(loan.type as LoanType, 'payment')
+      )
+    }
+
+    if (remaining > 0) {
+      await insforge.database.from('loan_payments').insert([
+        {
+          loan_id: loanId,
+          user_id: userId,
+          amount: remaining,
+          currency: loan.currency,
+          date: new Date().toISOString().slice(0, 10),
+          notes: 'Saldo final',
+        },
+      ])
+    }
+
+    const { error } = await insforge.database
+      .from('loans')
+      .update({
+        paid_amount: Number(loan.amount),
+        status: 'settled',
+        settled_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', loanId)
+      .eq('user_id', userId)
+    if (error) throw error
+
+    return { success: true }
+  } catch {
+    return { success: false, error: 'Error al saldar préstamo' }
+  }
+}

--- a/lib/actions/savings.actions.ts
+++ b/lib/actions/savings.actions.ts
@@ -1,0 +1,198 @@
+import { insforge } from '@/lib/insforge'
+import { applyBalanceDelta } from '@/lib/utils/balance-updater'
+import {
+  createSavingsGoalSchema,
+  updateSavingsGoalSchema,
+  addFundsSchema,
+  type CreateSavingsGoalInput,
+  type UpdateSavingsGoalInput,
+  type AddFundsInput,
+} from '@/lib/validations/savings'
+import type { Currency, SavingsGoal } from '@/types/database.types'
+
+interface Result<T = void> {
+  success: boolean
+  data?: T
+  error?: string
+}
+
+export async function getSavingsGoals(
+  userId: string
+): Promise<Result<SavingsGoal[]>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const { data, error } = await insforge.database
+      .from('savings_goals')
+      .select('*')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+    if (error) throw error
+    return { success: true, data: (data ?? []) as SavingsGoal[] }
+  } catch {
+    return { success: false, error: 'Error al cargar metas' }
+  }
+}
+
+export async function getSavingsGoalById(
+  id: string,
+  userId: string
+): Promise<Result<SavingsGoal>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const { data, error } = await insforge.database
+      .from('savings_goals')
+      .select('*')
+      .eq('id', id)
+      .eq('user_id', userId)
+      .maybeSingle()
+    if (error) throw error
+    if (!data) return { success: false, error: 'Meta no encontrada' }
+    return { success: true, data: data as SavingsGoal }
+  } catch {
+    return { success: false, error: 'Error al cargar meta' }
+  }
+}
+
+export async function createSavingsGoal(
+  userId: string,
+  input: CreateSavingsGoalInput
+): Promise<Result<SavingsGoal>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const validated = createSavingsGoalSchema.parse(input)
+    const { data, error } = await insforge.database
+      .from('savings_goals')
+      .insert([{ ...validated, user_id: userId }])
+      .select()
+      .single()
+    if (error) throw error
+    return { success: true, data: data as SavingsGoal }
+  } catch {
+    return { success: false, error: 'Error al crear meta' }
+  }
+}
+
+export async function updateSavingsGoal(
+  id: string,
+  userId: string,
+  input: UpdateSavingsGoalInput
+): Promise<Result<SavingsGoal>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const validated = updateSavingsGoalSchema.parse(input)
+    const { data, error } = await insforge.database
+      .from('savings_goals')
+      .update(validated)
+      .eq('id', id)
+      .eq('user_id', userId)
+      .select()
+      .single()
+    if (error) throw error
+    return { success: true, data: data as SavingsGoal }
+  } catch {
+    return { success: false, error: 'Error al actualizar meta' }
+  }
+}
+
+export async function deleteSavingsGoal(
+  id: string,
+  userId: string
+): Promise<Result> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const { error } = await insforge.database
+      .from('savings_goals')
+      .delete()
+      .eq('id', id)
+      .eq('user_id', userId)
+    if (error) throw error
+    return { success: true }
+  } catch {
+    return { success: false, error: 'Error al eliminar meta' }
+  }
+}
+
+/**
+ * Deposita fondos contra una meta. Es una acción multi-step:
+ *
+ *   1. Lee el goal (verifica ownership)
+ *   2. Calcula newAmount = min(current + amount, target) — clamp
+ *   3. Actualiza goal con newAmount + is_completed si llegó a target
+ *   4. Inserta row en savings_contributions (historial)
+ *   5. Si vino account_id → descuenta de la cuenta vía applyBalanceDelta
+ *
+ * NO es transaccional (InsForge no expone transacciones). Si algún paso
+ * falla a mitad de camino, el estado queda inconsistente. Por ahora
+ * cubrimos el caso común (todo OK) y dejamos los edge cases para una
+ * iteración futura con RPC server-side.
+ *
+ * Si el goal ya está completo, retorna error sin tocar nada.
+ */
+export async function addFundsToGoal(
+  id: string,
+  userId: string,
+  input: AddFundsInput & { account_id?: string | null; currency?: Currency }
+): Promise<Result<SavingsGoal>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const validated = addFundsSchema.parse({ amount: input.amount })
+
+    // 1. Fetch goal
+    const { data: goal, error: fetchError } = await insforge.database
+      .from('savings_goals')
+      .select('*')
+      .eq('id', id)
+      .eq('user_id', userId)
+      .single()
+    if (fetchError) throw fetchError
+    if (!goal) return { success: false, error: 'Meta no encontrada' }
+    if (goal.is_completed) {
+      return { success: false, error: 'Esta meta ya está completada' }
+    }
+
+    // 2-3. Clamp + update
+    const target = Number(goal.target_amount)
+    const current = Number(goal.current_amount)
+    const newAmount = Math.min(current + validated.amount, target)
+    const isCompleted = newAmount >= target
+
+    const { data: updated, error: updateError } = await insforge.database
+      .from('savings_goals')
+      .update({ current_amount: newAmount, is_completed: isCompleted })
+      .eq('id', id)
+      .eq('user_id', userId)
+      .select()
+      .single()
+    if (updateError) throw updateError
+
+    // 4. Insert contribution
+    const contributionCurrency = input.currency ?? goal.currency
+    await insforge.database.from('savings_contributions').insert([
+      {
+        goal_id: id,
+        user_id: userId,
+        amount: validated.amount,
+        currency: contributionCurrency,
+        account_id: input.account_id ?? null,
+      },
+    ])
+
+    // 5. Descontar de cuenta si aplica
+    if (input.account_id) {
+      const errMsg = await applyBalanceDelta(
+        input.account_id,
+        validated.amount,
+        contributionCurrency,
+        'subtract'
+      )
+      if (errMsg) {
+        // Log pero no falla la operación — el goal ya se actualizó.
+        // En una iteración futura: rollback o cola de reintento.
+      }
+    }
+
+    return { success: true, data: updated as SavingsGoal }
+  } catch {
+    return { success: false, error: 'Error al depositar fondos' }
+  }
+}

--- a/types/database.types.ts
+++ b/types/database.types.ts
@@ -141,6 +141,16 @@ export interface SavingsGoal {
   created_at: string
 }
 
+export interface SavingsContribution {
+  id: string
+  goal_id: string
+  user_id: string
+  amount: number
+  currency: Currency
+  account_id: string | null
+  created_at: string
+}
+
 export interface Tag {
   id: string
   user_id: string

--- a/types/database.types.ts
+++ b/types/database.types.ts
@@ -215,6 +215,12 @@ export interface BudgetWithCategory extends Budget {
   category: Category
 }
 
+export interface BudgetWithSpent extends BudgetWithCategory {
+  spent: number
+  periodStart: string
+  periodEnd: string
+}
+
 export interface RecurringTransactionWithCategory extends RecurringTransaction {
   category: Category
 }


### PR DESCRIPTION
Cierre de **FASE 3** del plan de migración. Tres features nuevas que añaden la capa de planificación financiera a la app.

## Tareas incluidas

- **T-3.1** — Presupuestos CRUD con cálculo de \`spent\` por período activo (#71)
- **T-3.2** — Metas de Ahorro CRUD + depósitos multi-step (#73)
- **T-3.3** — Préstamos CRUD + pagos con \`balanceDirection\` helper (#75)

## Cambios visibles para el usuario

### Presupuestos
- Define presupuestos mensuales o anuales por categoría.
- ProgressBar animada con color por umbral (verde < 70%, amarillo 70-99%, rojo ≥ 100%).
- Período activo es una **ventana móvil** anclada a \`start_date\` (no mes calendar).
- Badge "Excedido por X" cuando se pasa el límite.

### Metas de Ahorro
- Crea metas con nombre, monto objetivo, currency y fecha límite opcional.
- Card con ProgressBar verde + deadline relativa ("Faltan 30 días" / "Vencida hace 5 días").
- Botón **Depositar fondos** abre modal con monto + cuenta opcional. Si eliges cuenta, se descuenta de su balance.
- Auto-completa al alcanzar el objetivo con toast "¡Meta completada! 🎉".
- Clamp al target — no se permite pasarse del objetivo.

### Préstamos
- Tipo lent ("le presté") o borrowed ("me prestó") con tracking de pagos parciales.
- Lista segmentada con \`SectionList\`: **Por cobrar** / **Por pagar** / **Saldados**.
- Detalle con bloque de progreso + historial de pagos eliminables individualmente.
- Botones **Registrar pago/cobro** y **Saldar completo** (crea pago final por el saldo restante).
- Eliminar un pago **reabre el loan** si estaba saldado.

## Componentes y patrones nuevos

- **\`<ProgressBar />\`** (T-3.1) — \`components/ui/ProgressBar.tsx\` con \`reanimated\` (animación de \`width\` con \`withTiming + Easing.out(cubic)\`). Helper \`defaultColor()\` exportado para badges/texto.
- **\`<DepositModal />\`** (T-3.2) y **\`<PaymentModal />\`** (T-3.3) — primer patrón "modal de acción rápida" del proyecto, reusando \`FormDialog\` debajo.
- **\`balanceDirection(type, op)\`** (T-3.3) — helper puro \`(LoanType, BalanceOp) → 'add' | 'subtract'\` que centraliza la dirección del delta en 4 call sites del action.
- **Computación de período activo** (T-3.1) — ventana móvil mensual/anual anclada a fecha de inicio. Lógica documentada y aislada en \`computeActivePeriod()\`.

## Verificación

- [x] \`npx tsc --noEmit\` limpio en cada PR de tarea
- [x] Smoke test de los flujos críticos en iOS simulator:
  - [x] Crear presupuesto y ver spent reflejar transactions reales
  - [x] Crear meta, depositar con/sin cuenta, completar y verificar bloqueo
  - [x] Crear loan lent y borrowed, verificar que el balance se mueve en la dirección correcta
  - [x] Registrar pagos parciales, saldar completo, eliminar pago para reabrir
- [x] Cada PR mergeado con **merge commit** (no squash), historia preservada

## Cambios técnicos

\`\`\`
 app/(dashboard)/budgets/{_layout,index,[id]}.tsx     | 488 +++
 app/(dashboard)/savings/{_layout,index,[id]}.tsx     | 506 +++
 app/(dashboard)/loans/{_layout,index,[id]}.tsx       | 723 +++
 app/(dashboard)/more.tsx                              |  15 +
 components/{savings,loans}/{Deposit,Payment}Modal.tsx | 285 +++
 components/ui/ProgressBar.tsx                         |  88 +
 lib/actions/{budgets,savings,loans}.actions.ts        | 873 +++
 types/database.types.ts                               |  16 +
\`\`\`

🛑 **Stop point:** según el workflow (\`rules/github-flow.md\`), desarrollo detenido hasta aprobación manual de este PR. Una vez mergeado a \`main\` (con merge commit, no squash), sincronizar \`develop ← main\` y arrancar **FASE 4 — Dashboard y reportes**.

Closes #69