### PR TITLE
feat: currency UX en transaction form (T-5.1)

### DIFF
--- a/app/(dashboard)/transactions/[id].tsx
+++ b/app/(dashboard)/transactions/[id].tsx
@@ -15,6 +15,8 @@ import { FormInput } from '@/components/ui/FormInput'
 import { SelectModal } from '@/components/ui/SelectModal'
 import { PrimaryButton } from '@/components/ui/PrimaryButton'
 import { Icon } from '@/components/ui/Icon'
+import { CurrencyPreview } from '@/components/transactions/CurrencyPreview'
+import { formatCurrency } from '@/lib/utils/currency'
 import type { Category, Account, Currency } from '@/types/database.types'
 
 const CURRENCY_OPTIONS = [
@@ -115,6 +117,20 @@ export default function TransactionFormScreen() {
     ])
   }
 
+  /**
+   * Al elegir una cuenta, hereda la currency de la cuenta. Bloquea el
+   * picker de currency mientras haya cuenta — cada cuenta tiene su moneda
+   * fija, no tiene sentido permitir registrar una tx en USD contra una
+   * cuenta COP. Si el user quiere otra currency, primero quita la cuenta.
+   */
+  function handleAccountChange(newAccountId: string) {
+    setAccountId(newAccountId)
+    if (newAccountId) {
+      const acc = accounts.find((a) => a.id === newAccountId)
+      if (acc) setCurrency(acc.currency)
+    }
+  }
+
   const filteredCategories = categories.filter((c) => c.type === type || c.type === 'both')
   const categoryOptions = filteredCategories.map((c) => ({
     label: `${c.icon ?? ''} ${c.name}`.trim(),
@@ -129,6 +145,14 @@ export default function TransactionFormScreen() {
   ]
   const selectedCategory = categories.find((c) => c.id === categoryId)
   const selectedAccount = accounts.find((a) => a.id === accountId)
+
+  // Derivados de validación UX
+  const accountLocksCurrency = !!accountId
+  const parsedAmount = parseFloat(amount) || 0
+  const cardOverLimit =
+    type === 'expense' &&
+    selectedAccount?.type === 'card' &&
+    parsedAmount > Number(selectedAccount.balance ?? 0)
 
   if (initialLoading) {
     return (
@@ -202,13 +226,23 @@ export default function TransactionFormScreen() {
           placeholder="0.00"
         />
 
-        {/* Moneda */}
+        {/* Equivalente en otras monedas — solo si amount > 0 */}
+        <CurrencyPreview amount={parsedAmount} fromCurrency={currency} />
+
+        {/* Moneda — bloqueada si hay cuenta seleccionada */}
         <View className="mb-4">
-          <Text className="text-muted text-sm mb-1">Moneda</Text>
+          <Text className="text-muted text-sm mb-1">
+            Moneda{accountLocksCurrency ? ' (heredada de la cuenta)' : ''}
+          </Text>
           <TouchableOpacity
-            onPress={() => setShowCurrencyPicker(true)}
-            activeOpacity={0.7}
+            onPress={() => {
+              if (accountLocksCurrency) return
+              setShowCurrencyPicker(true)
+            }}
+            activeOpacity={accountLocksCurrency ? 1 : 0.7}
+            disabled={accountLocksCurrency}
             className="bg-surface border border-border rounded-xl px-4 py-3"
+            style={{ opacity: accountLocksCurrency ? 0.5 : 1 }}
           >
             <Text className="text-white">
               {CURRENCY_OPTIONS.find((o) => o.value === currency)?.label ?? currency}
@@ -242,11 +276,21 @@ export default function TransactionFormScreen() {
           >
             <Text className="text-white">
               {selectedAccount
-                ? `${selectedAccount.icon ?? '💳'} ${selectedAccount.name}`
+                ? `${selectedAccount.icon ?? '💳'} ${selectedAccount.name} (${selectedAccount.currency})`
                 : 'Sin cuenta'}
             </Text>
           </TouchableOpacity>
         </View>
+
+        {/* Card overlimit warning */}
+        {cardOverLimit && selectedAccount ? (
+          <View className="mb-4 px-3 py-2 rounded-xl bg-red-500/10 border border-red-500/40">
+            <Text className="text-red-400 text-xs">
+              El monto excede el cupo disponible (
+              {formatCurrency(Number(selectedAccount.balance), selectedAccount.currency)})
+            </Text>
+          </View>
+        ) : null}
 
         <FormInput
           label="Fecha *"
@@ -297,7 +341,7 @@ export default function TransactionFormScreen() {
         title="Seleccionar Cuenta"
         options={accountOptions}
         selected={accountId}
-        onSelect={(v) => { setAccountId(v); setShowAccountPicker(false) }}
+        onSelect={(v) => { handleAccountChange(v); setShowAccountPicker(false) }}
       />
     </SafeAreaView>
   )

--- a/components/transactions/CurrencyPreview.tsx
+++ b/components/transactions/CurrencyPreview.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'react'
+import { View, Text } from 'react-native'
+import { convertCurrency } from '@/lib/actions/exchangeRates.actions'
+import { formatCurrency } from '@/lib/utils/currency'
+import type { Currency } from '@/types/database.types'
+
+const CURRENCIES: Currency[] = ['COP', 'USD', 'VES']
+
+interface Props {
+  amount: number
+  fromCurrency: Currency
+}
+
+/**
+ * Muestra el equivalente del `amount` en las **otras** monedas soportadas
+ * (excluye la `fromCurrency`).
+ *
+ * Fetcha conversiones via `convertCurrency` (action que lee exchange_rates).
+ * Si la rate no existe, `convertCurrency` devuelve el amount sin cambios
+ * (degradación graceful — el componente sigue funcionando pero la cifra
+ * no es real).
+ *
+ * Se oculta solo si amount <= 0 — evitamos parpadeo cuando el user borra
+ * el input.
+ */
+export function CurrencyPreview({ amount, fromCurrency }: Props) {
+  const [conversions, setConversions] = useState<Record<string, number>>({})
+
+  useEffect(() => {
+    if (!amount || amount <= 0) {
+      setConversions({})
+      return
+    }
+
+    let cancelled = false
+    const targets = CURRENCIES.filter((c) => c !== fromCurrency)
+
+    Promise.all(
+      targets.map(async (to) => {
+        const converted = await convertCurrency(amount, fromCurrency, to)
+        return [to, converted] as [Currency, number]
+      })
+    ).then((results) => {
+      if (cancelled) return
+      setConversions(Object.fromEntries(results))
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [amount, fromCurrency])
+
+  if (!amount || amount <= 0 || Object.keys(conversions).length === 0) {
+    return null
+  }
+
+  return (
+    <View className="bg-surface border border-border rounded-xl px-3 py-2 mb-4">
+      <Text className="text-muted text-xs mb-1">Equivalente aproximado</Text>
+      <View className="flex-row flex-wrap gap-4">
+        {Object.entries(conversions).map(([currency, value]) => (
+          <Text key={currency} className="text-white text-sm">
+            {formatCurrency(value, currency as Currency)}
+          </Text>
+        ))}
+      </View>
+    </View>
+  )
+}


### PR DESCRIPTION
Closes #87 · Related to #86 (FASE 5)

## Cambios

### Componente nuevo
**\`components/transactions/CurrencyPreview.tsx\`** — port del web. Mientras el user escribe el \`amount\`, fetcha conversiones a las otras 2 monedas via \`convertCurrency()\` (action ya existente) y las muestra como una lista compacta debajo del input. Se oculta si \`amount <= 0\`. Cancel cleanup en el effect.

### Update \`app/(dashboard)/transactions/[id].tsx\`
- **\`handleAccountChange(id)\`** — al seleccionar cuenta, setea \`account_id\` Y \`currency\` (con la currency de la cuenta).
- **Currency picker deshabilitado** cuando hay cuenta seleccionada (\`accountLocksCurrency = !!accountId\`). Visual: opacity reducida + label dice "Moneda (heredada de la cuenta)".
- **Card overlimit warning** — derivado \`cardOverLimit\` (\`type=expense\` + \`account.type=card\` + \`amount > balance\`). Render condicional de un box rojo con el cupo. No bloquea guardado.
- **SelectModal de cuenta** llama \`handleAccountChange\` en \`onSelect\`.

## Comportamiento visible

1. Crear nueva tx → escribir monto → ver equivalentes en otras monedas debajo.
2. Elegir cuenta USD → la currency cambia a USD y el picker se "apaga".
3. Volver a "Sin cuenta" → currency picker se reactiva.
4. Si la cuenta es tarjeta y el monto excede el cupo → aparece warning rojo.

## Verificación

- [x] \`npx tsc --noEmit\` limpio
- [ ] Smoke test: crear/editar tx con distintas combinaciones de cuenta/currency

## Notas para Obsidian

- Bitácora \`T-5.1 — Currency UX.md\`
- Sin concepto nuevo — port directo del web, composición de patterns existentes.