### PR TITLE
feat(charts): setup victory-native v41 + Skia + wrappers (T-4.1)

### DIFF
--- a/app/(dashboard)/_layout.tsx
+++ b/app/(dashboard)/_layout.tsx
@@ -65,6 +65,17 @@ export default function DashboardLayout() {
           ),
         }}
       />
+
+      {/*
+        Hubs accesibles desde la pantalla "Más" — NO se exponen como tabs
+        directos para mantener el bottom bar limpio. expo-router los
+        descubre automáticamente al tener _layout.tsx; href: null los
+        oculta del tab bar pero quedan navegables con router.push('/xxx').
+      */}
+      <Tabs.Screen name="categories" options={{ href: null }} />
+      <Tabs.Screen name="budgets" options={{ href: null }} />
+      <Tabs.Screen name="savings" options={{ href: null }} />
+      <Tabs.Screen name="loans" options={{ href: null }} />
     </Tabs>
   )
 }

--- a/app/(dashboard)/index.tsx
+++ b/app/(dashboard)/index.tsx
@@ -1,13 +1,36 @@
 // app/(dashboard)/index.tsx
-import { View, Text } from 'react-native'
+//
+// T-4.1 placeholder: muestra los tres charts con mock data para verificar
+// que victory-native + Skia están configurados correctamente. T-4.2 va a
+// reemplazar esto con datos reales y summary cards.
+import { ScrollView, View, Text } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import { useAuth } from '@/context/AuthContext'
+import { DemoAccumulatedBalanceChart } from '@/components/charts/AccumulatedBalanceChart'
+import { DemoExpensesByCategoryChart } from '@/components/charts/ExpensesByCategoryChart'
+import { DemoMonthlyComparisonChart } from '@/components/charts/MonthlyComparisonChart'
 
 export default function DashboardScreen() {
   const { user } = useAuth()
   return (
-    <View className="flex-1 bg-bg items-center justify-center">
-      <Text className="text-white text-xl font-bold">Dashboard</Text>
-      <Text className="text-muted mt-2">Hola, {user?.name ?? user?.email}</Text>
-    </View>
+    <SafeAreaView edges={['top']} className="flex-1 bg-bg">
+      <View className="px-4 py-3 border-b border-border">
+        <Text className="text-white text-xl font-bold">Dashboard</Text>
+        <Text className="text-muted text-xs mt-0.5">
+          Hola, {user?.name ?? user?.email}
+        </Text>
+      </View>
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={{ padding: 16, gap: 16 }}
+      >
+        <Text className="text-amber-400 text-xs">
+          T-4.1: preview con mock data. T-4.2 conecta datos reales.
+        </Text>
+        <DemoAccumulatedBalanceChart />
+        <DemoExpensesByCategoryChart />
+        <DemoMonthlyComparisonChart />
+      </ScrollView>
+    </SafeAreaView>
   )
 }

--- a/components/charts/AccumulatedBalanceChart.tsx
+++ b/components/charts/AccumulatedBalanceChart.tsx
@@ -1,0 +1,159 @@
+import { View, Text } from 'react-native'
+import { CartesianChart, Line, Area } from 'victory-native'
+import { LinearGradient, vec } from '@shopify/react-native-skia'
+import type { TimeSeriesPoint } from './types'
+
+interface Props {
+  data: TimeSeriesPoint[]
+  /** Color principal — default primary. */
+  color?: string
+  /** Altura en px. Default 220. */
+  height?: number
+  /** Título opcional renderizado encima del chart. */
+  title?: string
+  /** Subtítulo opcional. */
+  subtitle?: string
+}
+
+/**
+ * Line + área degradada de un valor acumulado sobre el tiempo.
+ *
+ * Pensado para mostrar balance corrido día a día. El caller normaliza los
+ * datos (fecha YYYY-MM-DD + valor en la currency objetivo); este wrapper
+ * solo dibuja.
+ *
+ * El chart funciona sin font cargada — los ejes no muestran labels para
+ * evitar dependencias con expo-font. La currency y los rangos se muestran
+ * arriba del chart en una row de leyendas mínimas.
+ */
+export function AccumulatedBalanceChart({
+  data,
+  color = '#4F46E5',
+  height = 220,
+  title,
+  subtitle,
+}: Props) {
+  if (data.length === 0) {
+    return (
+      <ChartContainer title={title} subtitle={subtitle} height={height}>
+        <View className="flex-1 items-center justify-center">
+          <Text className="text-muted text-sm">Sin datos para mostrar</Text>
+        </View>
+      </ChartContainer>
+    )
+  }
+
+  // Transformamos las fechas a índices numéricos — victory-native v41
+  // necesita una xKey numérica o categórica simple. La fecha la usamos
+  // como ID y graficamos contra el índice.
+  const chartData = data.map((p, i) => ({
+    i,
+    value: p.value,
+    date: p.date,
+  }))
+
+  const first = data[0].value
+  const last = data[data.length - 1].value
+  const delta = last - first
+  const positive = delta >= 0
+
+  return (
+    <ChartContainer title={title} subtitle={subtitle} height={height}>
+      {/* Header con delta */}
+      <View className="flex-row items-baseline mb-2 px-1">
+        <Text className="text-white text-xl font-bold">
+          {Math.round(last).toLocaleString()}
+        </Text>
+        <Text
+          className={
+            positive ? 'text-green-400 text-xs ml-2' : 'text-red-400 text-xs ml-2'
+          }
+        >
+          {positive ? '↑' : '↓'} {Math.abs(Math.round(delta)).toLocaleString()}
+        </Text>
+      </View>
+
+      <View style={{ flex: 1 }}>
+        <CartesianChart
+          data={chartData}
+          xKey="i"
+          yKeys={['value']}
+          domainPadding={{ top: 12, bottom: 12, left: 8, right: 8 }}
+        >
+          {({ points, chartBounds }) => (
+            <>
+              <Area
+                points={points.value}
+                y0={chartBounds.bottom}
+                animate={{ type: 'timing', duration: 600 }}
+              >
+                <LinearGradient
+                  start={vec(0, 0)}
+                  end={vec(0, chartBounds.bottom)}
+                  colors={[`${color}66`, `${color}00`]}
+                />
+              </Area>
+              <Line
+                points={points.value}
+                color={color}
+                strokeWidth={2.5}
+                animate={{ type: 'timing', duration: 600 }}
+              />
+            </>
+          )}
+        </CartesianChart>
+      </View>
+    </ChartContainer>
+  )
+}
+
+/** Container con title/subtitle reusable (también lo usan los otros charts). */
+export function ChartContainer({
+  title,
+  subtitle,
+  height,
+  children,
+}: {
+  title?: string
+  subtitle?: string
+  height: number
+  children: React.ReactNode
+}) {
+  return (
+    <View className="bg-surface border border-border rounded-2xl p-4">
+      {title ? (
+        <Text className="text-white text-base font-semibold">{title}</Text>
+      ) : null}
+      {subtitle ? (
+        <Text className="text-muted text-xs mt-0.5 mb-2">{subtitle}</Text>
+      ) : (
+        title ? <View className="mb-2" /> : null
+      )}
+      <View style={{ height }}>{children}</View>
+    </View>
+  )
+}
+
+/** Mock data para verificación visual en T-4.1. Se borra en T-4.2. */
+export function DemoAccumulatedBalanceChart() {
+  const mock: TimeSeriesPoint[] = [
+    { date: '2026-04-01', value: 1_200_000 },
+    { date: '2026-04-05', value: 1_350_000 },
+    { date: '2026-04-10', value: 1_300_000 },
+    { date: '2026-04-15', value: 1_550_000 },
+    { date: '2026-04-20', value: 1_700_000 },
+    { date: '2026-04-25', value: 1_650_000 },
+    { date: '2026-04-30', value: 1_900_000 },
+    { date: '2026-05-05', value: 1_850_000 },
+    { date: '2026-05-10', value: 2_100_000 },
+    { date: '2026-05-15', value: 2_250_000 },
+    { date: '2026-05-20', value: 2_400_000 },
+  ]
+  return (
+    <AccumulatedBalanceChart
+      data={mock}
+      title="Balance acumulado"
+      subtitle="Últimos 30 días · COP"
+    />
+  )
+}

--- a/components/charts/ExpensesByCategoryChart.tsx
+++ b/components/charts/ExpensesByCategoryChart.tsx
@@ -1,0 +1,100 @@
+import { View, Text } from 'react-native'
+import { ProgressBar } from '@/components/ui/ProgressBar'
+import { ChartContainer } from './AccumulatedBalanceChart'
+import { formatCurrency } from '@/lib/utils/currency'
+import type { Currency } from '@/types/database.types'
+import type { CategoryAggregate } from './types'
+
+interface Props {
+  data: CategoryAggregate[]
+  currency: Currency
+  title?: string
+  subtitle?: string
+  /** Máximo de categorías a mostrar. Default 8. */
+  limit?: number
+}
+
+/**
+ * "Bar list" de gastos por categoría — barras horizontales con View+flex
+ * en lugar de un chart real. Para mobile esto se ve mucho mejor que un
+ * bar chart vertical con labels truncados, y no requiere Skia ni font
+ * loading.
+ *
+ * Se asume que `data` viene pre-agregada y convertida a la currency objetivo
+ * por el caller (en T-4.2 se hace en el useEffect del dashboard).
+ *
+ * Cada row reusa <ProgressBar /> pasando el color custom de la categoría.
+ */
+export function ExpensesByCategoryChart({
+  data,
+  currency,
+  title,
+  subtitle,
+  limit = 8,
+}: Props) {
+  const total = data.reduce((s, c) => s + c.value, 0)
+  const limited = data.slice(0, limit)
+  const heightEstimate = Math.max(120, limited.length * 56 + 20)
+
+  if (limited.length === 0) {
+    return (
+      <ChartContainer title={title} subtitle={subtitle} height={120}>
+        <View className="flex-1 items-center justify-center">
+          <Text className="text-muted text-sm">Sin datos para mostrar</Text>
+        </View>
+      </ChartContainer>
+    )
+  }
+
+  return (
+    <ChartContainer title={title} subtitle={subtitle} height={heightEstimate}>
+      <View className="gap-3">
+        {limited.map((cat) => {
+          const ratio = total > 0 ? cat.value / total : 0
+          const color = cat.color ?? '#4F46E5'
+          return (
+            <View key={cat.name}>
+              <View className="flex-row items-center mb-1">
+                <Text className="text-lg mr-2">{cat.icon ?? '📂'}</Text>
+                <Text className="text-white text-sm flex-1" numberOfLines={1}>
+                  {cat.name}
+                </Text>
+                <Text className="text-white text-sm font-semibold">
+                  {formatCurrency(cat.value, currency)}
+                </Text>
+              </View>
+              <View className="flex-row items-center gap-2">
+                <View style={{ flex: 1 }}>
+                  <ProgressBar value={ratio} color={color} height={6} />
+                </View>
+                <Text className="text-muted text-xs w-10 text-right">
+                  {Math.round(ratio * 100)}%
+                </Text>
+              </View>
+            </View>
+          )
+        })}
+      </View>
+    </ChartContainer>
+  )
+}
+
+/** Mock data para verificación visual. Se borra en T-4.2. */
+export function DemoExpensesByCategoryChart() {
+  const mock: CategoryAggregate[] = [
+    { name: 'Mercado', icon: '🛒', color: '#10b981', value: 850_000 },
+    { name: 'Restaurantes', icon: '🍽️', color: '#f59e0b', value: 420_000 },
+    { name: 'Transporte', icon: '🚗', color: '#3b82f6', value: 280_000 },
+    { name: 'Servicios', icon: '💡', color: '#a855f7', value: 195_000 },
+    { name: 'Salud', icon: '🏥', color: '#ef4444', value: 130_000 },
+    { name: 'Entretenimiento', icon: '🎬', color: '#ec4899', value: 95_000 },
+  ]
+  return (
+    <ExpensesByCategoryChart
+      data={mock}
+      currency="COP"
+      title="Gastos por categoría"
+      subtitle="Últimos 30 días"
+    />
+  )
+}

--- a/components/charts/MonthlyComparisonChart.tsx
+++ b/components/charts/MonthlyComparisonChart.tsx
@@ -1,0 +1,129 @@
+import { View, Text } from 'react-native'
+import { CartesianChart, Bar } from 'victory-native'
+import { ChartContainer } from './AccumulatedBalanceChart'
+import type { MonthlyPoint } from './types'
+
+interface Props {
+  data: MonthlyPoint[]
+  /** Color para income. Default green-500. */
+  incomeColor?: string
+  /** Color para expense. Default red-500. */
+  expenseColor?: string
+  height?: number
+  title?: string
+  subtitle?: string
+}
+
+/**
+ * Barras agrupadas income vs expense por mes.
+ *
+ * victory-native v41 renderiza Bar como barras verticales. Para "barras
+ * agrupadas" (dos series por categoría) se renderizan dos <Bar> con
+ * `barWidth` reducido — el offset visual se logra con la separación natural
+ * entre puntos del eje X.
+ *
+ * En lugar de eje X con labels (requiere font), usamos una row de labels
+ * debajo del chart en HTML/RN normal, alineada a los meses.
+ */
+export function MonthlyComparisonChart({
+  data,
+  incomeColor = '#10b981',
+  expenseColor = '#ef4444',
+  height = 240,
+  title,
+  subtitle,
+}: Props) {
+  if (data.length === 0) {
+    return (
+      <ChartContainer title={title} subtitle={subtitle} height={height}>
+        <View className="flex-1 items-center justify-center">
+          <Text className="text-muted text-sm">Sin datos para mostrar</Text>
+        </View>
+      </ChartContainer>
+    )
+  }
+
+  const chartData = data.map((p, i) => ({
+    i,
+    income: p.income,
+    expense: p.expense,
+  }))
+
+  return (
+    <ChartContainer title={title} subtitle={subtitle} height={height}>
+      {/* Legend */}
+      <View className="flex-row gap-4 mb-2">
+        <View className="flex-row items-center gap-1.5">
+          <View
+            style={{ width: 10, height: 10, backgroundColor: incomeColor, borderRadius: 2 }}
+          />
+          <Text className="text-muted text-xs">Ingresos</Text>
+        </View>
+        <View className="flex-row items-center gap-1.5">
+          <View
+            style={{ width: 10, height: 10, backgroundColor: expenseColor, borderRadius: 2 }}
+          />
+          <Text className="text-muted text-xs">Gastos</Text>
+        </View>
+      </View>
+
+      <View style={{ flex: 1 }}>
+        <CartesianChart
+          data={chartData}
+          xKey="i"
+          yKeys={['income', 'expense']}
+          domainPadding={{ top: 16, bottom: 8, left: 24, right: 24 }}
+        >
+          {({ points, chartBounds }) => (
+            <>
+              <Bar
+                points={points.income}
+                chartBounds={chartBounds}
+                color={incomeColor}
+                barWidth={10}
+                roundedCorners={{ topLeft: 3, topRight: 3 }}
+                animate={{ type: 'timing', duration: 500 }}
+              />
+              <Bar
+                points={points.expense}
+                chartBounds={chartBounds}
+                color={expenseColor}
+                barWidth={10}
+                roundedCorners={{ topLeft: 3, topRight: 3 }}
+                animate={{ type: 'timing', duration: 500 }}
+              />
+            </>
+          )}
+        </CartesianChart>
+      </View>
+
+      {/* Month labels — alineados aproximadamente con cada índice */}
+      <View className="flex-row justify-between mt-1 px-2">
+        {data.map((p) => (
+          <Text key={p.label} className="text-muted text-xs" style={{ width: `${100 / data.length}%`, textAlign: 'center' }}>
+            {p.label}
+          </Text>
+        ))}
+      </View>
+    </ChartContainer>
+  )
+}
+
+/** Mock data para verificación visual. Se borra en T-4.2. */
+export function DemoMonthlyComparisonChart() {
+  const mock: MonthlyPoint[] = [
+    { label: 'dic', income: 3_200_000, expense: 2_800_000 },
+    { label: 'ene', income: 3_500_000, expense: 3_100_000 },
+    { label: 'feb', income: 3_300_000, expense: 2_900_000 },
+    { label: 'mar', income: 3_700_000, expense: 3_400_000 },
+    { label: 'abr', income: 4_100_000, expense: 3_500_000 },
+    { label: 'may', income: 3_900_000, expense: 3_200_000 },
+  ]
+  return (
+    <MonthlyComparisonChart
+      data={mock}
+      title="Ingresos vs gastos"
+      subtitle="Últimos 6 meses"
+    />
+  )
+}

--- a/components/charts/types.ts
+++ b/components/charts/types.ts
@@ -1,0 +1,37 @@
+/**
+ * Tipos compartidos entre los chart wrappers.
+ *
+ * Diseñados para coincidir con los shapes que el web ya construye en sus
+ * actions. Esto permite que un mismo agrupador (server-side o cliente) sirva
+ * a ambos proyectos sin transformaciones intermedias.
+ */
+
+/** Punto en serie temporal — usado por AccumulatedBalanceChart. */
+export interface TimeSeriesPoint {
+  /** YYYY-MM-DD */
+  date: string
+  /** Valor numérico (balance, total, etc.) */
+  value: number
+}
+
+/** Categoría con monto agregado — usado por ExpensesByCategoryChart. */
+export interface CategoryAggregate {
+  /** Nombre legible (Mercado, Salud, etc.) */
+  name: string
+  /** Emoji opcional del category.icon */
+  icon?: string | null
+  /** Color de la categoría — hex */
+  color?: string | null
+  /** Monto agregado en la currency objetivo */
+  value: number
+  /** % del total — calculado por el caller */
+  percent?: number
+}
+
+/** Punto mensual con income+expense — usado por MonthlyComparisonChart. */
+export interface MonthlyPoint {
+  /** Label corto del mes: "ene", "feb", "mar", ..., "ene 25" si hay año mixto */
+  label: string
+  income: number
+  expense: number
+}

--- a/lib/utils/currency.ts
+++ b/lib/utils/currency.ts
@@ -1,17 +1,28 @@
 // lib/utils/currency.ts
 import type { Currency } from '@/types/database.types'
 
+/**
+ * Formatea un monto con el código ISO de moneda (no el símbolo).
+ *
+ * Usamos `currencyDisplay: 'code'` porque la app maneja COP, USD y VES
+ * en la misma pantalla — el símbolo `$` es ambiguo entre COP/USD y `Bs`
+ * solo lo entienden usuarios de Venezuela. Con código ISO no hay duda:
+ *
+ *   formatCurrency(40000, 'COP') → "COP 40.000"
+ *   formatCurrency(40, 'USD')    → "USD 40,00"
+ *   formatCurrency(40, 'VES')    → "VES 40,00"
+ *
+ * Decimales:
+ * - COP: 0 (los centavos colombianos no se usan en práctica)
+ * - USD / VES: 2 (los centavos importan)
+ */
 export function formatCurrency(amount: number, currency: Currency): string {
-  if (currency === 'VES') {
-    return `Bs ${amount.toLocaleString('es-VE', {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    })}`
-  }
+  const fractionDigits = currency === 'COP' ? 0 : 2
   return new Intl.NumberFormat('es-CO', {
     style: 'currency',
     currency,
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
+    currencyDisplay: 'code',
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
   }).format(amount)
 }

--- a/package.json
+++ b/package.json
@@ -37,5 +37,10 @@
     "@types/react": "~19.1.0",
     "typescript": "~5.9.2"
   },
-  "private": true
+  "private": true,
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@shopify/react-native-skia"
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@insforge/sdk": "^1.2.5",
     "@react-native-community/datetimepicker": "8.4.4",
+    "@shopify/react-native-skia": "^2.6.3",
     "expo": "~54.0.34",
     "expo-auth-session": "~7.0.11",
     "expo-router": "~6.0.23",
@@ -29,6 +30,7 @@
     "react-native-worklets": "0.5.1",
     "sonner-native": "^0.25.1",
     "tailwindcss": "^3.4.17",
+    "victory-native": "^41",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@react-native-community/datetimepicker':
         specifier: 8.4.4
         version: 8.4.4(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@shopify/react-native-skia':
+        specifier: ^2.6.3
+        version: 2.6.3(react-native-reanimated@4.1.7(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       expo:
         specifier: ~54.0.34
         version: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
@@ -68,6 +71,9 @@ importers:
       tailwindcss:
         specifier: ^3.4.17
         version: 3.4.19(yaml@2.8.3)
+      victory-native:
+        specifier: ^41
+        version: 41.20.3(69d0d1b6137f9c30f2540fc291ae31db)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -1179,6 +1185,19 @@ packages:
   '@react-navigation/routers@7.5.3':
     resolution: {integrity: sha512-1tJHg4KKRJuQ1/EvJxatrMef3NZXEPzwUIUZ3n1yJ2t7Q97siwRtbynRpQG9/69ebbtiZ8W3ScOZF/OmhvM4Rg==}
 
+  '@shopify/react-native-skia@2.6.3':
+    resolution: {integrity: sha512-P31NxwHxv3M5sFTNyD0vTmCMMpMH59ao+WRlVGnODp3d6KFx+IuKR2S/f7FPfs/vMKoP5OMuzVRDwGkR0WKzyA==}
+    hasBin: true
+    peerDependencies:
+      react: '>=19.0'
+      react-native: '>=0.78'
+      react-native-reanimated: '>=3.19.1'
+    peerDependenciesMeta:
+      react-native:
+        optional: true
+      react-native-reanimated:
+        optional: true
+
   '@sinclair/typebox@0.27.10':
     resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
 
@@ -1228,6 +1247,11 @@ packages:
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
+  '@types/react-reconciler@0.28.9':
+    resolution: {integrity: sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==}
+    peerDependencies:
+      '@types/react': '*'
+
   '@types/react@19.1.17':
     resolution: {integrity: sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==}
 
@@ -1251,6 +1275,9 @@ packages:
     resolution: {integrity: sha512-TQMCz2pFJMfpNxmSfX1VSfTjwUIFx/mL+p1bnfM1xjjdla7Z+KnGMW/EhFbpckp3LyWAH4PgOsMwOMnIN+MBFg==}
     peerDependencies:
       '@urql/core': ^5.0.0
+
+  '@webgpu/types@0.1.21':
+    resolution: {integrity: sha512-pUrWq3V5PiSGFLeLxoGqReTZmiiXwY3jRkIG5sLLKjyqNxrwm/04b4nw7LSmGWJcKk59XOM/YRTUwOzo4MMlow==}
 
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
@@ -1488,6 +1515,9 @@ packages:
   caniuse-lite@1.0.30001788:
     resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
 
+  canvaskit-wasm@0.41.0:
+    resolution: {integrity: sha512-cnbL02NFB3yOYMF/MtxViZHgD1vh55Pvy+zR8q4JuFvyCPejZP3eClkt2GuZ0S7jOmGMCJXaHBasbMChbR9JZg==}
+
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
@@ -1620,6 +1650,72 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -2108,6 +2204,10 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
+
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
@@ -2157,6 +2257,11 @@ packages:
   istanbul-lib-instrument@5.2.1:
     resolution: {integrity: sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==}
     engines: {node: '>=8'}
+
+  its-fine@1.2.5:
+    resolution: {integrity: sha512-fXtDA0X0t0eBYAGLVM5YsgJGsJ5jEmqZEPrGbzdf5awjv0xE7nqv3TVnvtUF060Tkes15DbDAKW/I48vsb6SyA==}
+    peerDependencies:
+      react: '>=18.0'
 
   jest-environment-node@29.7.0:
     resolution: {integrity: sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==}
@@ -3018,6 +3123,18 @@ packages:
       react: '*'
       react-native: '*'
 
+  react-native-skia-android@147.1.0:
+    resolution: {integrity: sha512-pWA0M0G74AhjEop0HLCkjWJMup2HJxOmuUjfPt6kSDhYeWKVx8AEzWh0Fh19ah78zE/s4hD0Of0Tyem5shhiTg==}
+
+  react-native-skia-apple-ios@147.1.0:
+    resolution: {integrity: sha512-cr4rWe4Bf0H0TTutUp5cgHt5/Felttl1bh4BAAAsgAeL2F10FAK9urX8spjUshzMwjqXD7rNOWuFzU6ZcNlGKw==}
+
+  react-native-skia-apple-macos@147.1.0:
+    resolution: {integrity: sha512-Qbv0Y7LgawtRKuGk8gnGeh8nDWwNiu03LcX0mVaQzBBbxFDYvqejanA+AkO3p8gsQb+fsXRc9DAk+U8cBnzZvA==}
+
+  react-native-skia-apple-tvos@147.1.0:
+    resolution: {integrity: sha512-b+4vILXHPu++t8H41PHLBVsTab2LPqwXNdzgdScyl4+Cu8Ta34aUQW3T469cB0ogAMPdu//KV00w4YVpDZoRUQ==}
+
   react-native-svg@15.12.1:
     resolution: {integrity: sha512-vCuZJDf8a5aNC2dlMovEv4Z0jjEUET53lm/iILFnFewa15b4atjVxU6Wirm6O9y6dEsdjDZVD7Q3QM4T1wlI8g==}
     peerDependencies:
@@ -3041,6 +3158,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-reconciler@0.31.0:
+    resolution: {integrity: sha512-7Ob7Z+URmesIsIVRjnLoDGwBEG/tVitidU0nMsqX/eeJaLY89RISO/10ERe0MqmzuKUUB1rmY+h1itMbUHg9BQ==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^19.0.0
 
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
@@ -3161,6 +3284,9 @@ packages:
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
+
+  scheduler@0.25.0:
+    resolution: {integrity: sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==}
 
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
@@ -3518,6 +3644,15 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+
+  victory-native@41.20.3:
+    resolution: {integrity: sha512-cpl5HGcuTbBqc60pxJIxQr6fjJWuKEfxAVgs1TkRXkpVnb480Ty3nYQdAoaqENbkH2FlXibUFI2G7XeNGEOX7Q==}
+    peerDependencies:
+      '@shopify/react-native-skia': '>=1.2.3 <3.0.0'
+      react: '*'
+      react-native: '*'
+      react-native-gesture-handler: '>=2.0.0'
+      react-native-reanimated: '>=3.0.0'
 
   vlq@1.0.1:
     resolution: {integrity: sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==}
@@ -5186,6 +5321,19 @@ snapshots:
     dependencies:
       nanoid: 3.3.11
 
+  '@shopify/react-native-skia@2.6.3(react-native-reanimated@4.1.7(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      canvaskit-wasm: 0.41.0
+      react: 19.1.0
+      react-native-skia-android: 147.1.0
+      react-native-skia-apple-ios: 147.1.0
+      react-native-skia-apple-macos: 147.1.0
+      react-native-skia-apple-tvos: 147.1.0
+      react-reconciler: 0.31.0(react@19.1.0)
+    optionalDependencies:
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
+      react-native-reanimated: 4.1.7(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+
   '@sinclair/typebox@0.27.10': {}
 
   '@sinonjs/commons@3.0.1':
@@ -5247,6 +5395,10 @@ snapshots:
     dependencies:
       undici-types: 7.19.2
 
+  '@types/react-reconciler@0.28.9(@types/react@19.1.17)':
+    dependencies:
+      '@types/react': 19.1.17
+
   '@types/react@19.1.17':
     dependencies:
       csstype: 3.2.3
@@ -5272,6 +5424,8 @@ snapshots:
     dependencies:
       '@urql/core': 5.2.0
       wonka: 6.3.6
+
+  '@webgpu/types@0.1.21': {}
 
   '@xmldom/xmldom@0.8.13': {}
 
@@ -5546,6 +5700,10 @@ snapshots:
 
   caniuse-lite@1.0.30001788: {}
 
+  canvaskit-wasm@0.41.0:
+    dependencies:
+      '@webgpu/types': 0.1.21
+
   chalk@2.4.2:
     dependencies:
       ansi-styles: 3.2.1
@@ -5703,6 +5861,70 @@ snapshots:
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   debug@2.6.9:
     dependencies:
@@ -6172,6 +6394,8 @@ snapshots:
 
   ini@1.3.8: {}
 
+  internmap@2.0.3: {}
+
   invariant@2.2.4:
     dependencies:
       loose-envify: 1.4.0
@@ -6215,6 +6439,13 @@ snapshots:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
+
+  its-fine@1.2.5(@types/react@19.1.17)(react@19.1.0):
+    dependencies:
+      '@types/react-reconciler': 0.28.9(@types/react@19.1.17)
+      react: 19.1.0
+    transitivePeerDependencies:
+      - '@types/react'
 
   jest-environment-node@29.7.0:
     dependencies:
@@ -7375,6 +7606,14 @@ snapshots:
       react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       warn-once: 0.1.1
 
+  react-native-skia-android@147.1.0: {}
+
+  react-native-skia-apple-ios@147.1.0: {}
+
+  react-native-skia-apple-macos@147.1.0: {}
+
+  react-native-skia-apple-tvos@147.1.0: {}
+
   react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       css-select: 5.2.2
@@ -7448,6 +7687,11 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  react-reconciler@0.31.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      scheduler: 0.25.0
 
   react-refresh@0.14.2: {}
 
@@ -7556,6 +7800,8 @@ snapshots:
   safe-buffer@5.2.1: {}
 
   sax@1.6.0: {}
+
+  scheduler@0.25.0: {}
 
   scheduler@0.26.0: {}
 
@@ -7896,6 +8142,21 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
+
+  victory-native@41.20.3(69d0d1b6137f9c30f2540fc291ae31db):
+    dependencies:
+      '@shopify/react-native-skia': 2.6.3(react-native-reanimated@4.1.7(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-zoom: 3.0.0
+      its-fine: 1.2.5(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+      react-fast-compare: 3.2.2
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
+      react-native-gesture-handler: 2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-native-reanimated: 4.1.7(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+    transitivePeerDependencies:
+      - '@types/react'
 
   vlq@1.0.1: {}
 


### PR DESCRIPTION
Closes #78 · Related to #77 (FASE 4)

## Cambios principales — setup de charts

### Deps nuevas
- \`victory-native\` ^41 (41.20.3) — API declarativa de charts sobre Skia
- \`@shopify/react-native-skia\` ^2 (2.6.3) — canvas rendering en UI thread

### Componentes nuevos en \`components/charts/\`
- **\`types.ts\`** — \`TimeSeriesPoint\`, \`CategoryAggregate\`, \`MonthlyPoint\`. Shapes compatibles con el web.
- **\`AccumulatedBalanceChart\`** — Line + Area con LinearGradient de Skia + header con valor actual + delta. \`ChartContainer\` reusable.
- **\`ExpensesByCategoryChart\`** — **NO usa victory-native**. Bar list con View + ProgressBar (decisión UX mobile-first).
- **\`MonthlyComparisonChart\`** — Bar × 2 series + legend + month labels.

Cada chart exporta \`Demo<Chart>\` con mock data. Dashboard temporal renderiza los tres para verificación visual. **T-4.2 lo reemplaza con datos reales.**

## Fixes adicionales descubiertos durante el smoke test

### 1. pnpm 10 bloqueando postinstall de Skia
pnpm 10 ignora postinstall scripts por defecto. Sin esto \`pod install\` falla con "Skia prebuilt binaries not found". Fix: \`pnpm.onlyBuiltDependencies\` en \`package.json\`. Después de pull: \`pnpm rebuild @shopify/react-native-skia\` fuerza el postinstall.

### 2. Tab bar overflow con folders de FASE 3
expo-router auto-expone como tab todo folder con \`_layout.tsx\`. Categories/budgets/savings/loans mostraban tabs con icono ▼ default. Fix: \`<Tabs.Screen name="..." options={{ href: null }} />\` para cada uno. Tab bar limpio: **Dashboard · Transacciones · Cuentas · Más**. Las rutas siguen navegables con \`router.push()\`.

### 3. Currency display ambigua
\`Intl.NumberFormat\` con \`style: 'currency'\` usa el símbolo local (\`$\` tanto para COP como USD en es-CO). Fix: \`currencyDisplay: 'code'\` → \`COP 40.000\` / \`USD 40,00\` / \`VES 40,00\`. Decimales por moneda (0 para COP, 2 para USD/VES).

## Verificación

- [x] \`npx tsc --noEmit\` limpio
- [x] Smoke test en simulator iOS (post-fix de pnpm + post-rebuild): los 3 charts renderizan correctamente
- [x] Tab bar muestra solo 4 tabs reales (sin flechas default)
- [x] Charts y cards muestran montos con código ISO de moneda

## Decisiones técnicas notables

- **Sin font loading inicial** — \`axisOptions.font\` opcional; cifras importantes van fuera del Skia canvas.
- **"Bar list" en lugar de bar chart real** para ExpensesByCategory — más legible en mobile, reusa ProgressBar.
- **Data shape compartida con web** — \`types.ts\` espeja shapes que el web ya construye (Recharts data).

## Notas para Obsidian

- 🆕 [[Skia rendering pipeline]] en \`10 - Concepts/React Native/\`
- 🆕 [[victory-native]] en \`10 - Concepts/React Native/\`
- Actualizado [[Tabs navigator]] con sección \"Ocultar una ruta del tab bar — href: null\"
- Bitácora \`T-4.1 — Setup charts.md\` (con gotcha de pnpm 10 documentada)

## Commits

1. \`chore: add victory-native v41 + react-native-skia v2 (T-4.1)\`
2. \`feat(charts): chart wrappers + dashboard preview (T-4.1)\`
3. \`fix: aprobar postinstall de @shopify/react-native-skia para pnpm 10\`
4. \`fix: ocultar hubs del tab bar + currency display con código ISO\`