### PR TITLE
feat: recordatorios + push notifications locales (T-5.3)

### DIFF
--- a/app.json
+++ b/app.json
@@ -42,7 +42,14 @@
       "expo-router",
       "expo-secure-store",
       "expo-web-browser",
-      "@react-native-community/datetimepicker"
+      "@react-native-community/datetimepicker",
+      [
+        "expo-notifications",
+        {
+          "icon": "./assets/icon.png",
+          "color": "#4F46E5"
+        }
+      ]
     ]
   }
 }

--- a/app/(dashboard)/_layout.tsx
+++ b/app/(dashboard)/_layout.tsx
@@ -100,6 +100,7 @@ export default function DashboardLayout() {
         <Tabs.Screen name="budgets" options={{ href: null }} />
         <Tabs.Screen name="savings" options={{ href: null }} />
         <Tabs.Screen name="loans" options={{ href: null }} />
+        <Tabs.Screen name="reminders" options={{ href: null }} />
       </Tabs>
 
       <QuickActionsSheet

--- a/app/(dashboard)/reminders/[id].tsx
+++ b/app/(dashboard)/reminders/[id].tsx
@@ -1,0 +1,424 @@
+import { useEffect, useState } from 'react'
+import {
+  View,
+  Text,
+  ScrollView,
+  TouchableOpacity,
+  KeyboardAvoidingView,
+  Platform,
+  ActivityIndicator,
+  Switch,
+} from 'react-native'
+import { useLocalSearchParams, router } from 'expo-router'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useAuth } from '@/context/AuthContext'
+import {
+  getReminderById,
+  createReminder,
+  updateReminder,
+  deleteReminder,
+} from '@/lib/actions/reminders.actions'
+import { getCategories } from '@/lib/actions/categories.actions'
+import { FormInput } from '@/components/ui/FormInput'
+import { SelectModal } from '@/components/ui/SelectModal'
+import { DateInput } from '@/components/ui/DateInput'
+import { PrimaryButton } from '@/components/ui/PrimaryButton'
+import { confirmDialog } from '@/components/ui/ConfirmDialog'
+import { toast } from '@/components/ui/Toast'
+import type {
+  Category,
+  ReminderFrequency,
+} from '@/types/database.types'
+
+const FREQUENCY_OPTIONS: { value: ReminderFrequency; label: string }[] = [
+  { value: 'once', label: 'Una vez' },
+  { value: 'weekly', label: 'Semanal' },
+  { value: 'monthly', label: 'Mensual' },
+  { value: 'yearly', label: 'Anual' },
+]
+
+const WEEKDAY_OPTIONS = [
+  { label: 'Domingo', value: '0' },
+  { label: 'Lunes', value: '1' },
+  { label: 'Martes', value: '2' },
+  { label: 'Miércoles', value: '3' },
+  { label: 'Jueves', value: '4' },
+  { label: 'Viernes', value: '5' },
+  { label: 'Sábado', value: '6' },
+]
+
+const MONTH_OPTIONS = [
+  { label: 'Enero', value: '1' },
+  { label: 'Febrero', value: '2' },
+  { label: 'Marzo', value: '3' },
+  { label: 'Abril', value: '4' },
+  { label: 'Mayo', value: '5' },
+  { label: 'Junio', value: '6' },
+  { label: 'Julio', value: '7' },
+  { label: 'Agosto', value: '8' },
+  { label: 'Septiembre', value: '9' },
+  { label: 'Octubre', value: '10' },
+  { label: 'Noviembre', value: '11' },
+  { label: 'Diciembre', value: '12' },
+]
+
+// Helper para generar días del mes 1-31
+const DAY_OPTIONS = Array.from({ length: 31 }, (_, i) => ({
+  label: String(i + 1),
+  value: String(i + 1),
+}))
+
+export default function ReminderFormScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>()
+  const { user } = useAuth()
+  const isNew = id === 'new'
+
+  const [initialLoading, setInitialLoading] = useState(!isNew)
+  const [saving, setSaving] = useState(false)
+  const [categories, setCategories] = useState<Category[]>([])
+
+  // Form state
+  const [description, setDescription] = useState('')
+  const [frequency, setFrequency] = useState<ReminderFrequency>('monthly')
+  const [dayOfWeek, setDayOfWeek] = useState<number | null>(null)
+  const [dayOfMonth, setDayOfMonth] = useState<number | null>(null)
+  const [monthOfYear, setMonthOfYear] = useState<number | null>(null)
+  const [specificDate, setSpecificDate] = useState<string>('')
+  const [categoryId, setCategoryId] = useState<string>('')
+  const [isActive, setIsActive] = useState(true)
+
+  // Modal toggles
+  const [showFreqPicker, setShowFreqPicker] = useState(false)
+  const [showDayWeekPicker, setShowDayWeekPicker] = useState(false)
+  const [showDayMonthPicker, setShowDayMonthPicker] = useState(false)
+  const [showMonthPicker, setShowMonthPicker] = useState(false)
+  const [showCategoryPicker, setShowCategoryPicker] = useState(false)
+
+  useEffect(() => {
+    if (!user) return
+    let cancelled = false
+
+    getCategories(user.id).then((res) => {
+      if (cancelled) return
+      if (res.success && res.data) setCategories(res.data)
+    })
+
+    if (!isNew) {
+      getReminderById(id, user.id).then((res) => {
+        if (cancelled) return
+        if (res.success && res.data) {
+          const r = res.data
+          setDescription(r.description)
+          setFrequency(r.frequency)
+          setDayOfWeek(r.day_of_week)
+          setDayOfMonth(r.day_of_month)
+          setMonthOfYear(r.month_of_year)
+          setSpecificDate(r.specific_date ?? '')
+          setCategoryId(r.category_id ?? '')
+          setIsActive(r.is_active)
+        } else {
+          toast.error(res.error ?? 'Recordatorio no encontrado')
+          router.back()
+        }
+        setInitialLoading(false)
+      })
+    }
+
+    return () => {
+      cancelled = true
+    }
+  }, [user, id, isNew])
+
+  function validate(): string | null {
+    if (!description.trim()) return 'La descripción es requerida'
+    if (frequency === 'once' && !specificDate) return 'Selecciona la fecha'
+    if (frequency === 'weekly' && dayOfWeek === null) return 'Selecciona el día de la semana'
+    if (frequency === 'monthly' && !dayOfMonth) return 'Selecciona el día del mes'
+    if (frequency === 'yearly' && (!dayOfMonth || !monthOfYear)) return 'Selecciona mes y día'
+    return null
+  }
+
+  async function handleSubmit() {
+    if (!user) return
+    const err = validate()
+    if (err) {
+      toast.error(err)
+      return
+    }
+    setSaving(true)
+
+    // Solo enviamos los campos relevantes para la frequency — los demás van null
+    const input = {
+      description: description.trim(),
+      frequency,
+      day_of_week: frequency === 'weekly' ? dayOfWeek : null,
+      day_of_month: frequency === 'monthly' || frequency === 'yearly' ? dayOfMonth : null,
+      month_of_year: frequency === 'yearly' ? monthOfYear : null,
+      specific_date: frequency === 'once' ? specificDate : null,
+      category_id: categoryId || null,
+      is_active: isActive,
+    }
+    const result = isNew
+      ? await createReminder(user.id, input)
+      : await updateReminder(id, user.id, input)
+    setSaving(false)
+
+    if (result.success) {
+      toast.success(isNew ? 'Recordatorio creado' : 'Recordatorio actualizado')
+      router.back()
+    } else {
+      toast.error(result.error ?? 'Error al guardar')
+    }
+  }
+
+  async function handleDelete() {
+    if (!user || isNew) return
+    const ok = await confirmDialog({
+      title: 'Eliminar recordatorio',
+      message: 'Se cancelará la notificación programada.',
+      confirmLabel: 'Eliminar',
+      destructive: true,
+    })
+    if (!ok) return
+
+    setSaving(true)
+    const result = await deleteReminder(id, user.id)
+    setSaving(false)
+    if (result.success) {
+      toast.success('Recordatorio eliminado')
+      router.back()
+    } else {
+      toast.error(result.error ?? 'Error al eliminar')
+    }
+  }
+
+  const categoryOptions = [
+    { label: 'Sin categoría', value: '' },
+    ...categories.map((c) => ({
+      label: `${c.icon ?? ''} ${c.name}`.trim(),
+      value: c.id,
+    })),
+  ]
+  const selectedCategory = categories.find((c) => c.id === categoryId)
+
+  if (initialLoading) {
+    return (
+      <View className="flex-1 bg-bg items-center justify-center">
+        <ActivityIndicator color="#4F46E5" />
+      </View>
+    )
+  }
+
+  return (
+    <SafeAreaView edges={['top', 'bottom']} className="flex-1 bg-bg">
+      {/* Header */}
+      <View className="flex-row items-center justify-between px-4 py-3 border-b border-border">
+        <TouchableOpacity onPress={() => router.back()} activeOpacity={0.7}>
+          <Text className="text-primary text-base">← Volver</Text>
+        </TouchableOpacity>
+        <Text className="text-white text-base font-bold">
+          {isNew ? 'Nuevo recordatorio' : 'Editar recordatorio'}
+        </Text>
+        {!isNew ? (
+          <TouchableOpacity onPress={handleDelete} disabled={saving} activeOpacity={0.7}>
+            <Text className="text-red-400 text-sm">Eliminar</Text>
+          </TouchableOpacity>
+        ) : (
+          <View style={{ width: 60 }} />
+        )}
+      </View>
+
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        className="flex-1"
+      >
+        <ScrollView
+          className="flex-1 px-4"
+          contentContainerStyle={{ paddingVertical: 16, paddingBottom: 40 }}
+          keyboardShouldPersistTaps="handled"
+        >
+          <FormInput
+            label="Descripción *"
+            value={description}
+            onChangeText={setDescription}
+            placeholder="Ej: Pagar arriendo"
+          />
+
+          {/* Frequency */}
+          <View className="mb-4">
+            <Text className="text-muted text-sm mb-1">Frecuencia *</Text>
+            <TouchableOpacity
+              onPress={() => setShowFreqPicker(true)}
+              activeOpacity={0.7}
+              className="bg-surface border border-border rounded-xl px-4 py-3"
+            >
+              <Text className="text-white">
+                {FREQUENCY_OPTIONS.find((o) => o.value === frequency)?.label}
+              </Text>
+            </TouchableOpacity>
+          </View>
+
+          {/* Campos condicionales según frequency */}
+          {frequency === 'once' ? (
+            <DateInput
+              label="Fecha *"
+              value={specificDate}
+              onChange={setSpecificDate}
+              minimumDate={new Date()}
+            />
+          ) : null}
+
+          {frequency === 'weekly' ? (
+            <View className="mb-4">
+              <Text className="text-muted text-sm mb-1">Día de la semana *</Text>
+              <TouchableOpacity
+                onPress={() => setShowDayWeekPicker(true)}
+                activeOpacity={0.7}
+                className="bg-surface border border-border rounded-xl px-4 py-3"
+              >
+                <Text className={dayOfWeek !== null ? 'text-white' : 'text-muted'}>
+                  {dayOfWeek !== null
+                    ? WEEKDAY_OPTIONS.find((o) => o.value === String(dayOfWeek))?.label
+                    : 'Seleccionar día...'}
+                </Text>
+              </TouchableOpacity>
+            </View>
+          ) : null}
+
+          {(frequency === 'monthly' || frequency === 'yearly') ? (
+            <View className="mb-4">
+              <Text className="text-muted text-sm mb-1">Día del mes *</Text>
+              <TouchableOpacity
+                onPress={() => setShowDayMonthPicker(true)}
+                activeOpacity={0.7}
+                className="bg-surface border border-border rounded-xl px-4 py-3"
+              >
+                <Text className={dayOfMonth ? 'text-white' : 'text-muted'}>
+                  {dayOfMonth ? `Día ${dayOfMonth}` : 'Seleccionar día...'}
+                </Text>
+              </TouchableOpacity>
+            </View>
+          ) : null}
+
+          {frequency === 'yearly' ? (
+            <View className="mb-4">
+              <Text className="text-muted text-sm mb-1">Mes *</Text>
+              <TouchableOpacity
+                onPress={() => setShowMonthPicker(true)}
+                activeOpacity={0.7}
+                className="bg-surface border border-border rounded-xl px-4 py-3"
+              >
+                <Text className={monthOfYear ? 'text-white' : 'text-muted'}>
+                  {monthOfYear
+                    ? MONTH_OPTIONS.find((o) => o.value === String(monthOfYear))?.label
+                    : 'Seleccionar mes...'}
+                </Text>
+              </TouchableOpacity>
+            </View>
+          ) : null}
+
+          {/* Categoría opcional */}
+          <View className="mb-4">
+            <Text className="text-muted text-sm mb-1">Categoría (opcional)</Text>
+            <TouchableOpacity
+              onPress={() => setShowCategoryPicker(true)}
+              activeOpacity={0.7}
+              className="bg-surface border border-border rounded-xl px-4 py-3"
+            >
+              <Text className={selectedCategory ? 'text-white' : 'text-muted'}>
+                {selectedCategory
+                  ? `${selectedCategory.icon ?? ''} ${selectedCategory.name}`.trim()
+                  : 'Sin categoría'}
+              </Text>
+            </TouchableOpacity>
+          </View>
+
+          {/* is_active toggle */}
+          <View className="mb-6 bg-surface border border-border rounded-xl px-4 py-3 flex-row items-center">
+            <View className="flex-1">
+              <Text className="text-white text-base">Activo</Text>
+              <Text className="text-muted text-xs mt-0.5">
+                Si lo desactivas, no recibirás la notificación
+              </Text>
+            </View>
+            <Switch
+              value={isActive}
+              onValueChange={setIsActive}
+              trackColor={{ false: '#3f3f46', true: '#4F46E5' }}
+              thumbColor="#fff"
+            />
+          </View>
+
+          <Text className="text-muted text-xs mb-4">
+            🔔 Las notificaciones se disparan a las 9:00 AM hora local.
+          </Text>
+
+          <PrimaryButton
+            onPress={handleSubmit}
+            loading={saving}
+            disabled={!description.trim()}
+          >
+            {isNew ? 'Crear recordatorio' : 'Guardar cambios'}
+          </PrimaryButton>
+        </ScrollView>
+      </KeyboardAvoidingView>
+
+      {/* Pickers */}
+      <SelectModal
+        visible={showFreqPicker}
+        onClose={() => setShowFreqPicker(false)}
+        title="Frecuencia"
+        options={FREQUENCY_OPTIONS.map((o) => ({ label: o.label, value: o.value }))}
+        selected={frequency}
+        onSelect={(v) => {
+          setFrequency(v as ReminderFrequency)
+          setShowFreqPicker(false)
+        }}
+      />
+      <SelectModal
+        visible={showDayWeekPicker}
+        onClose={() => setShowDayWeekPicker(false)}
+        title="Día de la semana"
+        options={WEEKDAY_OPTIONS}
+        selected={dayOfWeek !== null ? String(dayOfWeek) : ''}
+        onSelect={(v) => {
+          setDayOfWeek(parseInt(v, 10))
+          setShowDayWeekPicker(false)
+        }}
+      />
+      <SelectModal
+        visible={showDayMonthPicker}
+        onClose={() => setShowDayMonthPicker(false)}
+        title="Día del mes"
+        options={DAY_OPTIONS}
+        selected={dayOfMonth ? String(dayOfMonth) : ''}
+        onSelect={(v) => {
+          setDayOfMonth(parseInt(v, 10))
+          setShowDayMonthPicker(false)
+        }}
+      />
+      <SelectModal
+        visible={showMonthPicker}
+        onClose={() => setShowMonthPicker(false)}
+        title="Mes"
+        options={MONTH_OPTIONS}
+        selected={monthOfYear ? String(monthOfYear) : ''}
+        onSelect={(v) => {
+          setMonthOfYear(parseInt(v, 10))
+          setShowMonthPicker(false)
+        }}
+      />
+      <SelectModal
+        visible={showCategoryPicker}
+        onClose={() => setShowCategoryPicker(false)}
+        title="Categoría"
+        options={categoryOptions}
+        selected={categoryId}
+        onSelect={(v) => {
+          setCategoryId(v)
+          setShowCategoryPicker(false)
+        }}
+      />
+    </SafeAreaView>
+  )
+}

--- a/app/(dashboard)/reminders/_layout.tsx
+++ b/app/(dashboard)/reminders/_layout.tsx
@@ -1,0 +1,13 @@
+import { Stack } from 'expo-router'
+import { colors } from '@/constants/theme'
+
+export default function RemindersLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: colors.bg },
+      }}
+    />
+  )
+}

--- a/app/(dashboard)/reminders/index.tsx
+++ b/app/(dashboard)/reminders/index.tsx
@@ -1,0 +1,192 @@
+import { useCallback, useState } from 'react'
+import {
+  View,
+  Text,
+  FlatList,
+  TouchableOpacity,
+  ActivityIndicator,
+} from 'react-native'
+import { router, useFocusEffect } from 'expo-router'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useAuth } from '@/context/AuthContext'
+import { getReminders } from '@/lib/actions/reminders.actions'
+import { EmptyState } from '@/components/ui/EmptyState'
+import type {
+  ReminderFrequency,
+  ReminderWithCategory,
+} from '@/types/database.types'
+
+const FREQUENCY_LABEL: Record<ReminderFrequency, string> = {
+  once: 'Una vez',
+  weekly: 'Semanal',
+  monthly: 'Mensual',
+  yearly: 'Anual',
+}
+
+const WEEKDAY_NAMES = [
+  'Domingo',
+  'Lunes',
+  'Martes',
+  'Miércoles',
+  'Jueves',
+  'Viernes',
+  'Sábado',
+]
+
+const MONTH_NAMES = [
+  'enero',
+  'febrero',
+  'marzo',
+  'abril',
+  'mayo',
+  'junio',
+  'julio',
+  'agosto',
+  'septiembre',
+  'octubre',
+  'noviembre',
+  'diciembre',
+]
+
+function describeReminder(r: ReminderWithCategory): string {
+  switch (r.frequency) {
+    case 'once':
+      return r.specific_date
+        ? `El ${new Date(`${r.specific_date}T00:00:00`).toLocaleDateString('es', { day: 'numeric', month: 'long', year: 'numeric' })}`
+        : 'Una vez'
+    case 'weekly':
+      return r.day_of_week !== null && r.day_of_week !== undefined
+        ? `Todos los ${WEEKDAY_NAMES[r.day_of_week]}`
+        : 'Semanal'
+    case 'monthly':
+      return r.day_of_month
+        ? `Día ${r.day_of_month} de cada mes`
+        : 'Mensual'
+    case 'yearly':
+      return r.day_of_month && r.month_of_year
+        ? `${r.day_of_month} de ${MONTH_NAMES[r.month_of_year - 1]}`
+        : 'Anual'
+  }
+}
+
+export default function RemindersScreen() {
+  const { user } = useAuth()
+  const [reminders, setReminders] = useState<ReminderWithCategory[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const loadReminders = useCallback(async () => {
+    if (!user) return
+    const res = await getReminders(user.id)
+    if (res.success && res.data) setReminders(res.data)
+    setLoading(false)
+  }, [user])
+
+  useFocusEffect(
+    useCallback(() => {
+      let cancelled = false
+      ;(async () => {
+        await loadReminders()
+        if (cancelled) return
+      })()
+      return () => {
+        cancelled = true
+      }
+    }, [loadReminders])
+  )
+
+  if (loading) {
+    return (
+      <View className="flex-1 bg-bg items-center justify-center">
+        <ActivityIndicator color="#4F46E5" />
+      </View>
+    )
+  }
+
+  return (
+    <SafeAreaView edges={['top']} className="flex-1 bg-bg">
+      {/* Header */}
+      <View className="flex-row items-center justify-between px-4 py-3 border-b border-border">
+        <TouchableOpacity onPress={() => router.back()} activeOpacity={0.7}>
+          <Text className="text-primary text-base">← Volver</Text>
+        </TouchableOpacity>
+        <Text className="text-white text-base font-bold">Recordatorios</Text>
+        <View style={{ width: 60 }} />
+      </View>
+
+      <FlatList
+        data={reminders}
+        keyExtractor={(r) => r.id}
+        contentContainerStyle={
+          reminders.length === 0 ? { flex: 1 } : { paddingVertical: 12 }
+        }
+        ListEmptyComponent={
+          <EmptyState
+            icon="🔔"
+            title="Sin recordatorios"
+            description="Toca + para crear tu primer recordatorio"
+          />
+        }
+        renderItem={({ item }) => <ReminderCard reminder={item} />}
+      />
+
+      {/* FAB */}
+      <TouchableOpacity
+        onPress={() => router.push('/reminders/new')}
+        activeOpacity={0.8}
+        className="absolute bottom-6 right-6 w-14 h-14 rounded-full bg-primary items-center justify-center shadow-lg"
+        style={{
+          shadowColor: '#000',
+          shadowOffset: { width: 0, height: 4 },
+          shadowOpacity: 0.3,
+          shadowRadius: 6,
+          elevation: 6,
+        }}
+      >
+        <Text className="text-white text-3xl font-bold" style={{ lineHeight: 32 }}>
+          +
+        </Text>
+      </TouchableOpacity>
+    </SafeAreaView>
+  )
+}
+
+function ReminderCard({ reminder }: { reminder: ReminderWithCategory }) {
+  const inactive = !reminder.is_active
+  return (
+    <TouchableOpacity
+      onPress={() => router.push(`/reminders/${reminder.id}`)}
+      activeOpacity={0.7}
+      className="mx-4 mb-3 bg-surface border border-border rounded-2xl p-4"
+      style={{ opacity: inactive ? 0.5 : 1 }}
+    >
+      <View className="flex-row items-center mb-1">
+        <Text className="text-2xl mr-3">🔔</Text>
+        <View className="flex-1">
+          <Text className="text-white text-base font-semibold" numberOfLines={1}>
+            {reminder.description}
+          </Text>
+          <Text className="text-muted text-xs mt-0.5">
+            {describeReminder(reminder)} · {FREQUENCY_LABEL[reminder.frequency]}
+          </Text>
+        </View>
+        {inactive ? (
+          <View className="px-2 py-0.5 rounded-full bg-border">
+            <Text className="text-muted text-xs">Pausado</Text>
+          </View>
+        ) : null}
+      </View>
+
+      {reminder.category ? (
+        <View className="flex-row items-center mt-2 ml-9">
+          <View
+            style={{ backgroundColor: reminder.category.color ?? '#4F46E5' }}
+            className="w-5 h-5 rounded-full items-center justify-center mr-1.5"
+          >
+            <Text className="text-xs">{reminder.category.icon ?? '📂'}</Text>
+          </View>
+          <Text className="text-muted text-xs">{reminder.category.name}</Text>
+        </View>
+      ) : null}
+    </TouchableOpacity>
+  )
+}

--- a/app/(dashboard)/reminders/index.tsx
+++ b/app/(dashboard)/reminders/index.tsx
@@ -152,6 +152,12 @@ export default function RemindersScreen() {
 
 function ReminderCard({ reminder }: { reminder: ReminderWithCategory }) {
   const inactive = !reminder.is_active
+  // Avatar = icono + color de la categoría (mismo patrón que transacciones).
+  // Fallback a campanita si el recordatorio no tiene categoría asignada.
+  const hasCategory = !!reminder.category
+  const avatarColor = reminder.category?.color ?? '#4F46E5'
+  const avatarIcon = reminder.category?.icon ?? '🔔'
+
   return (
     <TouchableOpacity
       onPress={() => router.push(`/reminders/${reminder.id}`)}
@@ -159,13 +165,19 @@ function ReminderCard({ reminder }: { reminder: ReminderWithCategory }) {
       className="mx-4 mb-3 bg-surface border border-border rounded-2xl p-4"
       style={{ opacity: inactive ? 0.5 : 1 }}
     >
-      <View className="flex-row items-center mb-1">
-        <Text className="text-2xl mr-3">🔔</Text>
+      <View className="flex-row items-center">
+        <View
+          style={{ backgroundColor: avatarColor }}
+          className="w-10 h-10 rounded-full items-center justify-center mr-3"
+        >
+          <Text className="text-xl">{avatarIcon}</Text>
+        </View>
         <View className="flex-1">
           <Text className="text-white text-base font-semibold" numberOfLines={1}>
             {reminder.description}
           </Text>
-          <Text className="text-muted text-xs mt-0.5">
+          <Text className="text-muted text-xs mt-0.5" numberOfLines={1}>
+            {hasCategory ? `${reminder.category!.name} · ` : ''}
             {describeReminder(reminder)} · {FREQUENCY_LABEL[reminder.frequency]}
           </Text>
         </View>
@@ -175,18 +187,6 @@ function ReminderCard({ reminder }: { reminder: ReminderWithCategory }) {
           </View>
         ) : null}
       </View>
-
-      {reminder.category ? (
-        <View className="flex-row items-center mt-2 ml-9">
-          <View
-            style={{ backgroundColor: reminder.category.color ?? '#4F46E5' }}
-            className="w-5 h-5 rounded-full items-center justify-center mr-1.5"
-          >
-            <Text className="text-xs">{reminder.category.icon ?? '📂'}</Text>
-          </View>
-          <Text className="text-muted text-xs">{reminder.category.name}</Text>
-        </View>
-      ) : null}
     </TouchableOpacity>
   )
 }

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,11 +1,41 @@
 // app/_layout.tsx
-import { Stack } from 'expo-router'
+import { useEffect } from 'react'
+import { Stack, router } from 'expo-router'
 import { SafeAreaProvider } from 'react-native-safe-area-context'
+import * as Notifications from 'expo-notifications'
 import { AuthProvider } from '@/context/AuthContext'
 import { AppToaster } from '@/components/ui/Toast'
+import { ensureAndroidChannel } from '@/lib/utils/notifications'
 import '../global.css'
 
 export default function RootLayout() {
+  /**
+   * Setup global de notifications:
+   *   1. Crear canal Android (idempotente).
+   *   2. Listener para deep-link cuando el user TAPS una notification.
+   *      El payload contiene `data.url` = '/reminders/<id>'.
+   *
+   * El listener funciona tanto si la app está en foreground como background
+   * o killed. Si fue killed, el listener se llama al boot con el último
+   * `notificationResponse` que la disparó.
+   */
+  useEffect(() => {
+    ensureAndroidChannel()
+
+    const subscription = Notifications.addNotificationResponseReceivedListener(
+      (response) => {
+        const data = response.notification.request.content.data as
+          | { url?: string }
+          | null
+        if (data?.url) {
+          router.push(data.url as `/${string}`)
+        }
+      }
+    )
+
+    return () => subscription.remove()
+  }, [])
+
   return (
     <SafeAreaProvider>
       <AuthProvider>

--- a/components/quick-actions/QuickActionsSheet.tsx
+++ b/components/quick-actions/QuickActionsSheet.tsx
@@ -65,7 +65,7 @@ const TILES: ActionTile[] = [
     color: '#a855f7',
   },
   {
-    icon: 'arrow-up-circle',
+    icon: 'bell',
     label: 'Recordatorios',
     route: '/reminders',
     color: '#ec4899',

--- a/components/quick-actions/QuickActionsSheet.tsx
+++ b/components/quick-actions/QuickActionsSheet.tsx
@@ -67,7 +67,7 @@ const TILES: ActionTile[] = [
   {
     icon: 'arrow-up-circle',
     label: 'Recordatorios',
-    comingSoon: 'Recordatorios disponibles próximamente (T-5.3)',
+    route: '/reminders',
     color: '#ec4899',
   },
 ]

--- a/components/ui/Icon.tsx
+++ b/components/ui/Icon.tsx
@@ -19,6 +19,7 @@ import {
   PiggyBank,
   HandCoins,
   FolderTree,
+  Bell,
 } from 'lucide-react-native'
 
 /**
@@ -52,6 +53,7 @@ const ICONS = {
   piggy: PiggyBank,
   'hand-coins': HandCoins,
   'folder-tree': FolderTree,
+  bell: Bell,
 } as const
 
 export type IconName = keyof typeof ICONS

--- a/lib/actions/reminders.actions.ts
+++ b/lib/actions/reminders.actions.ts
@@ -1,0 +1,141 @@
+import { insforge } from '@/lib/insforge'
+import {
+  createReminderSchema,
+  updateReminderSchema,
+  type CreateReminderInput,
+  type UpdateReminderInput,
+} from '@/lib/validations/reminder'
+import type { Reminder, ReminderWithCategory } from '@/types/database.types'
+import {
+  cancelReminderNotification,
+  rescheduleReminderNotification,
+  scheduleReminderNotification,
+} from '@/lib/utils/notifications'
+
+interface Result<T = void> {
+  success: boolean
+  data?: T
+  error?: string
+}
+
+export async function getReminders(
+  userId: string
+): Promise<Result<ReminderWithCategory[]>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const { data, error } = await insforge.database
+      .from('reminders')
+      .select('*, category:categories(*)')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+    if (error) throw error
+    return { success: true, data: (data ?? []) as ReminderWithCategory[] }
+  } catch {
+    return { success: false, error: 'Error al cargar recordatorios' }
+  }
+}
+
+export async function getReminderById(
+  id: string,
+  userId: string
+): Promise<Result<ReminderWithCategory>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const { data, error } = await insforge.database
+      .from('reminders')
+      .select('*, category:categories(*)')
+      .eq('id', id)
+      .eq('user_id', userId)
+      .maybeSingle()
+    if (error) throw error
+    if (!data) return { success: false, error: 'Recordatorio no encontrado' }
+    return { success: true, data: data as ReminderWithCategory }
+  } catch {
+    return { success: false, error: 'Error al cargar recordatorio' }
+  }
+}
+
+/**
+ * Crea el reminder + programa la notification local.
+ *
+ * Acción multi-step ([[Acciones multi-step sin transacciones]]):
+ *   1. Insert en DB (orden importante — sin row no hay deep-link válido).
+ *   2. Schedule notification (con `data.reminderId` para deep-link).
+ *
+ * Si el schedule falla (permisos negados, OS limita, etc.), el reminder
+ * queda creado pero sin notification. Degradación graceful.
+ */
+export async function createReminder(
+  userId: string,
+  input: CreateReminderInput
+): Promise<Result<Reminder>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const validated = createReminderSchema.parse(input)
+    const { data, error } = await insforge.database
+      .from('reminders')
+      .insert([{ ...validated, user_id: userId }])
+      .select()
+      .single()
+    if (error) throw error
+
+    const reminder = data as Reminder
+    await scheduleReminderNotification(reminder)
+    return { success: true, data: reminder }
+  } catch {
+    return { success: false, error: 'Error al crear recordatorio' }
+  }
+}
+
+/**
+ * Update + reschedule. Reschedule cancela la notification anterior
+ * (buscando por reminderId en el data del payload) y crea una nueva con
+ * la nueva config.
+ */
+export async function updateReminder(
+  id: string,
+  userId: string,
+  input: UpdateReminderInput
+): Promise<Result<Reminder>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const validated = updateReminderSchema.parse(input)
+    const { data, error } = await insforge.database
+      .from('reminders')
+      .update(validated)
+      .eq('id', id)
+      .eq('user_id', userId)
+      .select()
+      .single()
+    if (error) throw error
+
+    const reminder = data as Reminder
+    await rescheduleReminderNotification(reminder)
+    return { success: true, data: reminder }
+  } catch {
+    return { success: false, error: 'Error al actualizar recordatorio' }
+  }
+}
+
+/**
+ * Delete + cancel. Cancel busca por reminderId en el payload, no necesita
+ * el `notificationId` persistido.
+ */
+export async function deleteReminder(
+  id: string,
+  userId: string
+): Promise<Result> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    await cancelReminderNotification(id)
+    const { error } = await insforge.database
+      .from('reminders')
+      .delete()
+      .eq('id', id)
+      .eq('user_id', userId)
+    if (error) throw error
+    return { success: true }
+  } catch {
+    return { success: false, error: 'Error al eliminar recordatorio' }
+  }
+}

--- a/lib/utils/notifications.ts
+++ b/lib/utils/notifications.ts
@@ -1,0 +1,208 @@
+// lib/utils/notifications.ts
+//
+// Wrapper sobre expo-notifications con la lógica específica del proyecto:
+// permisos, scheduling de reminders, cancelación, listener handler.
+//
+// Convención del proyecto:
+// - Toda notification se dispara a las 09:00 hora local del device.
+//   (El schema de reminders no tiene campo `time` — default razonable.)
+// - El payload incluye `{ data: { url: '/reminders/<id>' } }` para deep-link.
+// - Se cachea el `notificationId` en la DB para poder cancelar/reprogramar
+//   en updates/deletes.
+
+import * as Notifications from 'expo-notifications'
+import { Platform } from 'react-native'
+import type { Reminder, ReminderFrequency } from '@/types/database.types'
+
+// Hora fija de disparo. Configurable más adelante si se añade campo `time`.
+const DEFAULT_HOUR = 9
+const DEFAULT_MINUTE = 0
+
+// Canal Android (obligatorio para que las notifications aparezcan en
+// Android 8+). Lo creamos una sola vez al boot.
+const ANDROID_CHANNEL_ID = 'reminders'
+
+/**
+ * Configurar el handler de notifications cuando la app está en foreground.
+ * Por defecto expo-notifications NO muestra el banner si la app está abierta;
+ * con esto forzamos que se vea siempre.
+ */
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowBanner: true,
+    shouldShowList: true,
+    shouldPlaySound: true,
+    shouldSetBadge: false,
+  }),
+})
+
+/**
+ * Crear el canal Android. Idempotente — se puede llamar varias veces sin
+ * efecto. Llamar al boot (en root layout o al primer schedule).
+ */
+export async function ensureAndroidChannel(): Promise<void> {
+  if (Platform.OS !== 'android') return
+  await Notifications.setNotificationChannelAsync(ANDROID_CHANNEL_ID, {
+    name: 'Recordatorios',
+    importance: Notifications.AndroidImportance.HIGH,
+    vibrationPattern: [0, 250, 250, 250],
+    lightColor: '#4F46E5',
+  })
+}
+
+/**
+ * Pedir permisos. iOS los pide solo la primera vez; sucesivas calls
+ * devuelven el estado actual sin mostrar UI. Android 13+ requiere permiso
+ * explícito desde POST_NOTIFICATIONS (auto-managed por expo).
+ *
+ * @returns true si los permisos están concedidos.
+ */
+export async function requestNotificationPermissions(): Promise<boolean> {
+  const existing = await Notifications.getPermissionsAsync()
+  if (existing.granted) return true
+
+  const result = await Notifications.requestPermissionsAsync({
+    ios: {
+      allowAlert: true,
+      allowBadge: false,
+      allowSound: true,
+    },
+  })
+  return result.granted
+}
+
+/**
+ * Construye el trigger calendar según la frequency del reminder.
+ *
+ * - once: dispara una vez en `specific_date` a las 9:00.
+ * - weekly: cada semana en `day_of_week` a las 9:00.
+ * - monthly: cada mes en `day_of_month` a las 9:00.
+ * - yearly: cada año en `month_of_year`/`day_of_month` a las 9:00.
+ *
+ * Importante: expo-notifications usa **weekday 1-7 (Sunday=1)** en sus
+ * triggers, mientras que JS Date.getDay() devuelve 0-6 (Sunday=0). Nosotros
+ * almacenamos JS convention en `day_of_week` y convertimos al pasar.
+ */
+function buildTrigger(reminder: Reminder): Notifications.NotificationTriggerInput | null {
+  const hour = DEFAULT_HOUR
+  const minute = DEFAULT_MINUTE
+  const channelId = Platform.OS === 'android' ? ANDROID_CHANNEL_ID : undefined
+
+  switch (reminder.frequency) {
+    case 'once': {
+      if (!reminder.specific_date) return null
+      const date = new Date(`${reminder.specific_date}T${pad(hour)}:${pad(minute)}:00`)
+      if (date.getTime() <= Date.now()) return null // fecha pasada — no agendar
+      return {
+        type: Notifications.SchedulableTriggerInputTypes.DATE,
+        date,
+        channelId,
+      }
+    }
+    case 'weekly': {
+      if (reminder.day_of_week === null || reminder.day_of_week === undefined) return null
+      return {
+        type: Notifications.SchedulableTriggerInputTypes.WEEKLY,
+        weekday: reminder.day_of_week + 1, // JS 0-6 → expo 1-7
+        hour,
+        minute,
+        channelId,
+      }
+    }
+    case 'monthly': {
+      if (!reminder.day_of_month) return null
+      return {
+        type: Notifications.SchedulableTriggerInputTypes.MONTHLY,
+        day: reminder.day_of_month,
+        hour,
+        minute,
+        channelId,
+      }
+    }
+    case 'yearly': {
+      if (!reminder.day_of_month || !reminder.month_of_year) return null
+      return {
+        type: Notifications.SchedulableTriggerInputTypes.YEARLY,
+        month: reminder.month_of_year - 1, // expo usa 0-11 para month en yearly
+        day: reminder.day_of_month,
+        hour,
+        minute,
+        channelId,
+      }
+    }
+    default:
+      return null
+  }
+}
+
+function pad(n: number): string {
+  return String(n).padStart(2, '0')
+}
+
+/**
+ * Programa la notification local del reminder. Devuelve el `notificationId`
+ * generado por el OS (informativo — para cancelar después usamos
+ * `cancelReminderNotification(reminderId)` que busca por el `reminderId`
+ * embedido en el payload, sin necesidad de persistirlo).
+ *
+ * Si el reminder está inactivo, o si el trigger no se puede construir (ej.
+ * fecha en el pasado para `once`), no programa nada y devuelve null.
+ */
+export async function scheduleReminderNotification(
+  reminder: Reminder
+): Promise<string | null> {
+  if (!reminder.is_active) return null
+
+  const granted = await requestNotificationPermissions()
+  if (!granted) return null
+
+  await ensureAndroidChannel()
+
+  const trigger = buildTrigger(reminder)
+  if (!trigger) return null
+
+  return await Notifications.scheduleNotificationAsync({
+    content: {
+      title: 'Recordatorio',
+      body: reminder.description,
+      data: { url: `/reminders/${reminder.id}`, reminderId: reminder.id },
+    },
+    trigger,
+  })
+}
+
+/**
+ * Cancela todas las notifications programadas para un reminder dado.
+ *
+ * NO persistimos el `notificationId` en la DB — en su lugar embebimos el
+ * `reminderId` en el `data` del payload al schedule. Al cancelar, listamos
+ * todas las scheduled notifications, filtramos las que correspondan a este
+ * reminder, y cancelamos.
+ *
+ * Trade-off:
+ * - Pro: cero columnas nuevas en DB, cero AsyncStorage.
+ * - Con: O(N) en cada cancel donde N = scheduled notifications. Para una
+ *   app con <100 reminders esto es trivial.
+ */
+export async function cancelReminderNotification(reminderId: string): Promise<void> {
+  try {
+    const scheduled = await Notifications.getAllScheduledNotificationsAsync()
+    const toCancel = scheduled.filter(
+      (n) => (n.content.data as { reminderId?: string } | null)?.reminderId === reminderId
+    )
+    await Promise.all(
+      toCancel.map((n) => Notifications.cancelScheduledNotificationAsync(n.identifier))
+    )
+  } catch {
+    // Silencioso — best effort
+  }
+}
+
+/**
+ * Reprograma la notification: cancela la existente + programa una nueva.
+ * Útil para updates de reminders (cambió la frequency, day_of_week, etc.).
+ */
+export async function rescheduleReminderNotification(reminder: Reminder): Promise<string | null> {
+  await cancelReminderNotification(reminder.id)
+  return await scheduleReminderNotification(reminder)
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@shopify/react-native-skia": "^2.6.3",
     "expo": "~54.0.34",
     "expo-auth-session": "~7.0.11",
+    "expo-notifications": "~0.32.17",
     "expo-router": "~6.0.23",
     "expo-secure-store": "~15.0.8",
     "expo-status-bar": "~3.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,12 @@ importers:
       expo-auth-session:
         specifier: ~7.0.11
         version: 7.0.11(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-notifications:
+        specifier: ~0.32.17
+        version: 0.32.17(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-router:
         specifier: ~6.0.23
-        version: 6.0.23(50d6ae050edc32577f71db9557610d25)
+        version: 6.0.23(8ed3ad4190d356f0c40361b25ec1ba7d)
       expo-secure-store:
         specifier: ~15.0.8
         version: 15.0.8(expo@54.0.34)
@@ -648,6 +651,10 @@ packages:
   '@expo/env@2.0.11':
     resolution: {integrity: sha512-xV+ps6YCW7XIPVUwFVCRN2nox09dnRwy8uIjwHWTODu0zFw4kp4omnVkl0OOjuu2XOe7tdgAHxikrkJt9xB/7Q==}
 
+  '@expo/env@2.3.0':
+    resolution: {integrity: sha512-9HnnIbzwTTdbwSjNLXTk0fPm9ZwMJ7c1/31tsni8HZ8Q62KzYCyspahH+V365vg5J6lr001DzNwBxVWSaYCQLg==}
+    engines: {node: '>=20.12.0'}
+
   '@expo/fingerprint@0.15.5':
     resolution: {integrity: sha512-mdVoAMcux1WlM6kd1RoWiHRNqKqS+J6mKmWQ/BKgeh937S/fcW58EE68O6nc4KDXtWi3PBeNHskOFcgyIuD4hw==}
     hasBin: true
@@ -729,6 +736,9 @@ packages:
   '@expo/xcpretty@4.4.3':
     resolution: {integrity: sha512-wC562eD3gS6vO2tWHToFhlFnmHKfKHgF1oyvojeSkLK/ZYop1bMU+7cOMiF9Sq70CzcsLy/EMRy/uRc76QmNRw==}
     hasBin: true
+
+  '@ide/backoff@1.0.0':
+    resolution: {integrity: sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g==}
 
   '@insforge/sdk@1.2.5':
     resolution: {integrity: sha512-td9xryO7b+wR1wPVdFIaCLSKLZ+f3bzx/WpaXVrAs/ypOEJbZHQiWxK+c9Lr5WGShn2miRgSlTPrBNKe3aemlg==}
@@ -1357,8 +1367,15 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
+  assert@2.1.0:
+    resolution: {integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==}
+
   async-limiter@1.0.1:
     resolution: {integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==}
+
+  available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
 
   babel-jest@29.7.0:
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
@@ -1426,6 +1443,9 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
       '@babel/core': ^7.0.0
+
+  badgin@1.2.3:
+    resolution: {integrity: sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -1499,6 +1519,18 @@ packages:
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bind@1.0.9:
+    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   camelcase-css@2.0.1:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
@@ -1757,9 +1789,17 @@ packages:
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
 
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
   define-lazy-prop@2.0.0:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
     engines: {node: '>=8'}
+
+  define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -1808,6 +1848,10 @@ packages:
     resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
     engines: {node: '>=12'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
@@ -1843,8 +1887,16 @@ packages:
   error-stack-parser@2.1.4:
     resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
 
   escalade@3.2.0:
@@ -1903,6 +1955,12 @@ packages:
       expo: '*'
       react-native: '*'
 
+  expo-constants@56.0.15:
+    resolution: {integrity: sha512-7187sd55swLX+CM0noAV5LreEgkUaDG/zEXy9quonfzKpJxy8zJAszp9S++xOx/FcqBVEEEcQhE8tKTujwL8fg==}
+    peerDependencies:
+      expo: '*'
+      react-native: '*'
+
   expo-crypto@15.0.9:
     resolution: {integrity: sha512-SNWKa2fXx7v9gkp1h/7nqXY5XN7qgNDn3yRc2aO0gWGbeMbvob/haMxxsPFe9f51aqH5NjNCqHf2kvLhvAd8KQ==}
     peerDependencies:
@@ -1940,6 +1998,13 @@ packages:
   expo-modules-core@3.0.30:
     resolution: {integrity: sha512-a6IrpAn/Jbmwxi9L+hMmXKpNqnkUpoF7WHOpn02rVLyax2J0gB1vvCVE5rNydplEnt41Q6WxQwvcOjZaIkcSUg==}
     peerDependencies:
+      react: '*'
+      react-native: '*'
+
+  expo-notifications@0.32.17:
+    resolution: {integrity: sha512-lwwzn7tImuzTzn9PAglZlS2VfZEvsfFGJTK9Eb8I4cqkGh2DI23YJFJH+WPEIu4QhDvk5JeBjklenJ8IZbmA4A==}
+    peerDependencies:
+      expo: '*'
       react: '*'
       react-native: '*'
 
@@ -2069,6 +2134,10 @@ packages:
   fontfaceobserver@2.3.0:
     resolution: {integrity: sha512-6FPvD/IVyT4ZlNe7Wcn5Fb/4ChigpucKYSvD6a+0iMoLn2inpo711eyIcKjmDtE5XNcgAkSH9uN/nfAeZzHEfg==}
 
+  for-each@0.3.5:
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
+
   freeport-async@2.0.0:
     resolution: {integrity: sha512-K7od3Uw45AJg00XUmy15+Hae2hOcgKcmN3/EF6Y7i01O0gaqiRx8sUSpsb9+BRNL8RPBrhzPsVfy8q9ADlJuWQ==}
     engines: {node: '>=8'}
@@ -2088,6 +2157,10 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  generator-function@2.0.1:
+    resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
+    engines: {node: '>= 0.4'}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -2096,6 +2169,10 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
@@ -2103,6 +2180,10 @@ packages:
   get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
     engines: {node: '>=8.0.0'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   getenv@2.0.0:
     resolution: {integrity: sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ==}
@@ -2124,6 +2205,10 @@ packages:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -2134,6 +2219,17 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
 
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
@@ -2211,12 +2307,20 @@ packages:
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
+  is-arguments@1.2.0:
+    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
+    engines: {node: '>= 0.4'}
+
   is-arrayish@0.3.4:
     resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
 
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
+
+  is-callable@1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
 
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
@@ -2235,13 +2339,29 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  is-generator-function@1.1.2:
+    resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
+    engines: {node: '>= 0.4'}
+
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-nan@1.3.2:
+    resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
+    engines: {node: '>= 0.4'}
+
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-regex@1.2.1:
+    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
+    engines: {node: '>= 0.4'}
+
+  is-typed-array@1.1.15:
+    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
+    engines: {node: '>= 0.4'}
 
   is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
@@ -2526,6 +2646,10 @@ packages:
 
   marky@1.3.0:
     resolution: {integrity: sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
 
   mdn-data@2.0.14:
     resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
@@ -2849,6 +2973,18 @@ packages:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
 
+  object-is@1.1.6:
+    resolution: {integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==}
+    engines: {node: '>= 0.4'}
+
+  object-keys@1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
+
+  object.assign@4.1.7:
+    resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
+    engines: {node: '>= 0.4'}
+
   on-finished@2.3.0:
     resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
     engines: {node: '>= 0.8'}
@@ -2949,6 +3085,10 @@ packages:
   pngjs@3.4.0:
     resolution: {integrity: sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==}
     engines: {node: '>=4.0.0'}
+
+  possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
+    engines: {node: '>= 0.4'}
 
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
@@ -3281,6 +3421,10 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
+  safe-regex-test@1.1.0:
+    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
+    engines: {node: '>= 0.4'}
+
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
@@ -3327,6 +3471,10 @@ packages:
 
   server-only@0.0.1:
     resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
+
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -3622,6 +3770,9 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  util@0.12.5:
+    resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
+
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
@@ -3682,6 +3833,10 @@ packages:
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  which-typed-array@1.1.20:
+    resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
+    engines: {node: '>= 0.4'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -4490,7 +4645,7 @@ snapshots:
       wrap-ansi: 7.0.0
       ws: 8.20.0
     optionalDependencies:
-      expo-router: 6.0.23(50d6ae050edc32577f71db9557610d25)
+      expo-router: 6.0.23(8ed3ad4190d356f0c40361b25ec1ba7d)
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
     transitivePeerDependencies:
       - bufferutil
@@ -4562,6 +4717,14 @@ snapshots:
       debug: 4.4.3
       dotenv: 16.4.7
       dotenv-expand: 11.0.7
+      getenv: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@expo/env@2.3.0':
+    dependencies:
+      chalk: 4.1.2
+      debug: 4.4.3
       getenv: 2.0.0
     transitivePeerDependencies:
       - supports-color
@@ -4732,6 +4895,8 @@ snapshots:
       '@babel/code-frame': 7.29.0
       chalk: 4.1.2
       js-yaml: 4.1.1
+
+  '@ide/backoff@1.0.0': {}
 
   '@insforge/sdk@1.2.5':
     dependencies:
@@ -5490,7 +5655,19 @@ snapshots:
 
   asap@2.0.6: {}
 
+  assert@2.1.0:
+    dependencies:
+      call-bind: 1.0.9
+      is-nan: 1.3.2
+      object-is: 1.1.6
+      object.assign: 4.1.7
+      util: 0.12.5
+
   async-limiter@1.0.1: {}
+
+  available-typed-arrays@1.0.7:
+    dependencies:
+      possible-typed-array-names: 1.1.0
 
   babel-jest@29.7.0(@babel/core@7.29.0):
     dependencies:
@@ -5624,6 +5801,8 @@ snapshots:
       babel-plugin-jest-hoist: 29.6.3
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
 
+  badgin@1.2.3: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -5691,6 +5870,23 @@ snapshots:
       ieee754: 1.2.1
 
   bytes@3.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bind@1.0.9:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   camelcase-css@2.0.1: {}
 
@@ -5948,7 +6144,19 @@ snapshots:
     dependencies:
       clone: 1.0.4
 
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   define-lazy-prop@2.0.0: {}
+
+  define-properties@1.2.1:
+    dependencies:
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
+      object-keys: 1.1.1
 
   depd@2.0.0: {}
 
@@ -5988,6 +6196,12 @@ snapshots:
 
   dotenv@16.4.7: {}
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   ee-first@1.1.1: {}
 
   electron-to-chromium@1.5.340: {}
@@ -6020,7 +6234,13 @@ snapshots:
     dependencies:
       stackframe: 1.3.4
 
+  es-define-property@1.0.1: {}
+
   es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
 
   escalade@3.2.0: {}
 
@@ -6076,6 +6296,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  expo-constants@56.0.15(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)):
+    dependencies:
+      '@expo/env': 2.3.0
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
+    transitivePeerDependencies:
+      - supports-color
+
   expo-crypto@15.0.9(expo@54.0.34):
     dependencies:
       base64-js: 1.5.1
@@ -6122,7 +6350,23 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
 
-  expo-router@6.0.23(50d6ae050edc32577f71db9557610d25):
+  expo-notifications@0.32.17(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
+    dependencies:
+      '@expo/image-utils': 0.8.13(typescript@5.9.3)
+      '@ide/backoff': 1.0.0
+      abort-controller: 3.0.0
+      assert: 2.1.0
+      badgin: 1.2.3
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-application: 7.0.8(expo@54.0.34)
+      expo-constants: 18.0.13(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  expo-router@6.0.23(8ed3ad4190d356f0c40361b25ec1ba7d):
     dependencies:
       '@expo/metro-runtime': 6.1.2(expo@54.0.34)(react-dom@19.2.5(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@expo/schema-utils': 0.1.8
@@ -6135,7 +6379,7 @@ snapshots:
       debug: 4.4.3
       escape-string-regexp: 4.0.0
       expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-      expo-constants: 18.0.13(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
+      expo-constants: 56.0.15(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
       expo-linking: 8.0.12(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       expo-server: 1.0.5
       fast-deep-equal: 3.1.3
@@ -6272,6 +6516,10 @@ snapshots:
 
   fontfaceobserver@2.3.0: {}
 
+  for-each@0.3.5:
+    dependencies:
+      is-callable: 1.2.7
+
   freeport-async@2.0.0: {}
 
   fresh@0.5.2: {}
@@ -6283,13 +6531,33 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  generator-function@2.0.1: {}
+
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
   get-nonce@1.0.1: {}
 
   get-package-type@0.1.0: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
 
   getenv@2.0.0: {}
 
@@ -6316,11 +6584,23 @@ snapshots:
       once: 1.4.0
       path-is-absolute: 1.0.1
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
 
   has-flag@3.0.0: {}
 
   has-flag@4.0.0: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
 
   hasown@2.0.3:
     dependencies:
@@ -6400,11 +6680,18 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  is-arguments@1.2.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
   is-arrayish@0.3.4: {}
 
   is-binary-path@2.1.0:
     dependencies:
       binary-extensions: 2.3.0
+
+  is-callable@1.2.7: {}
 
   is-core-module@2.16.1:
     dependencies:
@@ -6416,11 +6703,35 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
+  is-generator-function@1.1.2:
+    dependencies:
+      call-bound: 1.0.4
+      generator-function: 2.0.1
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
+
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
 
+  is-nan@1.3.2:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+
   is-number@7.0.0: {}
+
+  is-regex@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
+
+  is-typed-array@1.1.15:
+    dependencies:
+      which-typed-array: 1.1.20
 
   is-wsl@2.2.0:
     dependencies:
@@ -6686,6 +6997,8 @@ snapshots:
       tmpl: 1.0.5
 
   marky@1.3.0: {}
+
+  math-intrinsics@1.1.0: {}
 
   mdn-data@2.0.14: {}
 
@@ -7349,6 +7662,22 @@ snapshots:
 
   object-hash@3.0.0: {}
 
+  object-is@1.1.6:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+
+  object-keys@1.1.1: {}
+
+  object.assign@4.1.7:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.2
+      has-symbols: 1.1.0
+      object-keys: 1.1.1
+
   on-finished@2.3.0:
     dependencies:
       ee-first: 1.1.1
@@ -7437,6 +7766,8 @@ snapshots:
       xmlbuilder: 15.1.1
 
   pngjs@3.4.0: {}
+
+  possible-typed-array-names@1.1.0: {}
 
   postcss-import@15.1.0(postcss@8.5.10):
     dependencies:
@@ -7799,6 +8130,12 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
+  safe-regex-test@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-regex: 1.2.1
+
   sax@1.6.0: {}
 
   scheduler@0.25.0: {}
@@ -7845,6 +8182,15 @@ snapshots:
       - supports-color
 
   server-only@0.0.1: {}
+
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
 
   setprototypeof@1.2.0: {}
 
@@ -8126,6 +8472,14 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  util@0.12.5:
+    dependencies:
+      inherits: 2.0.4
+      is-arguments: 1.2.0
+      is-generator-function: 1.1.2
+      is-typed-array: 1.1.15
+      which-typed-array: 1.1.20
+
   utils-merge@1.0.1: {}
 
   uuid@7.0.3: {}
@@ -8186,6 +8540,16 @@ snapshots:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
+
+  which-typed-array@1.1.20:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
Closes #91 · Related to #86 (FASE 5)

## Cambios

### Deps + config
- \`expo-notifications\` ~0.32.x (matchea SDK 54) — instalado vía \`npx expo install\` (NO \`pnpm add\`).
- Plugin en \`app.json\` con icon + color primary.

### Backend
- **\`lib/utils/notifications.ts\`** — wrapper completo: foreground handler, canal Android, permisos con \`granted\` boolean, builder de trigger según frequency (con conversiones JS ↔ expo), schedule/cancel/reschedule.
- **\`lib/actions/reminders.actions.ts\`** — CRUD que aplica el patrón [[Scheduled local notifications]]: create→schedule, update→reschedule, delete→cancel.

### UI
- **\`app/(dashboard)/reminders/\`** — layout + lista (\`describeReminder\` muestra la frequency en lenguaje natural: "Todos los martes", "Día 15 de cada mes", "5 de enero") + form con campos condicionales según frequency + Switch \`is_active\`.
- **\`app/_layout.tsx\`** — listener de tap que navega a \`data.url\` (\`/reminders/<id>\`).
- **QuickActionsSheet** — tile de Recordatorios ahora navega a \`/reminders\` (antes mostraba toast "Próximamente").

## Comportamiento visible

1. Tap en Menú → Recordatorios → lista.
2. Crear reminder semanal (lunes a las 9 AM) → notification programada por el OS.
3. Editar el día → reschedule (cancela vieja + crea nueva).
4. Toggle is_active off → cancel.
5. Eliminar → cancel + delete.
6. Cuando suene la notification → tap → abre el detalle del reminder.

## Decisiones técnicas

- **Tracking del notificationId** por embedded ID en payload (\`data.reminderId\`), no en DB. Cancel es O(N) sobre scheduled notifications pero cero migrations. Para apps con <100 reminders es trivial.
- **Conversiones JS ↔ expo**: \`day_of_week\` JS (0-6) → trigger WEEKLY \`weekday\` (1-7); \`month_of_year\` schema (1-12) → trigger YEARLY \`month\` (0-11).
- **Horario fijo 9 AM** — no hay campo \`time\` en el schema; default razonable.

## Verificación

- [x] \`npx tsc --noEmit\` limpio
- [ ] **Requiere rebuild del dev client** (\`npx expo run:ios\`) por los binarios nativos de expo-notifications
- [ ] Smoke test:
  - [ ] Permisos al primer reminder creado
  - [ ] Tile de Recordatorios en Menú navega a la lista
  - [ ] Crear/editar/eliminar reminders refleja en lista
  - [ ] Tile en QuickActions ya no muestra toast
  - [ ] Notification dispara en la hora programada (probar con \`once\` de mañana 9 AM, o weekly)
  - [ ] Tap en notification abre el detalle

## Notas para Obsidian

- 🆕 [[expo-notifications]] en \`10 - Concepts/Expo/\`
- 🆕 [[Scheduled local notifications]] en \`30 - Patterns/\`
- Bitácora \`T-5.3 — Recordatorios.md\`