### PR TITLE
feat: tab '+' Quick Actions + Profile screen (T-5.2)

### DIFF
--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -94,7 +94,11 @@ export default function LoginScreen() {
         throw new Error('Tu email no está autorizado para usar la app')
       }
 
-      // Create user in our users table if not exists
+      // Sync user row con los claims más recientes de Google. Para users
+      // existentes: actualiza name + avatar_url (importante para que se
+      // refleje cuando el user cambia su foto en Google, o para arreglar
+      // users legacy que se crearon sin avatar). Para users nuevos: crea
+      // la fila con los defaults.
       const { data: existingUser } = await insforge.database
         .from('users')
         .select('id')
@@ -108,6 +112,16 @@ export default function LoginScreen() {
           avatar_url,
           preferred_currency: 'COP',
         }])
+      } else if (name || avatar_url) {
+        // Solo actualizamos los campos que llegaron — evitamos sobreescribir
+        // con null si Google no devolvió alguno.
+        const patch: Record<string, string> = {}
+        if (name) patch.name = name
+        if (avatar_url) patch.avatar_url = avatar_url
+        await insforge.database
+          .from('users')
+          .update(patch)
+          .eq('email', email)
       }
 
       // Persist session (email-based) and load user profile

--- a/app/(dashboard)/_layout.tsx
+++ b/app/(dashboard)/_layout.tsx
@@ -76,9 +76,9 @@ export default function DashboardLayout() {
         <Tabs.Screen
           name="quick-actions"
           options={{
-            title: 'Crear',
+            title: 'Menú',
             tabBarIcon: ({ color, size }) => (
-              <Icon name="plus" color={color} size={size + 4} />
+              <Icon name="menu" color={color} size={size} />
             ),
           }}
           listeners={{

--- a/app/(dashboard)/_layout.tsx
+++ b/app/(dashboard)/_layout.tsx
@@ -1,12 +1,19 @@
 // app/(dashboard)/_layout.tsx
+//
+// Tab bar principal. El tab "+" (Crear) intercepta el tap y abre un bottom
+// sheet con quick actions en lugar de navegar — patrón documentado en
+// Obsidian: 30 - Patterns/Tab-intercepted modal sheet.md
 import { Tabs, router } from 'expo-router'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
+import { View } from 'react-native'
 import { useAuth } from '@/context/AuthContext'
 import { colors } from '@/constants/theme'
 import { Icon } from '@/components/ui/Icon'
+import { QuickActionsSheet } from '@/components/quick-actions/QuickActionsSheet'
 
 export default function DashboardLayout() {
   const { user, loading } = useAuth()
+  const [sheetVisible, setSheetVisible] = useState(false)
 
   useEffect(() => {
     if (!loading && !user) {
@@ -17,66 +24,88 @@ export default function DashboardLayout() {
   if (loading || !user) return null
 
   return (
-    <Tabs
-      screenOptions={{
-        headerShown: false,
-        tabBarStyle: {
-          backgroundColor: colors.surface,
-          borderTopColor: colors.border,
-        },
-        tabBarActiveTintColor: colors.primary,
-        tabBarInactiveTintColor: colors.muted,
-        tabBarLabelStyle: { fontSize: 11 },
-      }}
-    >
-      <Tabs.Screen
-        name="index"
-        options={{
-          title: 'Dashboard',
-          tabBarIcon: ({ color, size }) => (
-            <Icon name="dashboard" color={color} size={size} />
-          ),
+    <View style={{ flex: 1 }}>
+      <Tabs
+        screenOptions={{
+          headerShown: false,
+          tabBarStyle: {
+            backgroundColor: colors.surface,
+            borderTopColor: colors.border,
+          },
+          tabBarActiveTintColor: colors.primary,
+          tabBarInactiveTintColor: colors.muted,
+          tabBarLabelStyle: { fontSize: 11 },
         }}
-      />
-      <Tabs.Screen
-        name="transactions"
-        options={{
-          title: 'Transacciones',
-          tabBarIcon: ({ color, size }) => (
-            <Icon name="transactions" color={color} size={size} />
-          ),
-        }}
-      />
-      <Tabs.Screen
-        name="reports"
-        options={{
-          title: 'Reportes',
-          tabBarIcon: ({ color, size }) => (
-            <Icon name="chart" color={color} size={size} />
-          ),
-        }}
-      />
-      <Tabs.Screen
-        name="more"
-        options={{
-          title: 'Más',
-          tabBarIcon: ({ color, size }) => (
-            <Icon name="menu" color={color} size={size} />
-          ),
-        }}
-      />
+      >
+        <Tabs.Screen
+          name="index"
+          options={{
+            title: 'Dashboard',
+            tabBarIcon: ({ color, size }) => (
+              <Icon name="dashboard" color={color} size={size} />
+            ),
+          }}
+        />
+        <Tabs.Screen
+          name="transactions"
+          options={{
+            title: 'Transacciones',
+            tabBarIcon: ({ color, size }) => (
+              <Icon name="transactions" color={color} size={size} />
+            ),
+          }}
+        />
+        <Tabs.Screen
+          name="reports"
+          options={{
+            title: 'Reportes',
+            tabBarIcon: ({ color, size }) => (
+              <Icon name="chart" color={color} size={size} />
+            ),
+          }}
+        />
 
-      {/*
-        Hubs accesibles desde la pantalla "Más" — NO se exponen como tabs
-        directos para mantener el bottom bar limpio. expo-router los
-        descubre automáticamente al tener _layout.tsx; href: null los
-        oculta del tab bar pero quedan navegables con router.push('/xxx').
-      */}
-      <Tabs.Screen name="accounts" options={{ href: null }} />
-      <Tabs.Screen name="categories" options={{ href: null }} />
-      <Tabs.Screen name="budgets" options={{ href: null }} />
-      <Tabs.Screen name="savings" options={{ href: null }} />
-      <Tabs.Screen name="loans" options={{ href: null }} />
-    </Tabs>
+        {/*
+          Tab "+" — intercepta el tabPress para abrir el sheet de quick
+          actions en lugar de navegar. `href: null` previene el navigate;
+          el listener captura el tap antes de cualquier navegación.
+
+          Apunta a `profile` solo para tener una ruta válida — pero el
+          listener cancela el navigate y abre el sheet.
+        */}
+        <Tabs.Screen
+          name="quick-actions"
+          options={{
+            title: 'Crear',
+            tabBarIcon: ({ color, size }) => (
+              <Icon name="plus" color={color} size={size + 4} />
+            ),
+          }}
+          listeners={{
+            tabPress: (e) => {
+              e.preventDefault()
+              setSheetVisible(true)
+            },
+          }}
+        />
+
+        {/*
+          Hubs accesibles vía router.push, no en el tab bar.
+          - profile: accesible desde el sheet de quick actions
+          - el resto: desde profile > Datos
+        */}
+        <Tabs.Screen name="profile" options={{ href: null }} />
+        <Tabs.Screen name="accounts" options={{ href: null }} />
+        <Tabs.Screen name="categories" options={{ href: null }} />
+        <Tabs.Screen name="budgets" options={{ href: null }} />
+        <Tabs.Screen name="savings" options={{ href: null }} />
+        <Tabs.Screen name="loans" options={{ href: null }} />
+      </Tabs>
+
+      <QuickActionsSheet
+        visible={sheetVisible}
+        onClose={() => setSheetVisible(false)}
+      />
+    </View>
   )
 }

--- a/app/(dashboard)/profile/_layout.tsx
+++ b/app/(dashboard)/profile/_layout.tsx
@@ -1,0 +1,13 @@
+import { Stack } from 'expo-router'
+import { colors } from '@/constants/theme'
+
+export default function ProfileLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: colors.bg },
+      }}
+    />
+  )
+}

--- a/app/(dashboard)/profile/index.tsx
+++ b/app/(dashboard)/profile/index.tsx
@@ -1,4 +1,7 @@
-// app/(dashboard)/more.tsx
+// app/(dashboard)/profile/index.tsx
+//
+// Pantalla de perfil/configuración. Reemplaza al tab "Más" eliminado en
+// T-5.2 — ahora se accede desde el sheet de Quick Actions (último tile).
 import { useState } from 'react'
 import {
   View,
@@ -33,7 +36,7 @@ function formatDate(iso: string | null): string {
   })
 }
 
-export default function MoreScreen() {
+export default function ProfileScreen() {
   const { user, signOut, refreshUser } = useAuth()
   const [showCurrency, setShowCurrency] = useState(false)
   const [savingCurrency, setSavingCurrency] = useState(false)
@@ -67,8 +70,13 @@ export default function MoreScreen() {
 
   return (
     <SafeAreaView edges={['top']} className="flex-1 bg-bg">
-      <View className="px-4 py-3 border-b border-border">
-        <Text className="text-white text-xl font-bold">Más opciones</Text>
+      {/* Header con back */}
+      <View className="flex-row items-center justify-between px-4 py-3 border-b border-border">
+        <TouchableOpacity onPress={() => router.back()} activeOpacity={0.7}>
+          <Text className="text-primary text-base">← Volver</Text>
+        </TouchableOpacity>
+        <Text className="text-white text-base font-bold">Perfil</Text>
+        <View style={{ width: 60 }} />
       </View>
 
       <ScrollView

--- a/app/(dashboard)/profile/index.tsx
+++ b/app/(dashboard)/profile/index.tsx
@@ -20,6 +20,10 @@ import { Icon, type IconName } from '@/components/ui/Icon'
 import { toast } from '@/components/ui/Toast'
 import type { Currency } from '@/types/database.types'
 
+// Los hubs (Cuentas, Categorías, Presupuestos, Metas, Préstamos) están en
+// el menú principal del bottom bar. Esta pantalla se enfoca solo en perfil,
+// preferencias y conexiones del user.
+
 const CURRENCY_OPTIONS: { label: string; value: string }[] = [
   { label: 'COP — Peso Colombiano', value: 'COP' },
   { label: 'USD — Dólar', value: 'USD' },
@@ -146,34 +150,6 @@ export default function ProfileScreen() {
             </View>
           ) : null}
         </View>
-
-        {/* Datos */}
-        <SectionHeader title="Datos" />
-        <SettingsRow
-          icon="wallet"
-          label="Cuentas"
-          onPress={() => router.push('/accounts')}
-        />
-        <SettingsRow
-          icon="folder-tree"
-          label="Categorías"
-          onPress={() => router.push('/categories')}
-        />
-        <SettingsRow
-          icon="target"
-          label="Presupuestos"
-          onPress={() => router.push('/budgets')}
-        />
-        <SettingsRow
-          icon="piggy"
-          label="Metas de ahorro"
-          onPress={() => router.push('/savings')}
-        />
-        <SettingsRow
-          icon="hand-coins"
-          label="Préstamos"
-          onPress={() => router.push('/loans')}
-        />
 
         {/* Sign out */}
         <View className="px-4 pt-10">

--- a/app/(dashboard)/quick-actions.tsx
+++ b/app/(dashboard)/quick-actions.tsx
@@ -1,0 +1,13 @@
+// app/(dashboard)/quick-actions.tsx
+//
+// Ruta dummy — nunca se renderiza en práctica. El tabPress del tab "Crear"
+// se intercepta en _layout.tsx con e.preventDefault() y abre el
+// QuickActionsSheet en su lugar. expo-router exige que el tab apunte a una
+// ruta válida; esta vive solo para satisfacer ese requisito.
+//
+// Ver: 30 - Patterns/Tab-intercepted modal sheet.md
+import { View } from 'react-native'
+
+export default function QuickActionsPlaceholder() {
+  return <View className="flex-1 bg-bg" />
+}

--- a/components/quick-actions/QuickActionsSheet.tsx
+++ b/components/quick-actions/QuickActionsSheet.tsx
@@ -20,40 +20,53 @@ interface ActionTile {
   color: string
 }
 
+/**
+ * Tiles del menú principal. Mezcla de **accesos directos** (Transacción nueva,
+ * único shortcut a creación porque es la acción más frecuente) y **navegación
+ * a listados** (el resto — para ver, gestionar o crear desde su pantalla).
+ *
+ * No incluimos Transacciones como listado porque ya es un tab del bottom bar.
+ */
 const TILES: ActionTile[] = [
   {
-    icon: 'transactions',
-    label: 'Transacción',
+    icon: 'plus',
+    label: 'Nueva transacción',
     route: '/transactions/new',
     color: '#4F46E5',
   },
   {
+    icon: 'wallet',
+    label: 'Cuentas',
+    route: '/accounts',
+    color: '#0ea5e9',
+  },
+  {
     icon: 'folder-tree',
-    label: 'Categoría',
-    route: '/categories/new',
+    label: 'Categorías',
+    route: '/categories',
     color: '#06b6d4',
   },
   {
     icon: 'target',
-    label: 'Presupuesto',
-    route: '/budgets/new',
+    label: 'Presupuestos',
+    route: '/budgets',
     color: '#f59e0b',
   },
   {
     icon: 'piggy',
-    label: 'Meta de ahorro',
-    route: '/savings/new',
+    label: 'Metas de ahorro',
+    route: '/savings',
     color: '#10b981',
   },
   {
     icon: 'hand-coins',
-    label: 'Préstamo',
-    route: '/loans/new',
+    label: 'Préstamos',
+    route: '/loans',
     color: '#a855f7',
   },
   {
     icon: 'arrow-up-circle',
-    label: 'Recordatorio',
+    label: 'Recordatorios',
     comingSoon: 'Recordatorios disponibles próximamente (T-5.3)',
     color: '#ec4899',
   },
@@ -84,9 +97,9 @@ export function QuickActionsSheet({ visible, onClose }: QuickActionsSheetProps) 
 
   return (
     <BottomSheet visible={visible} onClose={onClose} maxHeightPercent={75}>
-      <Text className="text-white text-lg font-bold mb-1">Crear nuevo</Text>
+      <Text className="text-white text-lg font-bold mb-1">Menú principal</Text>
       <Text className="text-muted text-xs mb-4">
-        Elige qué quieres registrar
+        Accesos rápidos y secciones de tu app
       </Text>
 
       {/* Grid 2 col de tiles */}

--- a/components/quick-actions/QuickActionsSheet.tsx
+++ b/components/quick-actions/QuickActionsSheet.tsx
@@ -1,0 +1,142 @@
+import { View, Text, TouchableOpacity } from 'react-native'
+import { router } from 'expo-router'
+import { BottomSheet } from '@/components/ui/BottomSheet'
+import { Icon, type IconName } from '@/components/ui/Icon'
+import { toast } from '@/components/ui/Toast'
+
+interface QuickActionsSheetProps {
+  visible: boolean
+  onClose: () => void
+}
+
+interface ActionTile {
+  icon: IconName
+  label: string
+  /** Si está disponible, se navega a esta ruta al tap. */
+  route?: string
+  /** Si no hay ruta, este mensaje se muestra como toast. */
+  comingSoon?: string
+  /** Color del badge del icono. */
+  color: string
+}
+
+const TILES: ActionTile[] = [
+  {
+    icon: 'transactions',
+    label: 'Transacción',
+    route: '/transactions/new',
+    color: '#4F46E5',
+  },
+  {
+    icon: 'folder-tree',
+    label: 'Categoría',
+    route: '/categories/new',
+    color: '#06b6d4',
+  },
+  {
+    icon: 'target',
+    label: 'Presupuesto',
+    route: '/budgets/new',
+    color: '#f59e0b',
+  },
+  {
+    icon: 'piggy',
+    label: 'Meta de ahorro',
+    route: '/savings/new',
+    color: '#10b981',
+  },
+  {
+    icon: 'hand-coins',
+    label: 'Préstamo',
+    route: '/loans/new',
+    color: '#a855f7',
+  },
+  {
+    icon: 'arrow-up-circle',
+    label: 'Recordatorio',
+    comingSoon: 'Recordatorios disponibles próximamente (T-5.3)',
+    color: '#ec4899',
+  },
+]
+
+/**
+ * Bottom sheet de acciones rápidas — grid 2 columnas de tiles + un row
+ * full-width al final para "Configuración y perfil".
+ *
+ * Cada tile cierra el sheet y navega a la ruta de creación. El item de
+ * Recordatorios todavía no existe (T-5.3) — muestra un toast informativo.
+ */
+export function QuickActionsSheet({ visible, onClose }: QuickActionsSheetProps) {
+  function handleTilePress(tile: ActionTile) {
+    onClose()
+    if (tile.route) {
+      // Pequeño delay para que cierre la animación antes de navegar.
+      setTimeout(() => router.push(tile.route!), 250)
+    } else if (tile.comingSoon) {
+      setTimeout(() => toast(tile.comingSoon!), 250)
+    }
+  }
+
+  function handleProfilePress() {
+    onClose()
+    setTimeout(() => router.push('/profile'), 250)
+  }
+
+  return (
+    <BottomSheet visible={visible} onClose={onClose} maxHeightPercent={75}>
+      <Text className="text-white text-lg font-bold mb-1">Crear nuevo</Text>
+      <Text className="text-muted text-xs mb-4">
+        Elige qué quieres registrar
+      </Text>
+
+      {/* Grid 2 col de tiles */}
+      <View className="flex-row flex-wrap" style={{ marginHorizontal: -4 }}>
+        {TILES.map((tile) => (
+          <View key={tile.label} className="w-1/2 p-1">
+            <TouchableOpacity
+              onPress={() => handleTilePress(tile)}
+              activeOpacity={0.7}
+              className="bg-bg border border-border rounded-2xl p-4 items-center"
+            >
+              <View
+                style={{ backgroundColor: `${tile.color}22` }}
+                className="w-12 h-12 rounded-full items-center justify-center mb-2"
+              >
+                <Icon name={tile.icon} color={tile.color} size={22} />
+              </View>
+              <Text className="text-white text-sm font-medium">
+                {tile.label}
+              </Text>
+            </TouchableOpacity>
+          </View>
+        ))}
+      </View>
+
+      {/* Separador */}
+      <View className="h-px bg-border my-4" />
+
+      {/* Profile — full width */}
+      <TouchableOpacity
+        onPress={handleProfilePress}
+        activeOpacity={0.7}
+        className="bg-bg border border-border rounded-2xl px-4 py-3 flex-row items-center"
+      >
+        <View
+          style={{ backgroundColor: '#6b728022' }}
+          className="w-10 h-10 rounded-full items-center justify-center mr-3"
+        >
+          <Icon name="settings" color="#9ca3af" size={20} />
+        </View>
+        <View className="flex-1">
+          <Text className="text-white text-base font-medium">
+            Configuración y perfil
+          </Text>
+          <Text className="text-muted text-xs">
+            Preferencias, cuenta, datos
+          </Text>
+        </View>
+        <Icon name="chevron-right" color="#6b7280" size={18} />
+      </TouchableOpacity>
+    </BottomSheet>
+  )
+}

--- a/components/ui/BottomSheet.tsx
+++ b/components/ui/BottomSheet.tsx
@@ -1,0 +1,106 @@
+import { useEffect, type ReactNode } from 'react'
+import { Modal, Pressable, View, useWindowDimensions } from 'react-native'
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  Easing,
+  runOnJS,
+} from 'react-native-reanimated'
+
+interface BottomSheetProps {
+  visible: boolean
+  onClose: () => void
+  children: ReactNode
+  /** Altura máxima en % del viewport. Default 60%. */
+  maxHeightPercent?: number
+}
+
+/**
+ * Bottom sheet simple — Modal RN + Animated.View que entra desde abajo con
+ * reanimated. Tap fuera del card cierra.
+ *
+ * Distinto a [[FormDialog]]:
+ * - FormDialog ocupa toda la pantalla (modal full-screen).
+ * - BottomSheet ocupa solo la parte inferior, deja la pantalla visible atrás
+ *   (con un overlay semi-transparente).
+ *
+ * NO incluye drag-to-dismiss ni snap points (para eso `@gorhom/bottom-sheet`).
+ * Sirve para menús de acciones rápidas, action sheets simples y pickers.
+ */
+export function BottomSheet({
+  visible,
+  onClose,
+  children,
+  maxHeightPercent = 60,
+}: BottomSheetProps) {
+  const { height } = useWindowDimensions()
+  const translateY = useSharedValue(height) // empieza fuera de pantalla (abajo)
+
+  useEffect(() => {
+    if (visible) {
+      translateY.value = withTiming(0, {
+        duration: 280,
+        easing: Easing.out(Easing.cubic),
+      })
+    } else {
+      translateY.value = withTiming(height, {
+        duration: 220,
+        easing: Easing.in(Easing.cubic),
+      })
+    }
+  }, [visible, height, translateY])
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: translateY.value }],
+  }))
+
+  /**
+   * Cerrar con la animación inversa antes de llamar onClose. Si llamamos
+   * onClose directo el Modal se desmonta de golpe y se ve el "salto".
+   */
+  function handleClose() {
+    translateY.value = withTiming(
+      height,
+      { duration: 220, easing: Easing.in(Easing.cubic) },
+      (finished) => {
+        if (finished) runOnJS(onClose)()
+      }
+    )
+  }
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="none" // animamos nosotros con reanimated
+      onRequestClose={handleClose}
+      statusBarTranslucent
+    >
+      {/* Overlay tap-to-close */}
+      <Pressable
+        className="flex-1 bg-black/60 justify-end"
+        onPress={handleClose}
+      >
+        {/* El card mismo no propaga el tap */}
+        <Pressable onPress={() => {}}>
+          <Animated.View
+            style={[
+              {
+                maxHeight: `${maxHeightPercent}%`,
+              },
+              animatedStyle,
+            ]}
+            className="bg-surface border-t border-border rounded-t-3xl"
+          >
+            {/* Handle visual (no funcional, solo affordance) */}
+            <View className="items-center pt-3 pb-1">
+              <View className="w-10 h-1 bg-border rounded-full" />
+            </View>
+            <View className="px-4 pb-6 pt-2">{children}</View>
+          </Animated.View>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  )
+}


### PR DESCRIPTION
Closes #89 · Related to #86 (FASE 5)

## Cambios

### Componentes nuevos
- **\`components/ui/BottomSheet.tsx\`** — wrapper genérico Modal + reanimated slide-up. Sin deps nuevas. Tap-outside cierra, animación inversa antes de unmount con \`runOnJS\`. Handle visual sin drag (suficiente para action sheets; si después se necesita drag/snap usaremos \`@gorhom/bottom-sheet\`).
- **\`components/quick-actions/QuickActionsSheet.tsx\`** — usa BottomSheet con grid 2 col de 6 tiles (Transacción / Categoría / Presupuesto / Meta / Préstamo / Recordatorio) + row full-width "Configuración y perfil". Recordatorio dispara toast "Próximamente" (T-5.3).

### Pantallas
- **\`app/(dashboard)/profile/_layout.tsx\` + \`index.tsx\`** — copia del contenido de \`more.tsx\` con header propio (botón Volver + título "Perfil").
- **\`app/(dashboard)/more.tsx\`** eliminado.
- **\`app/(dashboard)/quick-actions.tsx\`** — placeholder dummy. Nunca se renderiza (listener intercepta), pero satisface el requisito de file-based routing de expo-router.

### Tab bar
- Antes: Dashboard · Transacciones · Reportes · Más
- Después: **Dashboard · Transacciones · Reportes · Crear** (+)
- Tap en "Crear" intercepta con \`listeners.tabPress\` + \`e.preventDefault()\` y abre el sheet. Patrón documentado en Obsidian.

## Comportamiento visible

1. Tap en tab "Crear" → abre sheet con grid de acciones.
2. Tap en cualquier tile → cierra el sheet y navega a la ruta de creación (con \`setTimeout 250ms\` para que termine la animación).
3. Tap fuera del sheet → cierra con animación.
4. Tap en "Configuración y perfil" → navega a \`/profile\` con el contenido del antiguo "Más".
5. El tab "Crear" no queda highlighteado (porque nunca se navega a esa ruta) — comportamiento intencional.

## Verificación

- [x] \`npx tsc --noEmit\` limpio
- [ ] Smoke test:
  - [ ] Tab bar muestra "Dashboard · Transacciones · Reportes · Crear"
  - [ ] Tap en "Crear" abre el sheet
  - [ ] Tap en cada tile navega correctamente
  - [ ] Tile de Recordatorio muestra toast
  - [ ] Profile accesible y muestra todo el contenido del antiguo "Más"
  - [ ] Tap fuera del sheet cierra con animación

## Notas para Obsidian

- 🆕 [[Bottom Sheet (Modal-based)]] en \`10 - Concepts/React Native/\`
- 🆕 [[Tab-intercepted modal sheet]] en \`30 - Patterns/\`
- Bitácora \`T-5.2 — Quick Actions FAB.md\`