### PR TITLE
feat: pantalla de Reports con range selector + 3 charts (T-4.3)

### DIFF
--- a/app/(dashboard)/_layout.tsx
+++ b/app/(dashboard)/_layout.tsx
@@ -48,11 +48,11 @@ export default function DashboardLayout() {
         }}
       />
       <Tabs.Screen
-        name="accounts"
+        name="reports"
         options={{
-          title: 'Cuentas',
+          title: 'Reportes',
           tabBarIcon: ({ color, size }) => (
-            <Icon name="wallet" color={color} size={size} />
+            <Icon name="chart" color={color} size={size} />
           ),
         }}
       />
@@ -72,6 +72,7 @@ export default function DashboardLayout() {
         descubre automáticamente al tener _layout.tsx; href: null los
         oculta del tab bar pero quedan navegables con router.push('/xxx').
       */}
+      <Tabs.Screen name="accounts" options={{ href: null }} />
       <Tabs.Screen name="categories" options={{ href: null }} />
       <Tabs.Screen name="budgets" options={{ href: null }} />
       <Tabs.Screen name="savings" options={{ href: null }} />

--- a/app/(dashboard)/more.tsx
+++ b/app/(dashboard)/more.tsx
@@ -142,22 +142,27 @@ export default function MoreScreen() {
         {/* Datos */}
         <SectionHeader title="Datos" />
         <SettingsRow
-          icon="dashboard"
+          icon="wallet"
+          label="Cuentas"
+          onPress={() => router.push('/accounts')}
+        />
+        <SettingsRow
+          icon="folder-tree"
           label="Categorías"
           onPress={() => router.push('/categories')}
         />
         <SettingsRow
-          icon="wallet"
+          icon="target"
           label="Presupuestos"
           onPress={() => router.push('/budgets')}
         />
         <SettingsRow
-          icon="arrow-up-circle"
+          icon="piggy"
           label="Metas de ahorro"
           onPress={() => router.push('/savings')}
         />
         <SettingsRow
-          icon="repeat"
+          icon="hand-coins"
           label="Préstamos"
           onPress={() => router.push('/loans')}
         />

--- a/app/(dashboard)/reports/_layout.tsx
+++ b/app/(dashboard)/reports/_layout.tsx
@@ -1,0 +1,13 @@
+import { Stack } from 'expo-router'
+import { colors } from '@/constants/theme'
+
+export default function ReportsLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: colors.bg },
+      }}
+    />
+  )
+}

--- a/app/(dashboard)/reports/index.tsx
+++ b/app/(dashboard)/reports/index.tsx
@@ -1,0 +1,147 @@
+// app/(dashboard)/reports/index.tsx
+//
+// Pantalla de Reports — T-4.3. Renderiza los 3 charts (Accumulated /
+// ExpensesByCategory / MonthlyComparison) con un selector de rango
+// (1M / 3M / 6M / 1Y).
+//
+// Comparte fetch con el dashboard (getTransactions + useExchangeRates).
+// Para rangos largos pedimos pageSize 500 — si el user tiene > 500 tx en
+// el rango, el chart subestima.
+import { useCallback, useMemo, useState } from 'react'
+import { ScrollView, View, Text, ActivityIndicator } from 'react-native'
+import { useFocusEffect } from 'expo-router'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useAuth } from '@/context/AuthContext'
+import { useExchangeRates } from '@/hooks/useExchangeRates'
+import { getTransactions } from '@/lib/actions/transactions.actions'
+import {
+  buildBalanceTimeSeries,
+  buildCategoryAggregates,
+} from '@/lib/utils/dashboard'
+import {
+  buildMonthlyAggregates,
+  RANGE_DAYS,
+  RANGE_MONTHS,
+  RANGE_LABEL,
+  type ReportRange,
+} from '@/lib/utils/reports'
+import { AccumulatedBalanceChart } from '@/components/charts/AccumulatedBalanceChart'
+import { ExpensesByCategoryChart } from '@/components/charts/ExpensesByCategoryChart'
+import { MonthlyComparisonChart } from '@/components/charts/MonthlyComparisonChart'
+import { RangeSelector } from '@/components/reports/RangeSelector'
+import type { TransactionWithCategory } from '@/types/database.types'
+
+export default function ReportsScreen() {
+  const { user } = useAuth()
+  const { rates } = useExchangeRates()
+  const [transactions, setTransactions] = useState<TransactionWithCategory[]>([])
+  const [loading, setLoading] = useState(true)
+  const [range, setRange] = useState<ReportRange>('3M')
+
+  const loadData = useCallback(async () => {
+    if (!user) return
+    const res = await getTransactions(
+      user.id,
+      {},
+      { page: 1, pageSize: 500 }
+    )
+    if (res.success && res.data) {
+      setTransactions(res.data.items)
+    }
+    setLoading(false)
+  }, [user])
+
+  useFocusEffect(
+    useCallback(() => {
+      let cancelled = false
+      ;(async () => {
+        if (cancelled) return
+        await loadData()
+      })()
+      return () => {
+        cancelled = true
+      }
+    }, [loadData])
+  )
+
+  const preferredCurrency = user?.preferred_currency ?? 'COP'
+
+  const balanceSeries = useMemo(
+    () =>
+      buildBalanceTimeSeries(transactions, {
+        days: RANGE_DAYS[range],
+        targetCurrency: preferredCurrency,
+        rates,
+      }),
+    [transactions, range, preferredCurrency, rates]
+  )
+
+  const categoryAggregates = useMemo(
+    () =>
+      buildCategoryAggregates(transactions, {
+        targetCurrency: preferredCurrency,
+        rates,
+        // Sin filtro de mes — usamos todas las tx del fetch (los últimos
+        // 500). El rango se interpreta visualmente con el subtítulo.
+      }),
+    [transactions, preferredCurrency, rates]
+  )
+
+  const monthlyAggregates = useMemo(
+    () =>
+      buildMonthlyAggregates(transactions, {
+        months: RANGE_MONTHS[range],
+        targetCurrency: preferredCurrency,
+        rates,
+      }),
+    [transactions, range, preferredCurrency, rates]
+  )
+
+  if (loading) {
+    return (
+      <SafeAreaView edges={['top']} className="flex-1 bg-bg">
+        <View className="flex-1 items-center justify-center">
+          <ActivityIndicator color="#4F46E5" />
+        </View>
+      </SafeAreaView>
+    )
+  }
+
+  return (
+    <SafeAreaView edges={['top']} className="flex-1 bg-bg">
+      <View className="px-4 py-3 border-b border-border">
+        <Text className="text-white text-xl font-bold">Reportes</Text>
+        <Text className="text-muted text-xs mt-0.5">
+          Análisis de los últimos {RANGE_LABEL[range]}
+        </Text>
+      </View>
+
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={{ padding: 16, paddingBottom: 40, gap: 20 }}
+      >
+        <RangeSelector value={range} onChange={setRange} />
+
+        <AccumulatedBalanceChart
+          data={balanceSeries}
+          title="Flujo acumulado"
+          subtitle={`${RANGE_LABEL[range]} · ${preferredCurrency}`}
+        />
+
+        <MonthlyComparisonChart
+          data={monthlyAggregates}
+          title="Ingresos vs gastos"
+          subtitle={`Últimos ${RANGE_MONTHS[range]} meses · ${preferredCurrency}`}
+        />
+
+        <ExpensesByCategoryChart
+          data={categoryAggregates}
+          currency={preferredCurrency}
+          title="Gastos por categoría"
+          subtitle={`Últimas ${transactions.length} transacciones`}
+          limit={12}
+        />
+      </ScrollView>
+    </SafeAreaView>
+  )
+}

--- a/components/reports/RangeSelector.tsx
+++ b/components/reports/RangeSelector.tsx
@@ -1,0 +1,39 @@
+import { View, Text, TouchableOpacity } from 'react-native'
+import { RANGE_LABEL, type ReportRange } from '@/lib/utils/reports'
+
+const RANGES: ReportRange[] = ['1M', '3M', '6M', '1Y']
+
+interface Props {
+  value: ReportRange
+  onChange: (range: ReportRange) => void
+}
+
+/**
+ * Segmented control para elegir rango de tiempo del reporte. Row de chips
+ * activable. El chip activo va con fondo primary; los demás con borde sutil.
+ */
+export function RangeSelector({ value, onChange }: Props) {
+  return (
+    <View className="flex-row gap-2">
+      {RANGES.map((r) => {
+        const active = r === value
+        return (
+          <TouchableOpacity
+            key={r}
+            onPress={() => onChange(r)}
+            activeOpacity={0.7}
+            className={`flex-1 py-2 rounded-xl items-center border ${
+              active
+                ? 'bg-primary border-primary'
+                : 'bg-transparent border-border'
+            }`}
+          >
+            <Text className={active ? 'text-white text-sm font-semibold' : 'text-muted text-sm'}>
+              {RANGE_LABEL[r]}
+            </Text>
+          </TouchableOpacity>
+        )
+      })}
+    </View>
+  )
+}

--- a/components/ui/Icon.tsx
+++ b/components/ui/Icon.tsx
@@ -14,6 +14,11 @@ import {
   Pencil,
   Search,
   Settings,
+  BarChart3,
+  Target,
+  PiggyBank,
+  HandCoins,
+  FolderTree,
 } from 'lucide-react-native'
 
 /**
@@ -42,6 +47,11 @@ const ICONS = {
   edit: Pencil,
   search: Search,
   settings: Settings,
+  chart: BarChart3,
+  target: Target,
+  piggy: PiggyBank,
+  'hand-coins': HandCoins,
+  'folder-tree': FolderTree,
 } as const
 
 export type IconName = keyof typeof ICONS

--- a/lib/utils/reports.ts
+++ b/lib/utils/reports.ts
@@ -1,0 +1,111 @@
+import type {
+  Currency,
+  ExchangeRate,
+  TransactionWithCategory,
+} from '@/types/database.types'
+import type { MonthlyPoint } from '@/components/charts/types'
+
+export type ReportRange = '1M' | '3M' | '6M' | '1Y'
+
+/** Días que mira cada rango para charts diarios (AccumulatedBalance). */
+export const RANGE_DAYS: Record<ReportRange, number> = {
+  '1M': 30,
+  '3M': 90,
+  '6M': 180,
+  '1Y': 365,
+}
+
+/** Meses que mira cada rango para charts mensuales (MonthlyComparison). */
+export const RANGE_MONTHS: Record<ReportRange, number> = {
+  '1M': 3, // siempre mostramos 3 meses mínimo para tener contexto
+  '3M': 3,
+  '6M': 6,
+  '1Y': 12,
+}
+
+export const RANGE_LABEL: Record<ReportRange, string> = {
+  '1M': '1 mes',
+  '3M': '3 meses',
+  '6M': '6 meses',
+  '1Y': '1 año',
+}
+
+function getRate(
+  from: Currency,
+  to: Currency,
+  rates: ExchangeRate[]
+): number {
+  if (from === to) return 1
+  const r = rates.find(
+    (x) => x.from_currency === from && x.to_currency === to
+  )
+  return r ? Number(r.rate) : 1
+}
+
+function shortMonthLabel(year: number, month: number): string {
+  const date = new Date(year, month, 1)
+  // 'ene', 'feb', etc. Con año si hay rango cruzado: 'ene 25'
+  return date
+    .toLocaleDateString('es', { month: 'short' })
+    .replace('.', '')
+    .toLowerCase()
+}
+
+/**
+ * Agrupa transactions por mes calendario (NO ventana móvil) y devuelve los
+ * últimos N meses con income/expense en target currency.
+ *
+ * Algoritmo:
+ *   1. Generar slots `YYYY-MM` desde hace `months - 1` meses hasta el actual.
+ *   2. Para cada tx, sumar al slot del mes correspondiente con conversion.
+ *   3. Mapear a MonthlyPoint con label corto (ene, feb, ...).
+ *
+ * Cross-year se anota con el año pegado: "dic 25", "ene 26".
+ */
+export function buildMonthlyAggregates(
+  transactions: TransactionWithCategory[],
+  options: {
+    months: number
+    targetCurrency: Currency
+    rates: ExchangeRate[]
+  }
+): MonthlyPoint[] {
+  const { months, targetCurrency, rates } = options
+  if (months <= 0) return []
+
+  const now = new Date()
+  const slots: { key: string; year: number; month: number }[] = []
+  for (let i = months - 1; i >= 0; i--) {
+    const d = new Date(now.getFullYear(), now.getMonth() - i, 1)
+    const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`
+    slots.push({ key, year: d.getFullYear(), month: d.getMonth() })
+  }
+
+  const byKey: Record<string, { income: number; expense: number }> = {}
+  for (const s of slots) byKey[s.key] = { income: 0, expense: 0 }
+
+  for (const t of transactions) {
+    const key = t.date.slice(0, 7) // YYYY-MM
+    if (!(key in byKey)) continue
+    const amount =
+      Number(t.amount) * getRate(t.currency, targetCurrency, rates)
+    if (t.type === 'income') byKey[key].income += amount
+    else if (t.type === 'expense') byKey[key].expense += amount
+  }
+
+  // Detectar si hay años distintos en el rango para añadir el sufijo de año
+  const years = new Set(slots.map((s) => s.year))
+  const showYear = years.size > 1
+
+  return slots.map((s) => {
+    const base = shortMonthLabel(s.year, s.month)
+    const label = showYear
+      ? `${base} ${String(s.year).slice(-2)}`
+      : base
+    return {
+      label,
+      income: byKey[s.key].income,
+      expense: byKey[s.key].expense,
+    }
+  })
+}


### PR DESCRIPTION
Closes #82 · Related to #77 (FASE 4) · **Última tarea de FASE 4**

## Cambios

### Backend / Helpers
- **\`lib/utils/reports.ts\`** — \`ReportRange\` ('1M' | '3M' | '6M' | '1Y') con mappings \`RANGE_DAYS\` / \`RANGE_MONTHS\` / \`RANGE_LABEL\`.
- **\`buildMonthlyAggregates(tx, { months, targetCurrency, rates })\`** — agrupa transactions por **mes calendar** (NO ventana móvil como budgets), convierte amounts a target currency, devuelve \`MonthlyPoint[]\` con labels cortos. Si el rango cruza años, añade sufijo: \`dic 25\`, \`ene 26\`.

### UI
- **\`components/reports/RangeSelector.tsx\`** — segmented control de 4 chips horizontales. El activo con \`bg-primary\`.
- **\`app/(dashboard)/reports/_layout.tsx\` + \`index.tsx\`** — pantalla nueva:
  - \`getTransactions\` con \`pageSize: 500\` + \`useExchangeRates\`
  - Derivados memoizados con \`useMemo\` por cambio de \`range\`
  - Composición: RangeSelector → AccumulatedBalance → MonthlyComparison → ExpensesByCategory

### Tab bar reorg
- **Reports añadido** como 3er tab con icono \`chart\` (\`BarChart3\` de lucide).
- **Cuentas movida a \`href: null\`** + link en \`more.tsx > Datos\`. Sigue navegable con \`router.push('/accounts')\`.
- Tab bar final: **Dashboard · Transacciones · Reportes · Más** (4 tabs).

### Iconos nuevos (\`components/ui/Icon.tsx\`)
- \`chart\` (BarChart3) — tab Reportes
- \`target\` — Presupuestos
- \`piggy\` (PiggyBank) — Metas de ahorro
- \`hand-coins\` — Préstamos
- \`folder-tree\` — Categorías

Reasignados en \`more.tsx\` para que cada entrada tenga icono propio (antes Cuentas y Presupuestos ambos usaban \`wallet\`).

## Verificación

- [x] \`npx tsc --noEmit\` limpio
- [ ] Smoke test: navegar a Reports, cambiar rangos, los 3 charts se actualizan
- [ ] Tab bar: 4 tabs, ningún ▼ default
- [ ] "Más > Datos" muestra Cuentas + iconos correctos

## Notas para Obsidian

- Bitácora \`T-4.3 — Reports screen.md\`
- Sin concepto nuevo grande — el patrón "agrupación por mes calendar" se documenta en la bitácora misma como contraste con la ventana móvil de budgets.

## Cierre de FASE 4

Después del merge: PR \`develop → main\` con título \`FASE 4: Dashboard y reportes\` y stop+aprobación según workflow.