### PR TITLE
FASE 4: Dashboard y reportes

### DIFF
--- a/app/(dashboard)/_layout.tsx
+++ b/app/(dashboard)/_layout.tsx
@@ -48,11 +48,11 @@ export default function DashboardLayout() {
         }}
       />
       <Tabs.Screen
-        name="accounts"
+        name="reports"
         options={{
-          title: 'Cuentas',
+          title: 'Reportes',
           tabBarIcon: ({ color, size }) => (
-            <Icon name="wallet" color={color} size={size} />
+            <Icon name="chart" color={color} size={size} />
           ),
         }}
       />
@@ -72,6 +72,7 @@ export default function DashboardLayout() {
         descubre automáticamente al tener _layout.tsx; href: null los
         oculta del tab bar pero quedan navegables con router.push('/xxx').
       */}
+      <Tabs.Screen name="accounts" options={{ href: null }} />
       <Tabs.Screen name="categories" options={{ href: null }} />
       <Tabs.Screen name="budgets" options={{ href: null }} />
       <Tabs.Screen name="savings" options={{ href: null }} />

--- a/app/(dashboard)/_layout.tsx
+++ b/app/(dashboard)/_layout.tsx
@@ -65,6 +65,17 @@ export default function DashboardLayout() {
           ),
         }}
       />
+
+      {/*
+        Hubs accesibles desde la pantalla "Más" — NO se exponen como tabs
+        directos para mantener el bottom bar limpio. expo-router los
+        descubre automáticamente al tener _layout.tsx; href: null los
+        oculta del tab bar pero quedan navegables con router.push('/xxx').
+      */}
+      <Tabs.Screen name="categories" options={{ href: null }} />
+      <Tabs.Screen name="budgets" options={{ href: null }} />
+      <Tabs.Screen name="savings" options={{ href: null }} />
+      <Tabs.Screen name="loans" options={{ href: null }} />
     </Tabs>
   )
 }

--- a/app/(dashboard)/index.tsx
+++ b/app/(dashboard)/index.tsx
@@ -1,13 +1,36 @@
 // app/(dashboard)/index.tsx
-import { View, Text } from 'react-native'
+//
+// T-4.1 placeholder: muestra los tres charts con mock data para verificar
+// que victory-native + Skia están configurados correctamente. T-4.2 va a
+// reemplazar esto con datos reales y summary cards.
+import { ScrollView, View, Text } from 'react-native'
+import { SafeAreaView } from 'react-native-safe-area-context'
 import { useAuth } from '@/context/AuthContext'
+import { DemoAccumulatedBalanceChart } from '@/components/charts/AccumulatedBalanceChart'
+import { DemoExpensesByCategoryChart } from '@/components/charts/ExpensesByCategoryChart'
+import { DemoMonthlyComparisonChart } from '@/components/charts/MonthlyComparisonChart'
 
 export default function DashboardScreen() {
   const { user } = useAuth()
   return (
-    <View className="flex-1 bg-bg items-center justify-center">
-      <Text className="text-white text-xl font-bold">Dashboard</Text>
-      <Text className="text-muted mt-2">Hola, {user?.name ?? user?.email}</Text>
-    </View>
+    <SafeAreaView edges={['top']} className="flex-1 bg-bg">
+      <View className="px-4 py-3 border-b border-border">
+        <Text className="text-white text-xl font-bold">Dashboard</Text>
+        <Text className="text-muted text-xs mt-0.5">
+          Hola, {user?.name ?? user?.email}
+        </Text>
+      </View>
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={{ padding: 16, gap: 16 }}
+      >
+        <Text className="text-amber-400 text-xs">
+          T-4.1: preview con mock data. T-4.2 conecta datos reales.
+        </Text>
+        <DemoAccumulatedBalanceChart />
+        <DemoExpensesByCategoryChart />
+        <DemoMonthlyComparisonChart />
+      </ScrollView>
+    </SafeAreaView>
   )
 }

--- a/app/(dashboard)/index.tsx
+++ b/app/(dashboard)/index.tsx
@@ -1,35 +1,157 @@
 // app/(dashboard)/index.tsx
 //
-// T-4.1 placeholder: muestra los tres charts con mock data para verificar
-// que victory-native + Skia están configurados correctamente. T-4.2 va a
-// reemplazar esto con datos reales y summary cards.
-import { ScrollView, View, Text } from 'react-native'
+// Dashboard real (T-4.2). Carga en paralelo:
+//   - Transactions de los últimos 60 días con category join
+//   - Budgets con spent calculado (BudgetWithSpent[])
+//   - Exchange rates (cacheadas via useExchangeRates)
+//
+// Compone: SummaryCards · AccumulatedBalanceChart · ExpensesByCategoryChart
+//          · RecentTransactions · ActiveBudgets
+//
+// Refresh on focus con useFocusEffect — al volver al tab se actualiza.
+import { useCallback, useMemo, useState } from 'react'
+import { ScrollView, View, Text, ActivityIndicator } from 'react-native'
+import { useFocusEffect } from 'expo-router'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useAuth } from '@/context/AuthContext'
-import { DemoAccumulatedBalanceChart } from '@/components/charts/AccumulatedBalanceChart'
-import { DemoExpensesByCategoryChart } from '@/components/charts/ExpensesByCategoryChart'
-import { DemoMonthlyComparisonChart } from '@/components/charts/MonthlyComparisonChart'
+import { useExchangeRates } from '@/hooks/useExchangeRates'
+import { getTransactions } from '@/lib/actions/transactions.actions'
+import { getBudgets } from '@/lib/actions/budgets.actions'
+import {
+  buildBalanceTimeSeries,
+  buildCategoryAggregates,
+  currentMonthPrefix,
+} from '@/lib/utils/dashboard'
+import { SummaryCards } from '@/components/dashboard/SummaryCards'
+import { RecentTransactions } from '@/components/dashboard/RecentTransactions'
+import { ActiveBudgets } from '@/components/dashboard/ActiveBudgets'
+import { AccumulatedBalanceChart } from '@/components/charts/AccumulatedBalanceChart'
+import { ExpensesByCategoryChart } from '@/components/charts/ExpensesByCategoryChart'
+import type {
+  BudgetWithSpent,
+  TransactionWithCategory,
+} from '@/types/database.types'
+
+const MONTH_LABEL = (() => {
+  const d = new Date()
+  return d
+    .toLocaleDateString('es', { month: 'long', year: 'numeric' })
+    .replace(/^\w/, (c) => c.toUpperCase())
+})()
 
 export default function DashboardScreen() {
   const { user } = useAuth()
+  const { rates } = useExchangeRates()
+  const [transactions, setTransactions] = useState<TransactionWithCategory[]>([])
+  const [budgets, setBudgets] = useState<BudgetWithSpent[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const loadData = useCallback(async () => {
+    if (!user) return
+    const [txRes, budgetsRes] = await Promise.all([
+      // 60 días alcanza para el chart de 30 + las 5 recientes + un buffer
+      getTransactions(
+        user.id,
+        {
+          month: undefined, // sin filtro de mes — el client filtra el rango por fecha
+        },
+        { page: 1, pageSize: 200 }
+      ),
+      getBudgets(user.id),
+    ])
+
+    if (txRes.success && txRes.data) {
+      setTransactions(txRes.data.items)
+    }
+    if (budgetsRes.success && budgetsRes.data) {
+      setBudgets(budgetsRes.data)
+    }
+    setLoading(false)
+  }, [user])
+
+  useFocusEffect(
+    useCallback(() => {
+      let cancelled = false
+      ;(async () => {
+        if (cancelled) return
+        await loadData()
+      })()
+      return () => {
+        cancelled = true
+      }
+    }, [loadData])
+  )
+
+  // Derivados — recomputados solo cuando cambian inputs
+  const monthPrefix = useMemo(() => currentMonthPrefix(), [])
+  const preferredCurrency = user?.preferred_currency ?? 'COP'
+
+  const balanceSeries = useMemo(
+    () =>
+      buildBalanceTimeSeries(transactions, {
+        days: 30,
+        targetCurrency: preferredCurrency,
+        rates,
+      }),
+    [transactions, preferredCurrency, rates]
+  )
+
+  const categoryAggregates = useMemo(
+    () =>
+      buildCategoryAggregates(transactions, {
+        targetCurrency: preferredCurrency,
+        rates,
+        month: monthPrefix,
+      }),
+    [transactions, preferredCurrency, rates, monthPrefix]
+  )
+
+  if (loading) {
+    return (
+      <SafeAreaView edges={['top']} className="flex-1 bg-bg">
+        <View className="flex-1 items-center justify-center">
+          <ActivityIndicator color="#4F46E5" />
+        </View>
+      </SafeAreaView>
+    )
+  }
+
   return (
     <SafeAreaView edges={['top']} className="flex-1 bg-bg">
       <View className="px-4 py-3 border-b border-border">
         <Text className="text-white text-xl font-bold">Dashboard</Text>
         <Text className="text-muted text-xs mt-0.5">
-          Hola, {user?.name ?? user?.email}
+          {user?.name ? `Hola, ${user.name}` : MONTH_LABEL} · {MONTH_LABEL}
         </Text>
       </View>
+
       <ScrollView
         className="flex-1"
-        contentContainerStyle={{ padding: 16, gap: 16 }}
+        contentContainerStyle={{ padding: 16, paddingBottom: 40, gap: 20 }}
       >
-        <Text className="text-amber-400 text-xs">
-          T-4.1: preview con mock data. T-4.2 conecta datos reales.
-        </Text>
-        <DemoAccumulatedBalanceChart />
-        <DemoExpensesByCategoryChart />
-        <DemoMonthlyComparisonChart />
+        <SummaryCards
+          transactions={transactions}
+          month={monthPrefix}
+          preferredCurrency={preferredCurrency}
+          exchangeRates={rates}
+        />
+
+        <AccumulatedBalanceChart
+          data={balanceSeries}
+          title="Flujo del mes"
+          subtitle={`Últimos 30 días · ${preferredCurrency}`}
+        />
+
+        <ExpensesByCategoryChart
+          data={categoryAggregates}
+          currency={preferredCurrency}
+          title="Gastos por categoría"
+          subtitle={MONTH_LABEL}
+        />
+
+        <RecentTransactions transactions={transactions} limit={5} />
+
+        <ActiveBudgets budgets={budgets} limit={3} />
       </ScrollView>
     </SafeAreaView>
   )

--- a/app/(dashboard)/more.tsx
+++ b/app/(dashboard)/more.tsx
@@ -142,22 +142,27 @@ export default function MoreScreen() {
         {/* Datos */}
         <SectionHeader title="Datos" />
         <SettingsRow
-          icon="dashboard"
+          icon="wallet"
+          label="Cuentas"
+          onPress={() => router.push('/accounts')}
+        />
+        <SettingsRow
+          icon="folder-tree"
           label="Categorías"
           onPress={() => router.push('/categories')}
         />
         <SettingsRow
-          icon="wallet"
+          icon="target"
           label="Presupuestos"
           onPress={() => router.push('/budgets')}
         />
         <SettingsRow
-          icon="arrow-up-circle"
+          icon="piggy"
           label="Metas de ahorro"
           onPress={() => router.push('/savings')}
         />
         <SettingsRow
-          icon="repeat"
+          icon="hand-coins"
           label="Préstamos"
           onPress={() => router.push('/loans')}
         />

--- a/app/(dashboard)/reports/_layout.tsx
+++ b/app/(dashboard)/reports/_layout.tsx
@@ -1,0 +1,13 @@
+import { Stack } from 'expo-router'
+import { colors } from '@/constants/theme'
+
+export default function ReportsLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: colors.bg },
+      }}
+    />
+  )
+}

--- a/app/(dashboard)/reports/index.tsx
+++ b/app/(dashboard)/reports/index.tsx
@@ -1,0 +1,147 @@
+// app/(dashboard)/reports/index.tsx
+//
+// Pantalla de Reports — T-4.3. Renderiza los 3 charts (Accumulated /
+// ExpensesByCategory / MonthlyComparison) con un selector de rango
+// (1M / 3M / 6M / 1Y).
+//
+// Comparte fetch con el dashboard (getTransactions + useExchangeRates).
+// Para rangos largos pedimos pageSize 500 — si el user tiene > 500 tx en
+// el rango, el chart subestima.
+import { useCallback, useMemo, useState } from 'react'
+import { ScrollView, View, Text, ActivityIndicator } from 'react-native'
+import { useFocusEffect } from 'expo-router'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useAuth } from '@/context/AuthContext'
+import { useExchangeRates } from '@/hooks/useExchangeRates'
+import { getTransactions } from '@/lib/actions/transactions.actions'
+import {
+  buildBalanceTimeSeries,
+  buildCategoryAggregates,
+} from '@/lib/utils/dashboard'
+import {
+  buildMonthlyAggregates,
+  RANGE_DAYS,
+  RANGE_MONTHS,
+  RANGE_LABEL,
+  type ReportRange,
+} from '@/lib/utils/reports'
+import { AccumulatedBalanceChart } from '@/components/charts/AccumulatedBalanceChart'
+import { ExpensesByCategoryChart } from '@/components/charts/ExpensesByCategoryChart'
+import { MonthlyComparisonChart } from '@/components/charts/MonthlyComparisonChart'
+import { RangeSelector } from '@/components/reports/RangeSelector'
+import type { TransactionWithCategory } from '@/types/database.types'
+
+export default function ReportsScreen() {
+  const { user } = useAuth()
+  const { rates } = useExchangeRates()
+  const [transactions, setTransactions] = useState<TransactionWithCategory[]>([])
+  const [loading, setLoading] = useState(true)
+  const [range, setRange] = useState<ReportRange>('3M')
+
+  const loadData = useCallback(async () => {
+    if (!user) return
+    const res = await getTransactions(
+      user.id,
+      {},
+      { page: 1, pageSize: 500 }
+    )
+    if (res.success && res.data) {
+      setTransactions(res.data.items)
+    }
+    setLoading(false)
+  }, [user])
+
+  useFocusEffect(
+    useCallback(() => {
+      let cancelled = false
+      ;(async () => {
+        if (cancelled) return
+        await loadData()
+      })()
+      return () => {
+        cancelled = true
+      }
+    }, [loadData])
+  )
+
+  const preferredCurrency = user?.preferred_currency ?? 'COP'
+
+  const balanceSeries = useMemo(
+    () =>
+      buildBalanceTimeSeries(transactions, {
+        days: RANGE_DAYS[range],
+        targetCurrency: preferredCurrency,
+        rates,
+      }),
+    [transactions, range, preferredCurrency, rates]
+  )
+
+  const categoryAggregates = useMemo(
+    () =>
+      buildCategoryAggregates(transactions, {
+        targetCurrency: preferredCurrency,
+        rates,
+        // Sin filtro de mes — usamos todas las tx del fetch (los últimos
+        // 500). El rango se interpreta visualmente con el subtítulo.
+      }),
+    [transactions, preferredCurrency, rates]
+  )
+
+  const monthlyAggregates = useMemo(
+    () =>
+      buildMonthlyAggregates(transactions, {
+        months: RANGE_MONTHS[range],
+        targetCurrency: preferredCurrency,
+        rates,
+      }),
+    [transactions, range, preferredCurrency, rates]
+  )
+
+  if (loading) {
+    return (
+      <SafeAreaView edges={['top']} className="flex-1 bg-bg">
+        <View className="flex-1 items-center justify-center">
+          <ActivityIndicator color="#4F46E5" />
+        </View>
+      </SafeAreaView>
+    )
+  }
+
+  return (
+    <SafeAreaView edges={['top']} className="flex-1 bg-bg">
+      <View className="px-4 py-3 border-b border-border">
+        <Text className="text-white text-xl font-bold">Reportes</Text>
+        <Text className="text-muted text-xs mt-0.5">
+          Análisis de los últimos {RANGE_LABEL[range]}
+        </Text>
+      </View>
+
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={{ padding: 16, paddingBottom: 40, gap: 20 }}
+      >
+        <RangeSelector value={range} onChange={setRange} />
+
+        <AccumulatedBalanceChart
+          data={balanceSeries}
+          title="Flujo acumulado"
+          subtitle={`${RANGE_LABEL[range]} · ${preferredCurrency}`}
+        />
+
+        <MonthlyComparisonChart
+          data={monthlyAggregates}
+          title="Ingresos vs gastos"
+          subtitle={`Últimos ${RANGE_MONTHS[range]} meses · ${preferredCurrency}`}
+        />
+
+        <ExpensesByCategoryChart
+          data={categoryAggregates}
+          currency={preferredCurrency}
+          title="Gastos por categoría"
+          subtitle={`Últimas ${transactions.length} transacciones`}
+          limit={12}
+        />
+      </ScrollView>
+    </SafeAreaView>
+  )
+}

--- a/components/charts/AccumulatedBalanceChart.tsx
+++ b/components/charts/AccumulatedBalanceChart.tsx
@@ -134,26 +134,3 @@ export function ChartContainer({
   )
 }
 
-/** Mock data para verificación visual en T-4.1. Se borra en T-4.2. */
-export function DemoAccumulatedBalanceChart() {
-  const mock: TimeSeriesPoint[] = [
-    { date: '2026-04-01', value: 1_200_000 },
-    { date: '2026-04-05', value: 1_350_000 },
-    { date: '2026-04-10', value: 1_300_000 },
-    { date: '2026-04-15', value: 1_550_000 },
-    { date: '2026-04-20', value: 1_700_000 },
-    { date: '2026-04-25', value: 1_650_000 },
-    { date: '2026-04-30', value: 1_900_000 },
-    { date: '2026-05-05', value: 1_850_000 },
-    { date: '2026-05-10', value: 2_100_000 },
-    { date: '2026-05-15', value: 2_250_000 },
-    { date: '2026-05-20', value: 2_400_000 },
-  ]
-  return (
-    <AccumulatedBalanceChart
-      data={mock}
-      title="Balance acumulado"
-      subtitle="Últimos 30 días · COP"
-    />
-  )
-}

--- a/components/charts/AccumulatedBalanceChart.tsx
+++ b/components/charts/AccumulatedBalanceChart.tsx
@@ -1,0 +1,159 @@
+import { View, Text } from 'react-native'
+import { CartesianChart, Line, Area } from 'victory-native'
+import { LinearGradient, vec } from '@shopify/react-native-skia'
+import type { TimeSeriesPoint } from './types'
+
+interface Props {
+  data: TimeSeriesPoint[]
+  /** Color principal — default primary. */
+  color?: string
+  /** Altura en px. Default 220. */
+  height?: number
+  /** Título opcional renderizado encima del chart. */
+  title?: string
+  /** Subtítulo opcional. */
+  subtitle?: string
+}
+
+/**
+ * Line + área degradada de un valor acumulado sobre el tiempo.
+ *
+ * Pensado para mostrar balance corrido día a día. El caller normaliza los
+ * datos (fecha YYYY-MM-DD + valor en la currency objetivo); este wrapper
+ * solo dibuja.
+ *
+ * El chart funciona sin font cargada — los ejes no muestran labels para
+ * evitar dependencias con expo-font. La currency y los rangos se muestran
+ * arriba del chart en una row de leyendas mínimas.
+ */
+export function AccumulatedBalanceChart({
+  data,
+  color = '#4F46E5',
+  height = 220,
+  title,
+  subtitle,
+}: Props) {
+  if (data.length === 0) {
+    return (
+      <ChartContainer title={title} subtitle={subtitle} height={height}>
+        <View className="flex-1 items-center justify-center">
+          <Text className="text-muted text-sm">Sin datos para mostrar</Text>
+        </View>
+      </ChartContainer>
+    )
+  }
+
+  // Transformamos las fechas a índices numéricos — victory-native v41
+  // necesita una xKey numérica o categórica simple. La fecha la usamos
+  // como ID y graficamos contra el índice.
+  const chartData = data.map((p, i) => ({
+    i,
+    value: p.value,
+    date: p.date,
+  }))
+
+  const first = data[0].value
+  const last = data[data.length - 1].value
+  const delta = last - first
+  const positive = delta >= 0
+
+  return (
+    <ChartContainer title={title} subtitle={subtitle} height={height}>
+      {/* Header con delta */}
+      <View className="flex-row items-baseline mb-2 px-1">
+        <Text className="text-white text-xl font-bold">
+          {Math.round(last).toLocaleString()}
+        </Text>
+        <Text
+          className={
+            positive ? 'text-green-400 text-xs ml-2' : 'text-red-400 text-xs ml-2'
+          }
+        >
+          {positive ? '↑' : '↓'} {Math.abs(Math.round(delta)).toLocaleString()}
+        </Text>
+      </View>
+
+      <View style={{ flex: 1 }}>
+        <CartesianChart
+          data={chartData}
+          xKey="i"
+          yKeys={['value']}
+          domainPadding={{ top: 12, bottom: 12, left: 8, right: 8 }}
+        >
+          {({ points, chartBounds }) => (
+            <>
+              <Area
+                points={points.value}
+                y0={chartBounds.bottom}
+                animate={{ type: 'timing', duration: 600 }}
+              >
+                <LinearGradient
+                  start={vec(0, 0)}
+                  end={vec(0, chartBounds.bottom)}
+                  colors={[`${color}66`, `${color}00`]}
+                />
+              </Area>
+              <Line
+                points={points.value}
+                color={color}
+                strokeWidth={2.5}
+                animate={{ type: 'timing', duration: 600 }}
+              />
+            </>
+          )}
+        </CartesianChart>
+      </View>
+    </ChartContainer>
+  )
+}
+
+/** Container con title/subtitle reusable (también lo usan los otros charts). */
+export function ChartContainer({
+  title,
+  subtitle,
+  height,
+  children,
+}: {
+  title?: string
+  subtitle?: string
+  height: number
+  children: React.ReactNode
+}) {
+  return (
+    <View className="bg-surface border border-border rounded-2xl p-4">
+      {title ? (
+        <Text className="text-white text-base font-semibold">{title}</Text>
+      ) : null}
+      {subtitle ? (
+        <Text className="text-muted text-xs mt-0.5 mb-2">{subtitle}</Text>
+      ) : (
+        title ? <View className="mb-2" /> : null
+      )}
+      <View style={{ height }}>{children}</View>
+    </View>
+  )
+}
+
+/** Mock data para verificación visual en T-4.1. Se borra en T-4.2. */
+export function DemoAccumulatedBalanceChart() {
+  const mock: TimeSeriesPoint[] = [
+    { date: '2026-04-01', value: 1_200_000 },
+    { date: '2026-04-05', value: 1_350_000 },
+    { date: '2026-04-10', value: 1_300_000 },
+    { date: '2026-04-15', value: 1_550_000 },
+    { date: '2026-04-20', value: 1_700_000 },
+    { date: '2026-04-25', value: 1_650_000 },
+    { date: '2026-04-30', value: 1_900_000 },
+    { date: '2026-05-05', value: 1_850_000 },
+    { date: '2026-05-10', value: 2_100_000 },
+    { date: '2026-05-15', value: 2_250_000 },
+    { date: '2026-05-20', value: 2_400_000 },
+  ]
+  return (
+    <AccumulatedBalanceChart
+      data={mock}
+      title="Balance acumulado"
+      subtitle="Últimos 30 días · COP"
+    />
+  )
+}

--- a/components/charts/ExpensesByCategoryChart.tsx
+++ b/components/charts/ExpensesByCategoryChart.tsx
@@ -79,22 +79,3 @@ export function ExpensesByCategoryChart({
   )
 }
 
-/** Mock data para verificación visual. Se borra en T-4.2. */
-export function DemoExpensesByCategoryChart() {
-  const mock: CategoryAggregate[] = [
-    { name: 'Mercado', icon: '🛒', color: '#10b981', value: 850_000 },
-    { name: 'Restaurantes', icon: '🍽️', color: '#f59e0b', value: 420_000 },
-    { name: 'Transporte', icon: '🚗', color: '#3b82f6', value: 280_000 },
-    { name: 'Servicios', icon: '💡', color: '#a855f7', value: 195_000 },
-    { name: 'Salud', icon: '🏥', color: '#ef4444', value: 130_000 },
-    { name: 'Entretenimiento', icon: '🎬', color: '#ec4899', value: 95_000 },
-  ]
-  return (
-    <ExpensesByCategoryChart
-      data={mock}
-      currency="COP"
-      title="Gastos por categoría"
-      subtitle="Últimos 30 días"
-    />
-  )
-}

--- a/components/charts/ExpensesByCategoryChart.tsx
+++ b/components/charts/ExpensesByCategoryChart.tsx
@@ -1,0 +1,100 @@
+import { View, Text } from 'react-native'
+import { ProgressBar } from '@/components/ui/ProgressBar'
+import { ChartContainer } from './AccumulatedBalanceChart'
+import { formatCurrency } from '@/lib/utils/currency'
+import type { Currency } from '@/types/database.types'
+import type { CategoryAggregate } from './types'
+
+interface Props {
+  data: CategoryAggregate[]
+  currency: Currency
+  title?: string
+  subtitle?: string
+  /** Máximo de categorías a mostrar. Default 8. */
+  limit?: number
+}
+
+/**
+ * "Bar list" de gastos por categoría — barras horizontales con View+flex
+ * en lugar de un chart real. Para mobile esto se ve mucho mejor que un
+ * bar chart vertical con labels truncados, y no requiere Skia ni font
+ * loading.
+ *
+ * Se asume que `data` viene pre-agregada y convertida a la currency objetivo
+ * por el caller (en T-4.2 se hace en el useEffect del dashboard).
+ *
+ * Cada row reusa <ProgressBar /> pasando el color custom de la categoría.
+ */
+export function ExpensesByCategoryChart({
+  data,
+  currency,
+  title,
+  subtitle,
+  limit = 8,
+}: Props) {
+  const total = data.reduce((s, c) => s + c.value, 0)
+  const limited = data.slice(0, limit)
+  const heightEstimate = Math.max(120, limited.length * 56 + 20)
+
+  if (limited.length === 0) {
+    return (
+      <ChartContainer title={title} subtitle={subtitle} height={120}>
+        <View className="flex-1 items-center justify-center">
+          <Text className="text-muted text-sm">Sin datos para mostrar</Text>
+        </View>
+      </ChartContainer>
+    )
+  }
+
+  return (
+    <ChartContainer title={title} subtitle={subtitle} height={heightEstimate}>
+      <View className="gap-3">
+        {limited.map((cat) => {
+          const ratio = total > 0 ? cat.value / total : 0
+          const color = cat.color ?? '#4F46E5'
+          return (
+            <View key={cat.name}>
+              <View className="flex-row items-center mb-1">
+                <Text className="text-lg mr-2">{cat.icon ?? '📂'}</Text>
+                <Text className="text-white text-sm flex-1" numberOfLines={1}>
+                  {cat.name}
+                </Text>
+                <Text className="text-white text-sm font-semibold">
+                  {formatCurrency(cat.value, currency)}
+                </Text>
+              </View>
+              <View className="flex-row items-center gap-2">
+                <View style={{ flex: 1 }}>
+                  <ProgressBar value={ratio} color={color} height={6} />
+                </View>
+                <Text className="text-muted text-xs w-10 text-right">
+                  {Math.round(ratio * 100)}%
+                </Text>
+              </View>
+            </View>
+          )
+        })}
+      </View>
+    </ChartContainer>
+  )
+}
+
+/** Mock data para verificación visual. Se borra en T-4.2. */
+export function DemoExpensesByCategoryChart() {
+  const mock: CategoryAggregate[] = [
+    { name: 'Mercado', icon: '🛒', color: '#10b981', value: 850_000 },
+    { name: 'Restaurantes', icon: '🍽️', color: '#f59e0b', value: 420_000 },
+    { name: 'Transporte', icon: '🚗', color: '#3b82f6', value: 280_000 },
+    { name: 'Servicios', icon: '💡', color: '#a855f7', value: 195_000 },
+    { name: 'Salud', icon: '🏥', color: '#ef4444', value: 130_000 },
+    { name: 'Entretenimiento', icon: '🎬', color: '#ec4899', value: 95_000 },
+  ]
+  return (
+    <ExpensesByCategoryChart
+      data={mock}
+      currency="COP"
+      title="Gastos por categoría"
+      subtitle="Últimos 30 días"
+    />
+  )
+}

--- a/components/charts/MonthlyComparisonChart.tsx
+++ b/components/charts/MonthlyComparisonChart.tsx
@@ -109,21 +109,3 @@ export function MonthlyComparisonChart({
   )
 }
 
-/** Mock data para verificación visual. Se borra en T-4.2. */
-export function DemoMonthlyComparisonChart() {
-  const mock: MonthlyPoint[] = [
-    { label: 'dic', income: 3_200_000, expense: 2_800_000 },
-    { label: 'ene', income: 3_500_000, expense: 3_100_000 },
-    { label: 'feb', income: 3_300_000, expense: 2_900_000 },
-    { label: 'mar', income: 3_700_000, expense: 3_400_000 },
-    { label: 'abr', income: 4_100_000, expense: 3_500_000 },
-    { label: 'may', income: 3_900_000, expense: 3_200_000 },
-  ]
-  return (
-    <MonthlyComparisonChart
-      data={mock}
-      title="Ingresos vs gastos"
-      subtitle="Últimos 6 meses"
-    />
-  )
-}

--- a/components/charts/MonthlyComparisonChart.tsx
+++ b/components/charts/MonthlyComparisonChart.tsx
@@ -1,0 +1,129 @@
+import { View, Text } from 'react-native'
+import { CartesianChart, Bar } from 'victory-native'
+import { ChartContainer } from './AccumulatedBalanceChart'
+import type { MonthlyPoint } from './types'
+
+interface Props {
+  data: MonthlyPoint[]
+  /** Color para income. Default green-500. */
+  incomeColor?: string
+  /** Color para expense. Default red-500. */
+  expenseColor?: string
+  height?: number
+  title?: string
+  subtitle?: string
+}
+
+/**
+ * Barras agrupadas income vs expense por mes.
+ *
+ * victory-native v41 renderiza Bar como barras verticales. Para "barras
+ * agrupadas" (dos series por categoría) se renderizan dos <Bar> con
+ * `barWidth` reducido — el offset visual se logra con la separación natural
+ * entre puntos del eje X.
+ *
+ * En lugar de eje X con labels (requiere font), usamos una row de labels
+ * debajo del chart en HTML/RN normal, alineada a los meses.
+ */
+export function MonthlyComparisonChart({
+  data,
+  incomeColor = '#10b981',
+  expenseColor = '#ef4444',
+  height = 240,
+  title,
+  subtitle,
+}: Props) {
+  if (data.length === 0) {
+    return (
+      <ChartContainer title={title} subtitle={subtitle} height={height}>
+        <View className="flex-1 items-center justify-center">
+          <Text className="text-muted text-sm">Sin datos para mostrar</Text>
+        </View>
+      </ChartContainer>
+    )
+  }
+
+  const chartData = data.map((p, i) => ({
+    i,
+    income: p.income,
+    expense: p.expense,
+  }))
+
+  return (
+    <ChartContainer title={title} subtitle={subtitle} height={height}>
+      {/* Legend */}
+      <View className="flex-row gap-4 mb-2">
+        <View className="flex-row items-center gap-1.5">
+          <View
+            style={{ width: 10, height: 10, backgroundColor: incomeColor, borderRadius: 2 }}
+          />
+          <Text className="text-muted text-xs">Ingresos</Text>
+        </View>
+        <View className="flex-row items-center gap-1.5">
+          <View
+            style={{ width: 10, height: 10, backgroundColor: expenseColor, borderRadius: 2 }}
+          />
+          <Text className="text-muted text-xs">Gastos</Text>
+        </View>
+      </View>
+
+      <View style={{ flex: 1 }}>
+        <CartesianChart
+          data={chartData}
+          xKey="i"
+          yKeys={['income', 'expense']}
+          domainPadding={{ top: 16, bottom: 8, left: 24, right: 24 }}
+        >
+          {({ points, chartBounds }) => (
+            <>
+              <Bar
+                points={points.income}
+                chartBounds={chartBounds}
+                color={incomeColor}
+                barWidth={10}
+                roundedCorners={{ topLeft: 3, topRight: 3 }}
+                animate={{ type: 'timing', duration: 500 }}
+              />
+              <Bar
+                points={points.expense}
+                chartBounds={chartBounds}
+                color={expenseColor}
+                barWidth={10}
+                roundedCorners={{ topLeft: 3, topRight: 3 }}
+                animate={{ type: 'timing', duration: 500 }}
+              />
+            </>
+          )}
+        </CartesianChart>
+      </View>
+
+      {/* Month labels — alineados aproximadamente con cada índice */}
+      <View className="flex-row justify-between mt-1 px-2">
+        {data.map((p) => (
+          <Text key={p.label} className="text-muted text-xs" style={{ width: `${100 / data.length}%`, textAlign: 'center' }}>
+            {p.label}
+          </Text>
+        ))}
+      </View>
+    </ChartContainer>
+  )
+}
+
+/** Mock data para verificación visual. Se borra en T-4.2. */
+export function DemoMonthlyComparisonChart() {
+  const mock: MonthlyPoint[] = [
+    { label: 'dic', income: 3_200_000, expense: 2_800_000 },
+    { label: 'ene', income: 3_500_000, expense: 3_100_000 },
+    { label: 'feb', income: 3_300_000, expense: 2_900_000 },
+    { label: 'mar', income: 3_700_000, expense: 3_400_000 },
+    { label: 'abr', income: 4_100_000, expense: 3_500_000 },
+    { label: 'may', income: 3_900_000, expense: 3_200_000 },
+  ]
+  return (
+    <MonthlyComparisonChart
+      data={mock}
+      title="Ingresos vs gastos"
+      subtitle="Últimos 6 meses"
+    />
+  )
+}

--- a/components/charts/types.ts
+++ b/components/charts/types.ts
@@ -1,0 +1,37 @@
+/**
+ * Tipos compartidos entre los chart wrappers.
+ *
+ * Diseñados para coincidir con los shapes que el web ya construye en sus
+ * actions. Esto permite que un mismo agrupador (server-side o cliente) sirva
+ * a ambos proyectos sin transformaciones intermedias.
+ */
+
+/** Punto en serie temporal — usado por AccumulatedBalanceChart. */
+export interface TimeSeriesPoint {
+  /** YYYY-MM-DD */
+  date: string
+  /** Valor numérico (balance, total, etc.) */
+  value: number
+}
+
+/** Categoría con monto agregado — usado por ExpensesByCategoryChart. */
+export interface CategoryAggregate {
+  /** Nombre legible (Mercado, Salud, etc.) */
+  name: string
+  /** Emoji opcional del category.icon */
+  icon?: string | null
+  /** Color de la categoría — hex */
+  color?: string | null
+  /** Monto agregado en la currency objetivo */
+  value: number
+  /** % del total — calculado por el caller */
+  percent?: number
+}
+
+/** Punto mensual con income+expense — usado por MonthlyComparisonChart. */
+export interface MonthlyPoint {
+  /** Label corto del mes: "ene", "feb", "mar", ..., "ene 25" si hay año mixto */
+  label: string
+  income: number
+  expense: number
+}

--- a/components/dashboard/ActiveBudgets.tsx
+++ b/components/dashboard/ActiveBudgets.tsx
@@ -1,0 +1,81 @@
+import { View, Text, TouchableOpacity } from 'react-native'
+import { router } from 'expo-router'
+import { ProgressBar, defaultColor } from '@/components/ui/ProgressBar'
+import { formatCurrency } from '@/lib/utils/currency'
+import type { BudgetWithSpent } from '@/types/database.types'
+
+interface Props {
+  budgets: BudgetWithSpent[]
+  limit?: number
+}
+
+/**
+ * Widget de presupuestos activos para el dashboard. Muestra los TOP N
+ * ordenados por % consumido descendente — los más urgentes primero
+ * (excedidos y casi excedidos en la cima).
+ *
+ * Si no hay budgets, se omite el componente entero (el caller decide
+ * mostrar un CTA o nada).
+ */
+export function ActiveBudgets({ budgets, limit = 3 }: Props) {
+  if (budgets.length === 0) return null
+
+  const sorted = [...budgets]
+    .sort((a, b) => {
+      const ra = a.amount > 0 ? a.spent / a.amount : 0
+      const rb = b.amount > 0 ? b.spent / b.amount : 0
+      return rb - ra
+    })
+    .slice(0, limit)
+
+  return (
+    <View>
+      <View className="flex-row items-center justify-between mb-2 px-1">
+        <Text className="text-muted text-xs uppercase tracking-wider">
+          Presupuestos
+        </Text>
+        <TouchableOpacity
+          onPress={() => router.push('/budgets')}
+          activeOpacity={0.7}
+        >
+          <Text className="text-primary text-xs">Ver todos →</Text>
+        </TouchableOpacity>
+      </View>
+
+      <View className="gap-2">
+        {sorted.map((b) => {
+          const ratio = b.amount > 0 ? b.spent / b.amount : 0
+          const color = defaultColor(ratio)
+          return (
+            <TouchableOpacity
+              key={b.id}
+              onPress={() => router.push(`/budgets/${b.id}`)}
+              activeOpacity={0.7}
+              className="bg-surface border border-border rounded-2xl p-3"
+            >
+              <View className="flex-row items-center mb-2">
+                <View
+                  style={{ backgroundColor: b.category.color ?? '#4F46E5' }}
+                  className="w-8 h-8 rounded-full items-center justify-center mr-2"
+                >
+                  <Text className="text-sm">{b.category.icon ?? '📂'}</Text>
+                </View>
+                <Text className="text-white text-sm flex-1" numberOfLines={1}>
+                  {b.category.name}
+                </Text>
+                <Text style={{ color }} className="text-sm font-bold">
+                  {Math.round(ratio * 100)}%
+                </Text>
+              </View>
+              <ProgressBar value={ratio} height={6} />
+              <Text className="text-muted text-xs mt-1.5">
+                {formatCurrency(b.spent, b.currency)} de{' '}
+                {formatCurrency(b.amount, b.currency)}
+              </Text>
+            </TouchableOpacity>
+          )
+        })}
+      </View>
+    </View>
+  )
+}

--- a/components/dashboard/RecentTransactions.tsx
+++ b/components/dashboard/RecentTransactions.tsx
@@ -1,0 +1,82 @@
+import { View, Text, TouchableOpacity } from 'react-native'
+import { router } from 'expo-router'
+import { formatCurrency } from '@/lib/utils/currency'
+import type { TransactionWithCategory } from '@/types/database.types'
+
+interface Props {
+  transactions: TransactionWithCategory[]
+  limit?: number
+}
+
+function formatShortDate(iso: string): string {
+  const d = new Date(`${iso}T00:00:00`)
+  return d.toLocaleDateString('es', { day: 'numeric', month: 'short' })
+}
+
+/**
+ * Lista compacta de las últimas N transacciones con link a la pantalla
+ * completa de transacciones. Se asume que `transactions` ya viene ordenado
+ * por fecha desc por el caller.
+ */
+export function RecentTransactions({ transactions, limit = 5 }: Props) {
+  const items = transactions.slice(0, limit)
+
+  return (
+    <View>
+      <View className="flex-row items-center justify-between mb-2 px-1">
+        <Text className="text-muted text-xs uppercase tracking-wider">
+          Últimas transacciones
+        </Text>
+        <TouchableOpacity
+          onPress={() => router.push('/transactions')}
+          activeOpacity={0.7}
+        >
+          <Text className="text-primary text-xs">Ver todas →</Text>
+        </TouchableOpacity>
+      </View>
+
+      <View className="bg-surface border border-border rounded-2xl overflow-hidden">
+        {items.length === 0 ? (
+          <View className="py-6 items-center">
+            <Text className="text-muted text-sm">Sin transacciones</Text>
+          </View>
+        ) : (
+          items.map((tx, idx) => (
+            <TouchableOpacity
+              key={tx.id}
+              onPress={() => router.push(`/transactions/${tx.id}`)}
+              activeOpacity={0.7}
+              className={`flex-row items-center px-4 py-3 ${
+                idx < items.length - 1 ? 'border-b border-border' : ''
+              }`}
+            >
+              <View
+                style={{ backgroundColor: tx.category?.color ?? '#4F46E5' }}
+                className="w-9 h-9 rounded-full items-center justify-center mr-3"
+              >
+                <Text className="text-base">{tx.category?.icon ?? '📂'}</Text>
+              </View>
+              <View className="flex-1">
+                <Text className="text-white text-sm font-medium" numberOfLines={1}>
+                  {tx.description}
+                </Text>
+                <Text className="text-muted text-xs mt-0.5">
+                  {tx.category?.name ?? 'Sin categoría'} ·{' '}
+                  {formatShortDate(tx.date)}
+                </Text>
+              </View>
+              <Text
+                className={`text-sm font-semibold ${
+                  tx.type === 'income' ? 'text-green-400' : 'text-red-400'
+                }`}
+              >
+                {tx.type === 'income' ? '+' : '−'}{' '}
+                {formatCurrency(Number(tx.amount), tx.currency)}
+              </Text>
+            </TouchableOpacity>
+          ))
+        )}
+      </View>
+    </View>
+  )
+}

--- a/components/dashboard/SummaryCards.tsx
+++ b/components/dashboard/SummaryCards.tsx
@@ -1,0 +1,108 @@
+import { View, Text } from 'react-native'
+import { useFinancialSummary } from '@/hooks/useFinancialSummary'
+import { formatCurrency } from '@/lib/utils/currency'
+import type {
+  Currency,
+  ExchangeRate,
+  TransactionWithCategory,
+} from '@/types/database.types'
+
+interface Props {
+  transactions: TransactionWithCategory[]
+  month: string // YYYY-MM
+  preferredCurrency: Currency
+  exchangeRates: ExchangeRate[]
+}
+
+/**
+ * Tres cards apiladas con income / expense / balance del mes activo.
+ * Reúsa el hook useFinancialSummary que ya hace currency conversion.
+ *
+ * Diseño mobile-first: cards en columna (no row de 3) para que los montos
+ * grandes no se trunquen en pantallas chicas. El balance card va arriba con
+ * tamaño extra grande porque es el número más importante.
+ */
+export function SummaryCards({
+  transactions,
+  month,
+  preferredCurrency,
+  exchangeRates,
+}: Props) {
+  const { summary } = useFinancialSummary(
+    transactions,
+    month,
+    preferredCurrency,
+    exchangeRates
+  )
+  const positive = summary.balance >= 0
+
+  return (
+    <View className="gap-3">
+      {/* Balance — hero card */}
+      <View className="bg-surface border border-border rounded-2xl p-5">
+        <Text className="text-muted text-xs uppercase tracking-wider">
+          Balance del mes
+        </Text>
+        <Text
+          className={`text-3xl font-bold mt-1 ${
+            positive ? 'text-white' : 'text-red-400'
+          }`}
+        >
+          {formatCurrency(summary.balance, preferredCurrency)}
+        </Text>
+        <Text className="text-muted text-xs mt-1">
+          {summary.transactionCount}{' '}
+          {summary.transactionCount === 1 ? 'transacción' : 'transacciones'}
+        </Text>
+      </View>
+
+      {/* Income + Expense lado a lado */}
+      <View className="flex-row gap-3">
+        <SummaryItem
+          label="Ingresos"
+          value={formatCurrency(summary.totalIncome, preferredCurrency)}
+          count={summary.incomeCount}
+          accent="green"
+        />
+        <SummaryItem
+          label="Gastos"
+          value={formatCurrency(summary.totalExpense, preferredCurrency)}
+          count={summary.expenseCount}
+          accent="red"
+        />
+      </View>
+    </View>
+  )
+}
+
+function SummaryItem({
+  label,
+  value,
+  count,
+  accent,
+}: {
+  label: string
+  value: string
+  count: number
+  accent: 'green' | 'red'
+}) {
+  return (
+    <View className="flex-1 bg-surface border border-border rounded-2xl p-4">
+      <Text className="text-muted text-xs uppercase tracking-wider">
+        {label}
+      </Text>
+      <Text
+        className={`text-base font-bold mt-1 ${
+          accent === 'green' ? 'text-green-400' : 'text-red-400'
+        }`}
+        numberOfLines={1}
+        adjustsFontSizeToFit
+      >
+        {value}
+      </Text>
+      <Text className="text-muted text-xs mt-1">
+        {count} {count === 1 ? 'tx' : 'tx'}
+      </Text>
+    </View>
+  )
+}

--- a/components/reports/RangeSelector.tsx
+++ b/components/reports/RangeSelector.tsx
@@ -1,0 +1,39 @@
+import { View, Text, TouchableOpacity } from 'react-native'
+import { RANGE_LABEL, type ReportRange } from '@/lib/utils/reports'
+
+const RANGES: ReportRange[] = ['1M', '3M', '6M', '1Y']
+
+interface Props {
+  value: ReportRange
+  onChange: (range: ReportRange) => void
+}
+
+/**
+ * Segmented control para elegir rango de tiempo del reporte. Row de chips
+ * activable. El chip activo va con fondo primary; los demás con borde sutil.
+ */
+export function RangeSelector({ value, onChange }: Props) {
+  return (
+    <View className="flex-row gap-2">
+      {RANGES.map((r) => {
+        const active = r === value
+        return (
+          <TouchableOpacity
+            key={r}
+            onPress={() => onChange(r)}
+            activeOpacity={0.7}
+            className={`flex-1 py-2 rounded-xl items-center border ${
+              active
+                ? 'bg-primary border-primary'
+                : 'bg-transparent border-border'
+            }`}
+          >
+            <Text className={active ? 'text-white text-sm font-semibold' : 'text-muted text-sm'}>
+              {RANGE_LABEL[r]}
+            </Text>
+          </TouchableOpacity>
+        )
+      })}
+    </View>
+  )
+}

--- a/components/ui/Icon.tsx
+++ b/components/ui/Icon.tsx
@@ -14,6 +14,11 @@ import {
   Pencil,
   Search,
   Settings,
+  BarChart3,
+  Target,
+  PiggyBank,
+  HandCoins,
+  FolderTree,
 } from 'lucide-react-native'
 
 /**
@@ -42,6 +47,11 @@ const ICONS = {
   edit: Pencil,
   search: Search,
   settings: Settings,
+  chart: BarChart3,
+  target: Target,
+  piggy: PiggyBank,
+  'hand-coins': HandCoins,
+  'folder-tree': FolderTree,
 } as const
 
 export type IconName = keyof typeof ICONS

--- a/lib/utils/currency.ts
+++ b/lib/utils/currency.ts
@@ -1,17 +1,28 @@
 // lib/utils/currency.ts
 import type { Currency } from '@/types/database.types'
 
+/**
+ * Formatea un monto con el código ISO de moneda (no el símbolo).
+ *
+ * Usamos `currencyDisplay: 'code'` porque la app maneja COP, USD y VES
+ * en la misma pantalla — el símbolo `$` es ambiguo entre COP/USD y `Bs`
+ * solo lo entienden usuarios de Venezuela. Con código ISO no hay duda:
+ *
+ *   formatCurrency(40000, 'COP') → "COP 40.000"
+ *   formatCurrency(40, 'USD')    → "USD 40,00"
+ *   formatCurrency(40, 'VES')    → "VES 40,00"
+ *
+ * Decimales:
+ * - COP: 0 (los centavos colombianos no se usan en práctica)
+ * - USD / VES: 2 (los centavos importan)
+ */
 export function formatCurrency(amount: number, currency: Currency): string {
-  if (currency === 'VES') {
-    return `Bs ${amount.toLocaleString('es-VE', {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    })}`
-  }
+  const fractionDigits = currency === 'COP' ? 0 : 2
   return new Intl.NumberFormat('es-CO', {
     style: 'currency',
     currency,
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
+    currencyDisplay: 'code',
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
   }).format(amount)
 }

--- a/lib/utils/dashboard.ts
+++ b/lib/utils/dashboard.ts
@@ -1,0 +1,146 @@
+import type {
+  Currency,
+  ExchangeRate,
+  TransactionWithCategory,
+} from '@/types/database.types'
+import type {
+  CategoryAggregate,
+  TimeSeriesPoint,
+} from '@/components/charts/types'
+
+/**
+ * Devuelve el multiplicador para convertir `from` → `to`. Si no encuentra
+ * rate, devuelve 1 (degradación silenciosa — el caller puede loguear).
+ */
+function getRate(
+  from: Currency,
+  to: Currency,
+  rates: ExchangeRate[]
+): number {
+  if (from === to) return 1
+  const r = rates.find(
+    (x) => x.from_currency === from && x.to_currency === to
+  )
+  return r ? Number(r.rate) : 1
+}
+
+/**
+ * Construye una serie temporal del **flujo acumulado** en los últimos N días.
+ *
+ * Algoritmo:
+ *   1. Generar un slot por día (hoy hacia atrás N días).
+ *   2. Para cada transaction dentro del rango, sumar/restar al slot del día.
+ *   3. Acumular slot[i] = slot[i-1] + delta[i].
+ *
+ * Es una vista de "cuánto fluyó el balance" durante el período, no el balance
+ * absoluto histórico (que requeriría sumar TODAS las transactions previas).
+ * Para un dashboard de mes corriente, esta vista es más útil que el absoluto.
+ *
+ * Monedas se convierten a `targetCurrency` con las rates provistas.
+ */
+export function buildBalanceTimeSeries(
+  transactions: TransactionWithCategory[],
+  options: {
+    days: number
+    targetCurrency: Currency
+    rates: ExchangeRate[]
+  }
+): TimeSeriesPoint[] {
+  const { days, targetCurrency, rates } = options
+  if (days <= 0) return []
+
+  // Generar fechas YYYY-MM-DD de hoy hacia atrás
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  const dates: string[] = []
+  const deltaByDate: Record<string, number> = {}
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date(today)
+    d.setDate(today.getDate() - i)
+    const iso = d.toISOString().slice(0, 10)
+    dates.push(iso)
+    deltaByDate[iso] = 0
+  }
+  const oldestDate = dates[0]
+
+  for (const t of transactions) {
+    if (t.date < oldestDate) continue
+    if (!(t.date in deltaByDate)) continue // tx en el futuro o fuera de rango
+    const converted =
+      Number(t.amount) * getRate(t.currency, targetCurrency, rates)
+    const sign = t.type === 'income' ? 1 : -1
+    deltaByDate[t.date] += converted * sign
+  }
+
+  // Acumular
+  let running = 0
+  return dates.map((date) => {
+    running += deltaByDate[date]
+    return { date, value: running }
+  })
+}
+
+/**
+ * Agrupa expense transactions por categoría y devuelve totales convertidos a
+ * la currency objetivo. Ordenado desc por value. Calcula percent del total.
+ *
+ * `month` opcional — si se pasa (formato YYYY-MM), filtra solo transactions
+ * cuya fecha empieza con ese prefijo. Si se omite, usa todas las dadas.
+ */
+export function buildCategoryAggregates(
+  transactions: TransactionWithCategory[],
+  options: {
+    targetCurrency: Currency
+    rates: ExchangeRate[]
+    month?: string
+  }
+): CategoryAggregate[] {
+  const { targetCurrency, rates, month } = options
+  const filtered = transactions.filter((t) => {
+    if (t.type !== 'expense') return false
+    if (month && !t.date.startsWith(month)) return false
+    return true
+  })
+
+  type Bucket = { name: string; icon: string | null; color: string | null; value: number }
+  const buckets: Record<string, Bucket> = {}
+
+  for (const t of filtered) {
+    const id = t.category?.id ?? '__no_cat__'
+    const converted =
+      Number(t.amount) * getRate(t.currency, targetCurrency, rates)
+    if (!buckets[id]) {
+      buckets[id] = {
+        name: t.category?.name ?? 'Sin categoría',
+        icon: t.category?.icon ?? null,
+        color: t.category?.color ?? null,
+        value: 0,
+      }
+    }
+    buckets[id].value += converted
+  }
+
+  const arr = Object.values(buckets)
+  const total = arr.reduce((s, b) => s + b.value, 0)
+
+  return arr
+    .map<CategoryAggregate>((b) => ({
+      name: b.name,
+      icon: b.icon,
+      color: b.color,
+      value: b.value,
+      percent: total > 0 ? (b.value / total) * 100 : 0,
+    }))
+    .sort((a, b) => b.value - a.value)
+}
+
+/**
+ * Devuelve el primer día del mes actual en formato YYYY-MM-DD.
+ * Útil para filtrar transactions del mes en curso.
+ */
+export function currentMonthPrefix(): string {
+  const now = new Date()
+  const y = now.getFullYear()
+  const m = String(now.getMonth() + 1).padStart(2, '0')
+  return `${y}-${m}`
+}

--- a/lib/utils/reports.ts
+++ b/lib/utils/reports.ts
@@ -1,0 +1,111 @@
+import type {
+  Currency,
+  ExchangeRate,
+  TransactionWithCategory,
+} from '@/types/database.types'
+import type { MonthlyPoint } from '@/components/charts/types'
+
+export type ReportRange = '1M' | '3M' | '6M' | '1Y'
+
+/** Días que mira cada rango para charts diarios (AccumulatedBalance). */
+export const RANGE_DAYS: Record<ReportRange, number> = {
+  '1M': 30,
+  '3M': 90,
+  '6M': 180,
+  '1Y': 365,
+}
+
+/** Meses que mira cada rango para charts mensuales (MonthlyComparison). */
+export const RANGE_MONTHS: Record<ReportRange, number> = {
+  '1M': 3, // siempre mostramos 3 meses mínimo para tener contexto
+  '3M': 3,
+  '6M': 6,
+  '1Y': 12,
+}
+
+export const RANGE_LABEL: Record<ReportRange, string> = {
+  '1M': '1 mes',
+  '3M': '3 meses',
+  '6M': '6 meses',
+  '1Y': '1 año',
+}
+
+function getRate(
+  from: Currency,
+  to: Currency,
+  rates: ExchangeRate[]
+): number {
+  if (from === to) return 1
+  const r = rates.find(
+    (x) => x.from_currency === from && x.to_currency === to
+  )
+  return r ? Number(r.rate) : 1
+}
+
+function shortMonthLabel(year: number, month: number): string {
+  const date = new Date(year, month, 1)
+  // 'ene', 'feb', etc. Con año si hay rango cruzado: 'ene 25'
+  return date
+    .toLocaleDateString('es', { month: 'short' })
+    .replace('.', '')
+    .toLowerCase()
+}
+
+/**
+ * Agrupa transactions por mes calendario (NO ventana móvil) y devuelve los
+ * últimos N meses con income/expense en target currency.
+ *
+ * Algoritmo:
+ *   1. Generar slots `YYYY-MM` desde hace `months - 1` meses hasta el actual.
+ *   2. Para cada tx, sumar al slot del mes correspondiente con conversion.
+ *   3. Mapear a MonthlyPoint con label corto (ene, feb, ...).
+ *
+ * Cross-year se anota con el año pegado: "dic 25", "ene 26".
+ */
+export function buildMonthlyAggregates(
+  transactions: TransactionWithCategory[],
+  options: {
+    months: number
+    targetCurrency: Currency
+    rates: ExchangeRate[]
+  }
+): MonthlyPoint[] {
+  const { months, targetCurrency, rates } = options
+  if (months <= 0) return []
+
+  const now = new Date()
+  const slots: { key: string; year: number; month: number }[] = []
+  for (let i = months - 1; i >= 0; i--) {
+    const d = new Date(now.getFullYear(), now.getMonth() - i, 1)
+    const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`
+    slots.push({ key, year: d.getFullYear(), month: d.getMonth() })
+  }
+
+  const byKey: Record<string, { income: number; expense: number }> = {}
+  for (const s of slots) byKey[s.key] = { income: 0, expense: 0 }
+
+  for (const t of transactions) {
+    const key = t.date.slice(0, 7) // YYYY-MM
+    if (!(key in byKey)) continue
+    const amount =
+      Number(t.amount) * getRate(t.currency, targetCurrency, rates)
+    if (t.type === 'income') byKey[key].income += amount
+    else if (t.type === 'expense') byKey[key].expense += amount
+  }
+
+  // Detectar si hay años distintos en el rango para añadir el sufijo de año
+  const years = new Set(slots.map((s) => s.year))
+  const showYear = years.size > 1
+
+  return slots.map((s) => {
+    const base = shortMonthLabel(s.year, s.month)
+    const label = showYear
+      ? `${base} ${String(s.year).slice(-2)}`
+      : base
+    return {
+      label,
+      income: byKey[s.key].income,
+      expense: byKey[s.key].expense,
+    }
+  })
+}

--- a/package.json
+++ b/package.json
@@ -37,5 +37,10 @@
     "@types/react": "~19.1.0",
     "typescript": "~5.9.2"
   },
-  "private": true
+  "private": true,
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "@shopify/react-native-skia"
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@insforge/sdk": "^1.2.5",
     "@react-native-community/datetimepicker": "8.4.4",
+    "@shopify/react-native-skia": "^2.6.3",
     "expo": "~54.0.34",
     "expo-auth-session": "~7.0.11",
     "expo-router": "~6.0.23",
@@ -29,6 +30,7 @@
     "react-native-worklets": "0.5.1",
     "sonner-native": "^0.25.1",
     "tailwindcss": "^3.4.17",
+    "victory-native": "^41",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@react-native-community/datetimepicker':
         specifier: 8.4.4
         version: 8.4.4(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@shopify/react-native-skia':
+        specifier: ^2.6.3
+        version: 2.6.3(react-native-reanimated@4.1.7(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       expo:
         specifier: ~54.0.34
         version: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
@@ -68,6 +71,9 @@ importers:
       tailwindcss:
         specifier: ^3.4.17
         version: 3.4.19(yaml@2.8.3)
+      victory-native:
+        specifier: ^41
+        version: 41.20.3(69d0d1b6137f9c30f2540fc291ae31db)
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -1179,6 +1185,19 @@ packages:
   '@react-navigation/routers@7.5.3':
     resolution: {integrity: sha512-1tJHg4KKRJuQ1/EvJxatrMef3NZXEPzwUIUZ3n1yJ2t7Q97siwRtbynRpQG9/69ebbtiZ8W3ScOZF/OmhvM4Rg==}
 
+  '@shopify/react-native-skia@2.6.3':
+    resolution: {integrity: sha512-P31NxwHxv3M5sFTNyD0vTmCMMpMH59ao+WRlVGnODp3d6KFx+IuKR2S/f7FPfs/vMKoP5OMuzVRDwGkR0WKzyA==}
+    hasBin: true
+    peerDependencies:
+      react: '>=19.0'
+      react-native: '>=0.78'
+      react-native-reanimated: '>=3.19.1'
+    peerDependenciesMeta:
+      react-native:
+        optional: true
+      react-native-reanimated:
+        optional: true
+
   '@sinclair/typebox@0.27.10':
     resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
 
@@ -1228,6 +1247,11 @@ packages:
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
+  '@types/react-reconciler@0.28.9':
+    resolution: {integrity: sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==}
+    peerDependencies:
+      '@types/react': '*'
+
   '@types/react@19.1.17':
     resolution: {integrity: sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==}
 
@@ -1251,6 +1275,9 @@ packages:
     resolution: {integrity: sha512-TQMCz2pFJMfpNxmSfX1VSfTjwUIFx/mL+p1bnfM1xjjdla7Z+KnGMW/EhFbpckp3LyWAH4PgOsMwOMnIN+MBFg==}
     peerDependencies:
       '@urql/core': ^5.0.0
+
+  '@webgpu/types@0.1.21':
+    resolution: {integrity: sha512-pUrWq3V5PiSGFLeLxoGqReTZmiiXwY3jRkIG5sLLKjyqNxrwm/04b4nw7LSmGWJcKk59XOM/YRTUwOzo4MMlow==}
 
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
@@ -1488,6 +1515,9 @@ packages:
   caniuse-lite@1.0.30001788:
     resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
 
+  canvaskit-wasm@0.41.0:
+    resolution: {integrity: sha512-cnbL02NFB3yOYMF/MtxViZHgD1vh55Pvy+zR8q4JuFvyCPejZP3eClkt2GuZ0S7jOmGMCJXaHBasbMChbR9JZg==}
+
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
     engines: {node: '>=4'}
@@ -1620,6 +1650,72 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -2108,6 +2204,10 @@ packages:
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
 
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
+
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
@@ -2157,6 +2257,11 @@ packages:
   istanbul-lib-instrument@5.2.1:
     resolution: {integrity: sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==}
     engines: {node: '>=8'}
+
+  its-fine@1.2.5:
+    resolution: {integrity: sha512-fXtDA0X0t0eBYAGLVM5YsgJGsJ5jEmqZEPrGbzdf5awjv0xE7nqv3TVnvtUF060Tkes15DbDAKW/I48vsb6SyA==}
+    peerDependencies:
+      react: '>=18.0'
 
   jest-environment-node@29.7.0:
     resolution: {integrity: sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==}
@@ -3018,6 +3123,18 @@ packages:
       react: '*'
       react-native: '*'
 
+  react-native-skia-android@147.1.0:
+    resolution: {integrity: sha512-pWA0M0G74AhjEop0HLCkjWJMup2HJxOmuUjfPt6kSDhYeWKVx8AEzWh0Fh19ah78zE/s4hD0Of0Tyem5shhiTg==}
+
+  react-native-skia-apple-ios@147.1.0:
+    resolution: {integrity: sha512-cr4rWe4Bf0H0TTutUp5cgHt5/Felttl1bh4BAAAsgAeL2F10FAK9urX8spjUshzMwjqXD7rNOWuFzU6ZcNlGKw==}
+
+  react-native-skia-apple-macos@147.1.0:
+    resolution: {integrity: sha512-Qbv0Y7LgawtRKuGk8gnGeh8nDWwNiu03LcX0mVaQzBBbxFDYvqejanA+AkO3p8gsQb+fsXRc9DAk+U8cBnzZvA==}
+
+  react-native-skia-apple-tvos@147.1.0:
+    resolution: {integrity: sha512-b+4vILXHPu++t8H41PHLBVsTab2LPqwXNdzgdScyl4+Cu8Ta34aUQW3T469cB0ogAMPdu//KV00w4YVpDZoRUQ==}
+
   react-native-svg@15.12.1:
     resolution: {integrity: sha512-vCuZJDf8a5aNC2dlMovEv4Z0jjEUET53lm/iILFnFewa15b4atjVxU6Wirm6O9y6dEsdjDZVD7Q3QM4T1wlI8g==}
     peerDependencies:
@@ -3041,6 +3158,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-reconciler@0.31.0:
+    resolution: {integrity: sha512-7Ob7Z+URmesIsIVRjnLoDGwBEG/tVitidU0nMsqX/eeJaLY89RISO/10ERe0MqmzuKUUB1rmY+h1itMbUHg9BQ==}
+    engines: {node: '>=0.10.0'}
+    peerDependencies:
+      react: ^19.0.0
 
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
@@ -3161,6 +3284,9 @@ packages:
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
+
+  scheduler@0.25.0:
+    resolution: {integrity: sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==}
 
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
@@ -3518,6 +3644,15 @@ packages:
     peerDependencies:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
       react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+
+  victory-native@41.20.3:
+    resolution: {integrity: sha512-cpl5HGcuTbBqc60pxJIxQr6fjJWuKEfxAVgs1TkRXkpVnb480Ty3nYQdAoaqENbkH2FlXibUFI2G7XeNGEOX7Q==}
+    peerDependencies:
+      '@shopify/react-native-skia': '>=1.2.3 <3.0.0'
+      react: '*'
+      react-native: '*'
+      react-native-gesture-handler: '>=2.0.0'
+      react-native-reanimated: '>=3.0.0'
 
   vlq@1.0.1:
     resolution: {integrity: sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==}
@@ -5186,6 +5321,19 @@ snapshots:
     dependencies:
       nanoid: 3.3.11
 
+  '@shopify/react-native-skia@2.6.3(react-native-reanimated@4.1.7(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      canvaskit-wasm: 0.41.0
+      react: 19.1.0
+      react-native-skia-android: 147.1.0
+      react-native-skia-apple-ios: 147.1.0
+      react-native-skia-apple-macos: 147.1.0
+      react-native-skia-apple-tvos: 147.1.0
+      react-reconciler: 0.31.0(react@19.1.0)
+    optionalDependencies:
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
+      react-native-reanimated: 4.1.7(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+
   '@sinclair/typebox@0.27.10': {}
 
   '@sinonjs/commons@3.0.1':
@@ -5247,6 +5395,10 @@ snapshots:
     dependencies:
       undici-types: 7.19.2
 
+  '@types/react-reconciler@0.28.9(@types/react@19.1.17)':
+    dependencies:
+      '@types/react': 19.1.17
+
   '@types/react@19.1.17':
     dependencies:
       csstype: 3.2.3
@@ -5272,6 +5424,8 @@ snapshots:
     dependencies:
       '@urql/core': 5.2.0
       wonka: 6.3.6
+
+  '@webgpu/types@0.1.21': {}
 
   '@xmldom/xmldom@0.8.13': {}
 
@@ -5546,6 +5700,10 @@ snapshots:
 
   caniuse-lite@1.0.30001788: {}
 
+  canvaskit-wasm@0.41.0:
+    dependencies:
+      '@webgpu/types': 0.1.21
+
   chalk@2.4.2:
     dependencies:
       ansi-styles: 3.2.1
@@ -5703,6 +5861,70 @@ snapshots:
   cssesc@3.0.0: {}
 
   csstype@3.2.3: {}
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   debug@2.6.9:
     dependencies:
@@ -6172,6 +6394,8 @@ snapshots:
 
   ini@1.3.8: {}
 
+  internmap@2.0.3: {}
+
   invariant@2.2.4:
     dependencies:
       loose-envify: 1.4.0
@@ -6215,6 +6439,13 @@ snapshots:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
+
+  its-fine@1.2.5(@types/react@19.1.17)(react@19.1.0):
+    dependencies:
+      '@types/react-reconciler': 0.28.9(@types/react@19.1.17)
+      react: 19.1.0
+    transitivePeerDependencies:
+      - '@types/react'
 
   jest-environment-node@29.7.0:
     dependencies:
@@ -7375,6 +7606,14 @@ snapshots:
       react-native-is-edge-to-edge: 1.3.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       warn-once: 0.1.1
 
+  react-native-skia-android@147.1.0: {}
+
+  react-native-skia-apple-ios@147.1.0: {}
+
+  react-native-skia-apple-macos@147.1.0: {}
+
+  react-native-skia-apple-tvos@147.1.0: {}
+
   react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       css-select: 5.2.2
@@ -7448,6 +7687,11 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  react-reconciler@0.31.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      scheduler: 0.25.0
 
   react-refresh@0.14.2: {}
 
@@ -7556,6 +7800,8 @@ snapshots:
   safe-buffer@5.2.1: {}
 
   sax@1.6.0: {}
+
+  scheduler@0.25.0: {}
 
   scheduler@0.26.0: {}
 
@@ -7896,6 +8142,21 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
+
+  victory-native@41.20.3(69d0d1b6137f9c30f2540fc291ae31db):
+    dependencies:
+      '@shopify/react-native-skia': 2.6.3(react-native-reanimated@4.1.7(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-zoom: 3.0.0
+      its-fine: 1.2.5(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+      react-fast-compare: 3.2.2
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
+      react-native-gesture-handler: 2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-native-reanimated: 4.1.7(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+    transitivePeerDependencies:
+      - '@types/react'
 
   vlq@1.0.1: {}
 


### PR DESCRIPTION
Cierre de **FASE 4** del plan de migración. Introduce la capa de visualización: charts con Skia + dashboard real + pantalla de reportes.

## Tareas incluidas

- **T-4.1** — Setup victory-native v41 + Skia + chart wrappers (#79)
- **T-4.2** — Dashboard real con summary cards y widgets (#81)
- **T-4.3** — Reports screen + tab bar reorg (#83)

## Cambios visibles para el usuario

### Dashboard
- 3 summary cards: **Balance del mes** (hero) + **Ingresos** + **Gastos**.
- **Flujo del mes** — Line + Area chart con balance acumulado de los últimos 30 días.
- **Gastos por categoría** — bar list con top 8 categorías del mes en curso.
- **Últimas 5 transacciones** con link a la pantalla completa.
- **Top 3 presupuestos** ordenados por % consumido descendente (urgentes primero).
- Refresh on focus al volver al tab.

### Reportes
- Pantalla nueva con range selector: **1M / 3M / 6M / 1Y**.
- Mismos 3 charts pero con rango configurable.
- **MonthlyComparisonChart** debutando: barras agrupadas income vs expense por mes (con sufijo de año si cruza ej. "dic 25", "ene 26").

### Tab bar reorganizado
Antes: Dashboard · Transacciones · Cuentas · Más
Después: **Dashboard · Transacciones · Reportes · Más**

Cuentas movida a "Más > Datos > Cuentas" (sigue accesible, ya no ocupa tab).

### Iconos
5 iconos nuevos para distinguir entradas del menú "Más" (antes Cuentas y Presupuestos compartían \`wallet\`).

## Componentes y patrones nuevos

- **Stack de charts:** \`victory-native\` v41 + \`@shopify/react-native-skia\` v2. Render en UI thread vía Skia (no SVG ni bridge).
- **\`<ProgressBar />\`** reutilizada en 4 contextos (budgets, savings, loans, dashboard widgets).
- **3 chart wrappers** con \`Demo<Chart>\` exports inicialmente (borrados en T-4.2 al conectar datos reales).
- **Helpers puros para agregaciones:**
  - \`buildBalanceTimeSeries(tx, { days, ... })\` — flujo acumulado.
  - \`buildCategoryAggregates(tx, { rates, month?, ... })\` — gastos por categoría.
  - \`buildMonthlyAggregates(tx, { months, ... })\` — mes calendar para grouped bars.
- **Widget components:** \`SummaryCards\`, \`RecentTransactions\`, \`ActiveBudgets\`, \`RangeSelector\`.
- **Fix de pnpm 10:** \`pnpm.onlyBuiltDependencies\` para que Skia ejecute su postinstall y descargue los binarios nativos.
- **Fix de tab bar:** \`href: null\` en hubs accesibles desde "Más" (categories, budgets, savings, loans, accounts). Patrón ya documentado en Obsidian.
- **Fix de currency display:** \`currencyDisplay: 'code'\` en \`formatCurrency\` → \`COP 40.000\` en vez de \`$ 40.000\` (resuelve ambigüedad COP/USD).

## Verificación

- [x] \`npx tsc --noEmit\` limpio en cada PR de tarea.
- [x] Smoke test en iOS simulator (post-rebuild con binarios Skia):
  - [x] Dashboard carga datos reales y refrescha on focus.
  - [x] Charts renderizan sin crashear.
  - [x] Range selector en Reports actualiza los 3 charts.
  - [x] Tab bar muestra 4 tabs reales (sin ▼ default).
  - [x] Cuentas accesible desde "Más > Datos".
  - [x] Montos en código ISO de moneda.
- [x] Cada PR de tarea mergeado con **merge commit** (no squash).

## Cambios técnicos

\`\`\`
 app/(dashboard)/_layout.tsx                   |  18 +-
 app/(dashboard)/index.tsx                     | 154 ++++++++-
 app/(dashboard)/more.tsx                      |  18 +-
 app/(dashboard)/reports/{_layout,index}.tsx   | 160 ++++++++
 components/charts/{3 wrappers + types.ts}     | 425 +++++++++++++++
 components/dashboard/{Summary,Recent,Active}  | 271 +++++++++
 components/reports/RangeSelector.tsx          |  39 ++
 components/ui/{Icon,ProgressBar}.tsx          |  98 ++++
 lib/utils/{dashboard,reports,currency}.ts     | 280 ++++++++++
 package.json + pnpm-lock.yaml                 | 270 ++++++++++
\`\`\`

🛑 **Stop point:** según el workflow, desarrollo detenido hasta aprobación manual de este PR. Una vez mergeado a \`main\` (con **merge commit**, no squash), sincronizar \`develop ← main\` y arrancar **FASE 5 — Productividad**: Tags, Calendario y Recordatorios con \`expo-notifications\`.

Closes #77