### PR TITLE
feat: dashboard real con summary, charts y widgets (T-4.2)

### DIFF
--- a/app/(dashboard)/index.tsx
+++ b/app/(dashboard)/index.tsx
@@ -1,35 +1,157 @@
 // app/(dashboard)/index.tsx
 //
-// T-4.1 placeholder: muestra los tres charts con mock data para verificar
-// que victory-native + Skia están configurados correctamente. T-4.2 va a
-// reemplazar esto con datos reales y summary cards.
-import { ScrollView, View, Text } from 'react-native'
+// Dashboard real (T-4.2). Carga en paralelo:
+//   - Transactions de los últimos 60 días con category join
+//   - Budgets con spent calculado (BudgetWithSpent[])
+//   - Exchange rates (cacheadas via useExchangeRates)
+//
+// Compone: SummaryCards · AccumulatedBalanceChart · ExpensesByCategoryChart
+//          · RecentTransactions · ActiveBudgets
+//
+// Refresh on focus con useFocusEffect — al volver al tab se actualiza.
+import { useCallback, useMemo, useState } from 'react'
+import { ScrollView, View, Text, ActivityIndicator } from 'react-native'
+import { useFocusEffect } from 'expo-router'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useAuth } from '@/context/AuthContext'
-import { DemoAccumulatedBalanceChart } from '@/components/charts/AccumulatedBalanceChart'
-import { DemoExpensesByCategoryChart } from '@/components/charts/ExpensesByCategoryChart'
-import { DemoMonthlyComparisonChart } from '@/components/charts/MonthlyComparisonChart'
+import { useExchangeRates } from '@/hooks/useExchangeRates'
+import { getTransactions } from '@/lib/actions/transactions.actions'
+import { getBudgets } from '@/lib/actions/budgets.actions'
+import {
+  buildBalanceTimeSeries,
+  buildCategoryAggregates,
+  currentMonthPrefix,
+} from '@/lib/utils/dashboard'
+import { SummaryCards } from '@/components/dashboard/SummaryCards'
+import { RecentTransactions } from '@/components/dashboard/RecentTransactions'
+import { ActiveBudgets } from '@/components/dashboard/ActiveBudgets'
+import { AccumulatedBalanceChart } from '@/components/charts/AccumulatedBalanceChart'
+import { ExpensesByCategoryChart } from '@/components/charts/ExpensesByCategoryChart'
+import type {
+  BudgetWithSpent,
+  TransactionWithCategory,
+} from '@/types/database.types'
+
+const MONTH_LABEL = (() => {
+  const d = new Date()
+  return d
+    .toLocaleDateString('es', { month: 'long', year: 'numeric' })
+    .replace(/^\w/, (c) => c.toUpperCase())
+})()
 
 export default function DashboardScreen() {
   const { user } = useAuth()
+  const { rates } = useExchangeRates()
+  const [transactions, setTransactions] = useState<TransactionWithCategory[]>([])
+  const [budgets, setBudgets] = useState<BudgetWithSpent[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const loadData = useCallback(async () => {
+    if (!user) return
+    const [txRes, budgetsRes] = await Promise.all([
+      // 60 días alcanza para el chart de 30 + las 5 recientes + un buffer
+      getTransactions(
+        user.id,
+        {
+          month: undefined, // sin filtro de mes — el client filtra el rango por fecha
+        },
+        { page: 1, pageSize: 200 }
+      ),
+      getBudgets(user.id),
+    ])
+
+    if (txRes.success && txRes.data) {
+      setTransactions(txRes.data.items)
+    }
+    if (budgetsRes.success && budgetsRes.data) {
+      setBudgets(budgetsRes.data)
+    }
+    setLoading(false)
+  }, [user])
+
+  useFocusEffect(
+    useCallback(() => {
+      let cancelled = false
+      ;(async () => {
+        if (cancelled) return
+        await loadData()
+      })()
+      return () => {
+        cancelled = true
+      }
+    }, [loadData])
+  )
+
+  // Derivados — recomputados solo cuando cambian inputs
+  const monthPrefix = useMemo(() => currentMonthPrefix(), [])
+  const preferredCurrency = user?.preferred_currency ?? 'COP'
+
+  const balanceSeries = useMemo(
+    () =>
+      buildBalanceTimeSeries(transactions, {
+        days: 30,
+        targetCurrency: preferredCurrency,
+        rates,
+      }),
+    [transactions, preferredCurrency, rates]
+  )
+
+  const categoryAggregates = useMemo(
+    () =>
+      buildCategoryAggregates(transactions, {
+        targetCurrency: preferredCurrency,
+        rates,
+        month: monthPrefix,
+      }),
+    [transactions, preferredCurrency, rates, monthPrefix]
+  )
+
+  if (loading) {
+    return (
+      <SafeAreaView edges={['top']} className="flex-1 bg-bg">
+        <View className="flex-1 items-center justify-center">
+          <ActivityIndicator color="#4F46E5" />
+        </View>
+      </SafeAreaView>
+    )
+  }
+
   return (
     <SafeAreaView edges={['top']} className="flex-1 bg-bg">
       <View className="px-4 py-3 border-b border-border">
         <Text className="text-white text-xl font-bold">Dashboard</Text>
         <Text className="text-muted text-xs mt-0.5">
-          Hola, {user?.name ?? user?.email}
+          {user?.name ? `Hola, ${user.name}` : MONTH_LABEL} · {MONTH_LABEL}
         </Text>
       </View>
+
       <ScrollView
         className="flex-1"
-        contentContainerStyle={{ padding: 16, gap: 16 }}
+        contentContainerStyle={{ padding: 16, paddingBottom: 40, gap: 20 }}
       >
-        <Text className="text-amber-400 text-xs">
-          T-4.1: preview con mock data. T-4.2 conecta datos reales.
-        </Text>
-        <DemoAccumulatedBalanceChart />
-        <DemoExpensesByCategoryChart />
-        <DemoMonthlyComparisonChart />
+        <SummaryCards
+          transactions={transactions}
+          month={monthPrefix}
+          preferredCurrency={preferredCurrency}
+          exchangeRates={rates}
+        />
+
+        <AccumulatedBalanceChart
+          data={balanceSeries}
+          title="Flujo del mes"
+          subtitle={`Últimos 30 días · ${preferredCurrency}`}
+        />
+
+        <ExpensesByCategoryChart
+          data={categoryAggregates}
+          currency={preferredCurrency}
+          title="Gastos por categoría"
+          subtitle={MONTH_LABEL}
+        />
+
+        <RecentTransactions transactions={transactions} limit={5} />
+
+        <ActiveBudgets budgets={budgets} limit={3} />
       </ScrollView>
     </SafeAreaView>
   )

--- a/components/charts/AccumulatedBalanceChart.tsx
+++ b/components/charts/AccumulatedBalanceChart.tsx
@@ -134,26 +134,3 @@ export function ChartContainer({
   )
 }
 
-/** Mock data para verificación visual en T-4.1. Se borra en T-4.2. */
-export function DemoAccumulatedBalanceChart() {
-  const mock: TimeSeriesPoint[] = [
-    { date: '2026-04-01', value: 1_200_000 },
-    { date: '2026-04-05', value: 1_350_000 },
-    { date: '2026-04-10', value: 1_300_000 },
-    { date: '2026-04-15', value: 1_550_000 },
-    { date: '2026-04-20', value: 1_700_000 },
-    { date: '2026-04-25', value: 1_650_000 },
-    { date: '2026-04-30', value: 1_900_000 },
-    { date: '2026-05-05', value: 1_850_000 },
-    { date: '2026-05-10', value: 2_100_000 },
-    { date: '2026-05-15', value: 2_250_000 },
-    { date: '2026-05-20', value: 2_400_000 },
-  ]
-  return (
-    <AccumulatedBalanceChart
-      data={mock}
-      title="Balance acumulado"
-      subtitle="Últimos 30 días · COP"
-    />
-  )
-}

--- a/components/charts/ExpensesByCategoryChart.tsx
+++ b/components/charts/ExpensesByCategoryChart.tsx
@@ -79,22 +79,3 @@ export function ExpensesByCategoryChart({
   )
 }
 
-/** Mock data para verificación visual. Se borra en T-4.2. */
-export function DemoExpensesByCategoryChart() {
-  const mock: CategoryAggregate[] = [
-    { name: 'Mercado', icon: '🛒', color: '#10b981', value: 850_000 },
-    { name: 'Restaurantes', icon: '🍽️', color: '#f59e0b', value: 420_000 },
-    { name: 'Transporte', icon: '🚗', color: '#3b82f6', value: 280_000 },
-    { name: 'Servicios', icon: '💡', color: '#a855f7', value: 195_000 },
-    { name: 'Salud', icon: '🏥', color: '#ef4444', value: 130_000 },
-    { name: 'Entretenimiento', icon: '🎬', color: '#ec4899', value: 95_000 },
-  ]
-  return (
-    <ExpensesByCategoryChart
-      data={mock}
-      currency="COP"
-      title="Gastos por categoría"
-      subtitle="Últimos 30 días"
-    />
-  )
-}

--- a/components/charts/MonthlyComparisonChart.tsx
+++ b/components/charts/MonthlyComparisonChart.tsx
@@ -109,21 +109,3 @@ export function MonthlyComparisonChart({
   )
 }
 
-/** Mock data para verificación visual. Se borra en T-4.2. */
-export function DemoMonthlyComparisonChart() {
-  const mock: MonthlyPoint[] = [
-    { label: 'dic', income: 3_200_000, expense: 2_800_000 },
-    { label: 'ene', income: 3_500_000, expense: 3_100_000 },
-    { label: 'feb', income: 3_300_000, expense: 2_900_000 },
-    { label: 'mar', income: 3_700_000, expense: 3_400_000 },
-    { label: 'abr', income: 4_100_000, expense: 3_500_000 },
-    { label: 'may', income: 3_900_000, expense: 3_200_000 },
-  ]
-  return (
-    <MonthlyComparisonChart
-      data={mock}
-      title="Ingresos vs gastos"
-      subtitle="Últimos 6 meses"
-    />
-  )
-}

--- a/components/dashboard/ActiveBudgets.tsx
+++ b/components/dashboard/ActiveBudgets.tsx
@@ -1,0 +1,81 @@
+import { View, Text, TouchableOpacity } from 'react-native'
+import { router } from 'expo-router'
+import { ProgressBar, defaultColor } from '@/components/ui/ProgressBar'
+import { formatCurrency } from '@/lib/utils/currency'
+import type { BudgetWithSpent } from '@/types/database.types'
+
+interface Props {
+  budgets: BudgetWithSpent[]
+  limit?: number
+}
+
+/**
+ * Widget de presupuestos activos para el dashboard. Muestra los TOP N
+ * ordenados por % consumido descendente — los más urgentes primero
+ * (excedidos y casi excedidos en la cima).
+ *
+ * Si no hay budgets, se omite el componente entero (el caller decide
+ * mostrar un CTA o nada).
+ */
+export function ActiveBudgets({ budgets, limit = 3 }: Props) {
+  if (budgets.length === 0) return null
+
+  const sorted = [...budgets]
+    .sort((a, b) => {
+      const ra = a.amount > 0 ? a.spent / a.amount : 0
+      const rb = b.amount > 0 ? b.spent / b.amount : 0
+      return rb - ra
+    })
+    .slice(0, limit)
+
+  return (
+    <View>
+      <View className="flex-row items-center justify-between mb-2 px-1">
+        <Text className="text-muted text-xs uppercase tracking-wider">
+          Presupuestos
+        </Text>
+        <TouchableOpacity
+          onPress={() => router.push('/budgets')}
+          activeOpacity={0.7}
+        >
+          <Text className="text-primary text-xs">Ver todos →</Text>
+        </TouchableOpacity>
+      </View>
+
+      <View className="gap-2">
+        {sorted.map((b) => {
+          const ratio = b.amount > 0 ? b.spent / b.amount : 0
+          const color = defaultColor(ratio)
+          return (
+            <TouchableOpacity
+              key={b.id}
+              onPress={() => router.push(`/budgets/${b.id}`)}
+              activeOpacity={0.7}
+              className="bg-surface border border-border rounded-2xl p-3"
+            >
+              <View className="flex-row items-center mb-2">
+                <View
+                  style={{ backgroundColor: b.category.color ?? '#4F46E5' }}
+                  className="w-8 h-8 rounded-full items-center justify-center mr-2"
+                >
+                  <Text className="text-sm">{b.category.icon ?? '📂'}</Text>
+                </View>
+                <Text className="text-white text-sm flex-1" numberOfLines={1}>
+                  {b.category.name}
+                </Text>
+                <Text style={{ color }} className="text-sm font-bold">
+                  {Math.round(ratio * 100)}%
+                </Text>
+              </View>
+              <ProgressBar value={ratio} height={6} />
+              <Text className="text-muted text-xs mt-1.5">
+                {formatCurrency(b.spent, b.currency)} de{' '}
+                {formatCurrency(b.amount, b.currency)}
+              </Text>
+            </TouchableOpacity>
+          )
+        })}
+      </View>
+    </View>
+  )
+}

--- a/components/dashboard/RecentTransactions.tsx
+++ b/components/dashboard/RecentTransactions.tsx
@@ -1,0 +1,82 @@
+import { View, Text, TouchableOpacity } from 'react-native'
+import { router } from 'expo-router'
+import { formatCurrency } from '@/lib/utils/currency'
+import type { TransactionWithCategory } from '@/types/database.types'
+
+interface Props {
+  transactions: TransactionWithCategory[]
+  limit?: number
+}
+
+function formatShortDate(iso: string): string {
+  const d = new Date(`${iso}T00:00:00`)
+  return d.toLocaleDateString('es', { day: 'numeric', month: 'short' })
+}
+
+/**
+ * Lista compacta de las últimas N transacciones con link a la pantalla
+ * completa de transacciones. Se asume que `transactions` ya viene ordenado
+ * por fecha desc por el caller.
+ */
+export function RecentTransactions({ transactions, limit = 5 }: Props) {
+  const items = transactions.slice(0, limit)
+
+  return (
+    <View>
+      <View className="flex-row items-center justify-between mb-2 px-1">
+        <Text className="text-muted text-xs uppercase tracking-wider">
+          Últimas transacciones
+        </Text>
+        <TouchableOpacity
+          onPress={() => router.push('/transactions')}
+          activeOpacity={0.7}
+        >
+          <Text className="text-primary text-xs">Ver todas →</Text>
+        </TouchableOpacity>
+      </View>
+
+      <View className="bg-surface border border-border rounded-2xl overflow-hidden">
+        {items.length === 0 ? (
+          <View className="py-6 items-center">
+            <Text className="text-muted text-sm">Sin transacciones</Text>
+          </View>
+        ) : (
+          items.map((tx, idx) => (
+            <TouchableOpacity
+              key={tx.id}
+              onPress={() => router.push(`/transactions/${tx.id}`)}
+              activeOpacity={0.7}
+              className={`flex-row items-center px-4 py-3 ${
+                idx < items.length - 1 ? 'border-b border-border' : ''
+              }`}
+            >
+              <View
+                style={{ backgroundColor: tx.category?.color ?? '#4F46E5' }}
+                className="w-9 h-9 rounded-full items-center justify-center mr-3"
+              >
+                <Text className="text-base">{tx.category?.icon ?? '📂'}</Text>
+              </View>
+              <View className="flex-1">
+                <Text className="text-white text-sm font-medium" numberOfLines={1}>
+                  {tx.description}
+                </Text>
+                <Text className="text-muted text-xs mt-0.5">
+                  {tx.category?.name ?? 'Sin categoría'} ·{' '}
+                  {formatShortDate(tx.date)}
+                </Text>
+              </View>
+              <Text
+                className={`text-sm font-semibold ${
+                  tx.type === 'income' ? 'text-green-400' : 'text-red-400'
+                }`}
+              >
+                {tx.type === 'income' ? '+' : '−'}{' '}
+                {formatCurrency(Number(tx.amount), tx.currency)}
+              </Text>
+            </TouchableOpacity>
+          ))
+        )}
+      </View>
+    </View>
+  )
+}

--- a/components/dashboard/SummaryCards.tsx
+++ b/components/dashboard/SummaryCards.tsx
@@ -1,0 +1,108 @@
+import { View, Text } from 'react-native'
+import { useFinancialSummary } from '@/hooks/useFinancialSummary'
+import { formatCurrency } from '@/lib/utils/currency'
+import type {
+  Currency,
+  ExchangeRate,
+  TransactionWithCategory,
+} from '@/types/database.types'
+
+interface Props {
+  transactions: TransactionWithCategory[]
+  month: string // YYYY-MM
+  preferredCurrency: Currency
+  exchangeRates: ExchangeRate[]
+}
+
+/**
+ * Tres cards apiladas con income / expense / balance del mes activo.
+ * Reúsa el hook useFinancialSummary que ya hace currency conversion.
+ *
+ * Diseño mobile-first: cards en columna (no row de 3) para que los montos
+ * grandes no se trunquen en pantallas chicas. El balance card va arriba con
+ * tamaño extra grande porque es el número más importante.
+ */
+export function SummaryCards({
+  transactions,
+  month,
+  preferredCurrency,
+  exchangeRates,
+}: Props) {
+  const { summary } = useFinancialSummary(
+    transactions,
+    month,
+    preferredCurrency,
+    exchangeRates
+  )
+  const positive = summary.balance >= 0
+
+  return (
+    <View className="gap-3">
+      {/* Balance — hero card */}
+      <View className="bg-surface border border-border rounded-2xl p-5">
+        <Text className="text-muted text-xs uppercase tracking-wider">
+          Balance del mes
+        </Text>
+        <Text
+          className={`text-3xl font-bold mt-1 ${
+            positive ? 'text-white' : 'text-red-400'
+          }`}
+        >
+          {formatCurrency(summary.balance, preferredCurrency)}
+        </Text>
+        <Text className="text-muted text-xs mt-1">
+          {summary.transactionCount}{' '}
+          {summary.transactionCount === 1 ? 'transacción' : 'transacciones'}
+        </Text>
+      </View>
+
+      {/* Income + Expense lado a lado */}
+      <View className="flex-row gap-3">
+        <SummaryItem
+          label="Ingresos"
+          value={formatCurrency(summary.totalIncome, preferredCurrency)}
+          count={summary.incomeCount}
+          accent="green"
+        />
+        <SummaryItem
+          label="Gastos"
+          value={formatCurrency(summary.totalExpense, preferredCurrency)}
+          count={summary.expenseCount}
+          accent="red"
+        />
+      </View>
+    </View>
+  )
+}
+
+function SummaryItem({
+  label,
+  value,
+  count,
+  accent,
+}: {
+  label: string
+  value: string
+  count: number
+  accent: 'green' | 'red'
+}) {
+  return (
+    <View className="flex-1 bg-surface border border-border rounded-2xl p-4">
+      <Text className="text-muted text-xs uppercase tracking-wider">
+        {label}
+      </Text>
+      <Text
+        className={`text-base font-bold mt-1 ${
+          accent === 'green' ? 'text-green-400' : 'text-red-400'
+        }`}
+        numberOfLines={1}
+        adjustsFontSizeToFit
+      >
+        {value}
+      </Text>
+      <Text className="text-muted text-xs mt-1">
+        {count} {count === 1 ? 'tx' : 'tx'}
+      </Text>
+    </View>
+  )
+}

--- a/lib/utils/dashboard.ts
+++ b/lib/utils/dashboard.ts
@@ -1,0 +1,146 @@
+import type {
+  Currency,
+  ExchangeRate,
+  TransactionWithCategory,
+} from '@/types/database.types'
+import type {
+  CategoryAggregate,
+  TimeSeriesPoint,
+} from '@/components/charts/types'
+
+/**
+ * Devuelve el multiplicador para convertir `from` → `to`. Si no encuentra
+ * rate, devuelve 1 (degradación silenciosa — el caller puede loguear).
+ */
+function getRate(
+  from: Currency,
+  to: Currency,
+  rates: ExchangeRate[]
+): number {
+  if (from === to) return 1
+  const r = rates.find(
+    (x) => x.from_currency === from && x.to_currency === to
+  )
+  return r ? Number(r.rate) : 1
+}
+
+/**
+ * Construye una serie temporal del **flujo acumulado** en los últimos N días.
+ *
+ * Algoritmo:
+ *   1. Generar un slot por día (hoy hacia atrás N días).
+ *   2. Para cada transaction dentro del rango, sumar/restar al slot del día.
+ *   3. Acumular slot[i] = slot[i-1] + delta[i].
+ *
+ * Es una vista de "cuánto fluyó el balance" durante el período, no el balance
+ * absoluto histórico (que requeriría sumar TODAS las transactions previas).
+ * Para un dashboard de mes corriente, esta vista es más útil que el absoluto.
+ *
+ * Monedas se convierten a `targetCurrency` con las rates provistas.
+ */
+export function buildBalanceTimeSeries(
+  transactions: TransactionWithCategory[],
+  options: {
+    days: number
+    targetCurrency: Currency
+    rates: ExchangeRate[]
+  }
+): TimeSeriesPoint[] {
+  const { days, targetCurrency, rates } = options
+  if (days <= 0) return []
+
+  // Generar fechas YYYY-MM-DD de hoy hacia atrás
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  const dates: string[] = []
+  const deltaByDate: Record<string, number> = {}
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(today)
+    d.setDate(today.getDate() - i)
+    const iso = d.toISOString().slice(0, 10)
+    dates.push(iso)
+    deltaByDate[iso] = 0
+  }
+  const oldestDate = dates[0]
+
+  for (const t of transactions) {
+    if (t.date < oldestDate) continue
+    if (!(t.date in deltaByDate)) continue // tx en el futuro o fuera de rango
+    const converted =
+      Number(t.amount) * getRate(t.currency, targetCurrency, rates)
+    const sign = t.type === 'income' ? 1 : -1
+    deltaByDate[t.date] += converted * sign
+  }
+
+  // Acumular
+  let running = 0
+  return dates.map((date) => {
+    running += deltaByDate[date]
+    return { date, value: running }
+  })
+}
+
+/**
+ * Agrupa expense transactions por categoría y devuelve totales convertidos a
+ * la currency objetivo. Ordenado desc por value. Calcula percent del total.
+ *
+ * `month` opcional — si se pasa (formato YYYY-MM), filtra solo transactions
+ * cuya fecha empieza con ese prefijo. Si se omite, usa todas las dadas.
+ */
+export function buildCategoryAggregates(
+  transactions: TransactionWithCategory[],
+  options: {
+    targetCurrency: Currency
+    rates: ExchangeRate[]
+    month?: string
+  }
+): CategoryAggregate[] {
+  const { targetCurrency, rates, month } = options
+  const filtered = transactions.filter((t) => {
+    if (t.type !== 'expense') return false
+    if (month && !t.date.startsWith(month)) return false
+    return true
+  })
+
+  type Bucket = { name: string; icon: string | null; color: string | null; value: number }
+  const buckets: Record<string, Bucket> = {}
+
+  for (const t of filtered) {
+    const id = t.category?.id ?? '__no_cat__'
+    const converted =
+      Number(t.amount) * getRate(t.currency, targetCurrency, rates)
+    if (!buckets[id]) {
+      buckets[id] = {
+        name: t.category?.name ?? 'Sin categoría',
+        icon: t.category?.icon ?? null,
+        color: t.category?.color ?? null,
+        value: 0,
+      }
+    }
+    buckets[id].value += converted
+  }
+
+  const arr = Object.values(buckets)
+  const total = arr.reduce((s, b) => s + b.value, 0)
+
+  return arr
+    .map<CategoryAggregate>((b) => ({
+      name: b.name,
+      icon: b.icon,
+      color: b.color,
+      value: b.value,
+      percent: total > 0 ? (b.value / total) * 100 : 0,
+    }))
+    .sort((a, b) => b.value - a.value)
+}
+
+/**
+ * Devuelve el primer día del mes actual en formato YYYY-MM-DD.
+ * Útil para filtrar transactions del mes en curso.
+ */
+export function currentMonthPrefix(): string {
+  const now = new Date()
+  const y = now.getFullYear()
+  const m = String(now.getMonth() + 1).padStart(2, '0')
+  return `${y}-${m}`
+}


### PR DESCRIPTION
Closes #80 · Related to #77 (FASE 4)

## Cambios

### Helpers puros — \`lib/utils/dashboard.ts\`
- **\`buildBalanceTimeSeries(transactions, { days, targetCurrency, rates })\`** — genera N puntos del flujo acumulado. Empieza en 0 y acumula \`income − expense\` por día. NO es balance absoluto histórico — es "cuánto fluyó durante el período". Más útil para tendencia del mes que el balance real (que requeriría sumar TODAS las tx previas).
- **\`buildCategoryAggregates(transactions, { targetCurrency, rates, month? })\`** — agrupa expense tx por \`category_id\`, convierte a target currency, calcula percent del total, ordena desc.
- **\`currentMonthPrefix()\`** — 'YYYY-MM' del mes activo.

Funciones puras sin React → fáciles de testear, sin acoplamiento al UI.

### Widgets — \`components/dashboard/\`
- **\`SummaryCards\`** — hero card de balance + row income/expense. Reusa \`useFinancialSummary\`.
- **\`RecentTransactions\`** — lista de 5 con link a \`/transactions\` y al detalle de cada tx.
- **\`ActiveBudgets\`** — top 3 budgets ordenados por % consumido descendente (urgentes primero). Reusa \`ProgressBar\` + \`defaultColor()\`.

### Pantalla — \`app/(dashboard)/index.tsx\`
Reescrita completa:
- Carga paralela \`getTransactions\` + \`getBudgets\` en \`useFocusEffect\`.
- \`useExchangeRates\` cacheada en module-level (primer call fetches, siguientes hit caché).
- Derivados memoizados con \`useMemo\` (balanceSeries, categoryAggregates).
- Composición vertical: SummaryCards → AccumulatedBalanceChart → ExpensesByCategoryChart → RecentTransactions → ActiveBudgets.

### Cleanup
- Borrado de \`Demo*\` exports de los 3 chart wrappers (eran solo para preview de T-4.1).

## Comportamiento visible

- Al abrir el tab: spinner → datos cargados.
- Al volver al tab desde otra pantalla: refetch automático (\`useFocusEffect\`).
- Todos los montos en la moneda preferida del user.
- Charts reflejan tx reales del usuario.
- Budgets aparecen ordenados por urgencia (excedidos primero, verdes al final).
- Tap en una tx reciente abre el detalle. Tap en "Ver todas" abre la pantalla completa.

## Verificación

- [x] \`npx tsc --noEmit\` limpio
- [ ] Smoke test en simulator con datos reales del usuario

## Notas para Obsidian

- Sin notas nuevas — composición de conceptos existentes.
- Bitácora \`T-4.2 — Dashboard real.md\`.