### PR TITLE
feat: calendario con 2 tabs (TX + Recordatorios) (T-5.4)

### DIFF
--- a/app/(dashboard)/_layout.tsx
+++ b/app/(dashboard)/_layout.tsx
@@ -56,6 +56,15 @@ export default function DashboardLayout() {
           }}
         />
         <Tabs.Screen
+          name="calendar"
+          options={{
+            title: 'Calendario',
+            tabBarIcon: ({ color, size }) => (
+              <Icon name="calendar" color={color} size={size} />
+            ),
+          }}
+        />
+        <Tabs.Screen
           name="reports"
           options={{
             title: 'Reportes',

--- a/app/(dashboard)/calendar/_layout.tsx
+++ b/app/(dashboard)/calendar/_layout.tsx
@@ -1,0 +1,13 @@
+import { Stack } from 'expo-router'
+import { colors } from '@/constants/theme'
+
+export default function CalendarLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: colors.bg },
+      }}
+    />
+  )
+}

--- a/app/(dashboard)/calendar/index.tsx
+++ b/app/(dashboard)/calendar/index.tsx
@@ -1,0 +1,217 @@
+// app/(dashboard)/calendar/index.tsx
+//
+// Calendario con 2 tabs (Transacciones / Recordatorios) usando
+// react-native-calendars. Markers según el tab activo; tap día abre
+// DayDetailSheet con la lista del día + botón de crear.
+import { useCallback, useMemo, useState } from 'react'
+import { View, Text, ActivityIndicator } from 'react-native'
+import { Calendar, LocaleConfig } from 'react-native-calendars'
+import { useFocusEffect } from 'expo-router'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useAuth } from '@/context/AuthContext'
+import { getTransactions } from '@/lib/actions/transactions.actions'
+import { getReminders } from '@/lib/actions/reminders.actions'
+import { CalendarHeader, type CalendarTab } from '@/components/calendar/CalendarHeader'
+import { DayDetailSheet } from '@/components/calendar/DayDetailSheet'
+import { reminderMatchesDate } from '@/lib/utils/reminderMatchesDate'
+import { colors } from '@/constants/theme'
+import type {
+  ReminderWithCategory,
+  TransactionWithCategory,
+} from '@/types/database.types'
+
+// ---------------------------------------------------------------------------
+// Locale español para react-native-calendars
+// ---------------------------------------------------------------------------
+LocaleConfig.locales['es'] = {
+  monthNames: [
+    'Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio',
+    'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre',
+  ],
+  monthNamesShort: [
+    'Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun',
+    'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic',
+  ],
+  dayNames: [
+    'Domingo', 'Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado',
+  ],
+  dayNamesShort: ['D', 'L', 'M', 'M', 'J', 'V', 'S'],
+  today: 'Hoy',
+}
+LocaleConfig.defaultLocale = 'es'
+
+// Theme dark adaptado a los tokens del proyecto
+const CALENDAR_THEME = {
+  backgroundColor: colors.bg,
+  calendarBackground: colors.bg,
+  textSectionTitleColor: colors.muted,
+  selectedDayBackgroundColor: colors.primary,
+  selectedDayTextColor: '#fff',
+  todayTextColor: colors.primary,
+  dayTextColor: '#fff',
+  textDisabledColor: '#3f3f46',
+  arrowColor: colors.primary,
+  monthTextColor: '#fff',
+  textMonthFontWeight: 'bold' as const,
+  textDayFontSize: 14,
+  textMonthFontSize: 16,
+}
+
+function currentMonthIso(): string {
+  // YYYY-MM-DD del primer día del mes actual
+  const d = new Date()
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-01`
+}
+
+export default function CalendarScreen() {
+  const { user } = useAuth()
+  const [tab, setTab] = useState<CalendarTab>('transactions')
+  const [loading, setLoading] = useState(true)
+  const [transactions, setTransactions] = useState<TransactionWithCategory[]>([])
+  const [reminders, setReminders] = useState<ReminderWithCategory[]>([])
+  const [visibleMonth, setVisibleMonth] = useState<string>(currentMonthIso())
+
+  const [selectedDay, setSelectedDay] = useState<string | null>(null)
+
+  // Cargamos datasets completos al focus — el calendario es vista panorámica,
+  // no se beneficia mucho de paginar por mes (los reminders no tienen filtro
+  // de mes en backend y las tx son < 500 en general).
+  const loadData = useCallback(async () => {
+    if (!user) return
+    const [txRes, remRes] = await Promise.all([
+      getTransactions(user.id, {}, { page: 1, pageSize: 500 }),
+      getReminders(user.id),
+    ])
+    if (txRes.success && txRes.data) setTransactions(txRes.data.items)
+    if (remRes.success && remRes.data) setReminders(remRes.data)
+    setLoading(false)
+  }, [user])
+
+  useFocusEffect(
+    useCallback(() => {
+      let cancelled = false
+      ;(async () => {
+        if (cancelled) return
+        await loadData()
+      })()
+      return () => {
+        cancelled = true
+      }
+    }, [loadData])
+  )
+
+  // ---------------------------------------------------------------------------
+  // markedDates por tab
+  // ---------------------------------------------------------------------------
+  /**
+   * Para transacciones: multi-dot por día con el color de cada categoría
+   * presente. Si hay más de 4 categorías distintas en el día, mostramos las
+   * primeras 4 (react-native-calendars limita visualmente igual).
+   */
+  const transactionMarkers = useMemo(() => {
+    const map: Record<string, { dots: { color: string; key: string }[] }> = {}
+    for (const tx of transactions) {
+      const date = tx.date.slice(0, 10)
+      if (!map[date]) map[date] = { dots: [] }
+      const color = tx.category?.color ?? '#4F46E5'
+      const key = tx.category?.id ?? 'sin-cat'
+      // Evitar duplicar dots de la misma categoría en el mismo día
+      if (!map[date].dots.find((d) => d.key === key)) {
+        if (map[date].dots.length < 4) {
+          map[date].dots.push({ color, key })
+        }
+      }
+    }
+    return map
+  }, [transactions])
+
+  /**
+   * Para reminders: dots por día donde algún reminder activo dispara.
+   * Filtramos solo los activos. Iteramos los días visibles del mes (suficiente
+   * para una vista mensual — para anuales recordatorios futuros también
+   * marcamos su día del mes actual).
+   */
+  const reminderMarkers = useMemo(() => {
+    const map: Record<string, { dots: { color: string; key: string }[] }> = {}
+    if (!visibleMonth) return map
+    const [year, month] = visibleMonth.split('-').map(Number)
+    const daysInMonth = new Date(year, month, 0).getDate()
+    const active = reminders.filter((r) => r.is_active)
+
+    for (let day = 1; day <= daysInMonth; day++) {
+      const date = new Date(year, month - 1, day)
+      const matching = active.filter((r) => reminderMatchesDate(r, date))
+      if (matching.length === 0) continue
+      const iso = `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`
+      map[iso] = {
+        dots: matching.slice(0, 4).map((r) => ({
+          color: r.category?.color ?? '#ec4899',
+          key: r.id,
+        })),
+      }
+    }
+    return map
+  }, [reminders, visibleMonth])
+
+  const markedDates = tab === 'transactions' ? transactionMarkers : reminderMarkers
+
+  // ---------------------------------------------------------------------------
+  // Items del día seleccionado
+  // ---------------------------------------------------------------------------
+  const selectedDayTransactions = useMemo(() => {
+    if (!selectedDay) return []
+    return transactions.filter((t) => t.date.slice(0, 10) === selectedDay)
+  }, [transactions, selectedDay])
+
+  const selectedDayReminders = useMemo(() => {
+    if (!selectedDay) return []
+    const date = new Date(`${selectedDay}T00:00:00`)
+    return reminders.filter((r) => r.is_active && reminderMatchesDate(r, date))
+  }, [reminders, selectedDay])
+
+  if (loading) {
+    return (
+      <SafeAreaView edges={['top']} className="flex-1 bg-bg">
+        <View className="flex-1 items-center justify-center">
+          <ActivityIndicator color="#4F46E5" />
+        </View>
+      </SafeAreaView>
+    )
+  }
+
+  return (
+    <SafeAreaView edges={['top']} className="flex-1 bg-bg">
+      <View className="px-4 py-3 border-b border-border">
+        <Text className="text-white text-xl font-bold">Calendario</Text>
+      </View>
+
+      <CalendarHeader value={tab} onChange={setTab} />
+
+      <Calendar
+        // Usamos la primera fecha del mes para que react-native-calendars
+        // sepa qué mes mostrar inicialmente
+        current={visibleMonth}
+        markedDates={markedDates}
+        markingType="multi-dot"
+        firstDay={1}
+        theme={CALENDAR_THEME}
+        onDayPress={(day) => setSelectedDay(day.dateString)}
+        onMonthChange={(month) => {
+          setVisibleMonth(`${month.year}-${String(month.month).padStart(2, '0')}-01`)
+        }}
+        style={{
+          backgroundColor: colors.bg,
+        }}
+      />
+
+      <DayDetailSheet
+        visible={selectedDay !== null}
+        onClose={() => setSelectedDay(null)}
+        dayIso={selectedDay}
+        mode={tab}
+        transactions={selectedDayTransactions}
+        reminders={selectedDayReminders}
+      />
+    </SafeAreaView>
+  )
+}

--- a/app/(dashboard)/calendar/index.tsx
+++ b/app/(dashboard)/calendar/index.tsx
@@ -3,10 +3,10 @@
 // Calendario con 2 tabs (Transacciones / Recordatorios) usando
 // react-native-calendars. Markers según el tab activo; tap día abre
 // DayDetailSheet con la lista del día + botón de crear.
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { View, Text, ActivityIndicator } from 'react-native'
 import { Calendar, LocaleConfig } from 'react-native-calendars'
-import { useFocusEffect } from 'expo-router'
+import { useFocusEffect, useNavigation } from 'expo-router'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useAuth } from '@/context/AuthContext'
 import { getTransactions } from '@/lib/actions/transactions.actions'
@@ -65,6 +65,7 @@ function currentMonthIso(): string {
 
 export default function CalendarScreen() {
   const { user } = useAuth()
+  const navigation = useNavigation()
   const [tab, setTab] = useState<CalendarTab>('transactions')
   const [loading, setLoading] = useState(true)
   const [transactions, setTransactions] = useState<TransactionWithCategory[]>([])
@@ -72,6 +73,27 @@ export default function CalendarScreen() {
   const [visibleMonth, setVisibleMonth] = useState<string>(currentMonthIso())
 
   const [selectedDay, setSelectedDay] = useState<string | null>(null)
+
+  /**
+   * Cuando el DayDetailSheet está abierto, ocultamos el tab bar del navegador
+   * padre. Esto resuelve el bug de "transparencia debajo del card" que aparece
+   * cuando un Modal se monta dentro de un screen de tab navigator — el tab
+   * bar se renderiza en una capa intermedia que el modal no cubre.
+   *
+   * Al cerrarse el sheet (selectedDay === null), restauramos el tab bar.
+   */
+  useEffect(() => {
+    const parent = navigation.getParent()
+    if (!parent) return
+    parent.setOptions({
+      tabBarStyle: selectedDay
+        ? { display: 'none' }
+        : {
+            backgroundColor: colors.surface,
+            borderTopColor: colors.border,
+          },
+    })
+  }, [selectedDay, navigation])
 
   // Cargamos datasets completos al focus — el calendario es vista panorámica,
   // no se beneficia mucho de paginar por mes (los reminders no tienen filtro

--- a/components/calendar/CalendarHeader.tsx
+++ b/components/calendar/CalendarHeader.tsx
@@ -1,0 +1,47 @@
+import { View, Text, TouchableOpacity } from 'react-native'
+
+export type CalendarTab = 'transactions' | 'reminders'
+
+interface Props {
+  value: CalendarTab
+  onChange: (tab: CalendarTab) => void
+}
+
+const TABS: { value: CalendarTab; label: string }[] = [
+  { value: 'transactions', label: 'Transacciones' },
+  { value: 'reminders', label: 'Recordatorios' },
+]
+
+/**
+ * Segmented control con 2 opciones: Transacciones / Recordatorios.
+ * Mismo patrón visual que `RangeSelector` de Reports.
+ */
+export function CalendarHeader({ value, onChange }: Props) {
+  return (
+    <View className="flex-row gap-2 px-4 py-3 border-b border-border">
+      {TABS.map((tab) => {
+        const active = tab.value === value
+        return (
+          <TouchableOpacity
+            key={tab.value}
+            onPress={() => onChange(tab.value)}
+            activeOpacity={0.7}
+            className={`flex-1 py-2 rounded-xl items-center border ${
+              active
+                ? 'bg-primary border-primary'
+                : 'bg-transparent border-border'
+            }`}
+          >
+            <Text
+              className={
+                active ? 'text-white text-sm font-semibold' : 'text-muted text-sm'
+              }
+            >
+              {tab.label}
+            </Text>
+          </TouchableOpacity>
+        )
+      })}
+    </View>
+  )
+}

--- a/components/calendar/DayDetailSheet.tsx
+++ b/components/calendar/DayDetailSheet.tsx
@@ -5,7 +5,7 @@ import { BottomSheet } from '@/components/ui/BottomSheet'
 import { PrimaryButton } from '@/components/ui/PrimaryButton'
 import { formatCurrency } from '@/lib/utils/currency'
 import type {
-  Reminder,
+  ReminderWithCategory,
   TransactionWithCategory,
 } from '@/types/database.types'
 
@@ -18,7 +18,7 @@ interface Props {
   mode: 'transactions' | 'reminders'
   /** Items del día — el caller los filtra. */
   transactions?: TransactionWithCategory[]
-  reminders?: Reminder[]
+  reminders?: ReminderWithCategory[]
 }
 
 function formatLongDate(iso: string): string {
@@ -124,28 +124,39 @@ export function DayDetailSheet({
                 </Text>
               </TouchableOpacity>
             ))
-          : reminders.map((r, idx) => (
-              <TouchableOpacity
-                key={r.id}
-                onPress={() => handleItemPress(r.id)}
-                activeOpacity={0.7}
-                className={`flex-row items-center py-3 ${
-                  idx < reminders.length - 1 ? 'border-b border-border' : ''
-                }`}
-              >
-                <View className="w-9 h-9 rounded-full bg-primary items-center justify-center mr-3">
-                  <Text className="text-base">🔔</Text>
-                </View>
-                <View className="flex-1">
-                  <Text className="text-white text-sm font-medium" numberOfLines={1}>
-                    {r.description}
-                  </Text>
-                  <Text className="text-muted text-xs mt-0.5">
-                    {r.is_active ? '9:00 AM' : 'Pausado'}
-                  </Text>
-                </View>
-              </TouchableOpacity>
-            ))}
+          : reminders.map((r, idx) => {
+              // Mismo patrón que ReminderCard y RecentTransactions:
+              // avatar con icono+color de la categoría. Fallback 🔔
+              // sobre fondo primary si no tiene categoría asignada.
+              const avatarColor = r.category?.color ?? '#4F46E5'
+              const avatarIcon = r.category?.icon ?? '🔔'
+              return (
+                <TouchableOpacity
+                  key={r.id}
+                  onPress={() => handleItemPress(r.id)}
+                  activeOpacity={0.7}
+                  className={`flex-row items-center py-3 ${
+                    idx < reminders.length - 1 ? 'border-b border-border' : ''
+                  }`}
+                >
+                  <View
+                    style={{ backgroundColor: avatarColor }}
+                    className="w-9 h-9 rounded-full items-center justify-center mr-3"
+                  >
+                    <Text className="text-base">{avatarIcon}</Text>
+                  </View>
+                  <View className="flex-1">
+                    <Text className="text-white text-sm font-medium" numberOfLines={1}>
+                      {r.description}
+                    </Text>
+                    <Text className="text-muted text-xs mt-0.5">
+                      {r.category ? `${r.category.name} · ` : ''}
+                      {r.is_active ? '9:00 AM' : 'Pausado'}
+                    </Text>
+                  </View>
+                </TouchableOpacity>
+              )
+            })}
       </ScrollView>
 
       <View className="mt-3">

--- a/components/calendar/DayDetailSheet.tsx
+++ b/components/calendar/DayDetailSheet.tsx
@@ -1,0 +1,158 @@
+import { useMemo } from 'react'
+import { View, Text, TouchableOpacity, ScrollView } from 'react-native'
+import { router } from 'expo-router'
+import { BottomSheet } from '@/components/ui/BottomSheet'
+import { PrimaryButton } from '@/components/ui/PrimaryButton'
+import { formatCurrency } from '@/lib/utils/currency'
+import type {
+  Reminder,
+  TransactionWithCategory,
+} from '@/types/database.types'
+
+interface Props {
+  visible: boolean
+  onClose: () => void
+  /** YYYY-MM-DD del día seleccionado, o null si nada. */
+  dayIso: string | null
+  /** Modo del sheet — determina qué render y qué CTA. */
+  mode: 'transactions' | 'reminders'
+  /** Items del día — el caller los filtra. */
+  transactions?: TransactionWithCategory[]
+  reminders?: Reminder[]
+}
+
+function formatLongDate(iso: string): string {
+  const d = new Date(`${iso}T00:00:00`)
+  return d
+    .toLocaleDateString('es', {
+      weekday: 'long',
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+    })
+    .replace(/^\w/, (c) => c.toUpperCase())
+}
+
+/**
+ * Bottom sheet con el detalle del día seleccionado en el calendario.
+ * Reutiliza el [[Bottom Sheet (Modal-based)]] genérico.
+ *
+ * Dos modos:
+ *   - 'transactions': lista las tx del día + botón "Crear tx aquí" que
+ *     navega a /transactions/new (sin date pre-llenada por simplicidad —
+ *     el form usa hoy por default).
+ *   - 'reminders': lista los reminders que disparan en ese día + botón
+ *     "Crear recordatorio aquí".
+ */
+export function DayDetailSheet({
+  visible,
+  onClose,
+  dayIso,
+  mode,
+  transactions = [],
+  reminders = [],
+}: Props) {
+  const items = mode === 'transactions' ? transactions : reminders
+
+  const handleCreate = () => {
+    onClose()
+    setTimeout(() => {
+      router.push(mode === 'transactions' ? '/transactions/new' : '/reminders/new')
+    }, 250)
+  }
+
+  const handleItemPress = (id: string) => {
+    onClose()
+    setTimeout(() => {
+      router.push(
+        mode === 'transactions'
+          ? (`/transactions/${id}` as const)
+          : (`/reminders/${id}` as const)
+      )
+    }, 250)
+  }
+
+  const title = useMemo(() => (dayIso ? formatLongDate(dayIso) : ''), [dayIso])
+
+  return (
+    <BottomSheet visible={visible} onClose={onClose} maxHeightPercent={75}>
+      <Text className="text-white text-lg font-bold mb-1">{title}</Text>
+      <Text className="text-muted text-xs mb-3">
+        {items.length === 0
+          ? mode === 'transactions'
+            ? 'Sin transacciones este día'
+            : 'Sin recordatorios este día'
+          : `${items.length} ${items.length === 1 ? 'item' : 'items'}`}
+      </Text>
+
+      <ScrollView
+        className="max-h-80"
+        contentContainerStyle={{ paddingBottom: 8 }}
+        showsVerticalScrollIndicator={false}
+      >
+        {mode === 'transactions'
+          ? transactions.map((tx, idx) => (
+              <TouchableOpacity
+                key={tx.id}
+                onPress={() => handleItemPress(tx.id)}
+                activeOpacity={0.7}
+                className={`flex-row items-center py-3 ${
+                  idx < transactions.length - 1 ? 'border-b border-border' : ''
+                }`}
+              >
+                <View
+                  style={{ backgroundColor: tx.category?.color ?? '#4F46E5' }}
+                  className="w-9 h-9 rounded-full items-center justify-center mr-3"
+                >
+                  <Text className="text-base">{tx.category?.icon ?? '📂'}</Text>
+                </View>
+                <View className="flex-1">
+                  <Text className="text-white text-sm font-medium" numberOfLines={1}>
+                    {tx.description}
+                  </Text>
+                  <Text className="text-muted text-xs mt-0.5">
+                    {tx.category?.name ?? 'Sin categoría'}
+                  </Text>
+                </View>
+                <Text
+                  className={`text-sm font-semibold ${
+                    tx.type === 'income' ? 'text-green-400' : 'text-red-400'
+                  }`}
+                >
+                  {tx.type === 'income' ? '+' : '−'}{' '}
+                  {formatCurrency(Number(tx.amount), tx.currency)}
+                </Text>
+              </TouchableOpacity>
+            ))
+          : reminders.map((r, idx) => (
+              <TouchableOpacity
+                key={r.id}
+                onPress={() => handleItemPress(r.id)}
+                activeOpacity={0.7}
+                className={`flex-row items-center py-3 ${
+                  idx < reminders.length - 1 ? 'border-b border-border' : ''
+                }`}
+              >
+                <View className="w-9 h-9 rounded-full bg-primary items-center justify-center mr-3">
+                  <Text className="text-base">🔔</Text>
+                </View>
+                <View className="flex-1">
+                  <Text className="text-white text-sm font-medium" numberOfLines={1}>
+                    {r.description}
+                  </Text>
+                  <Text className="text-muted text-xs mt-0.5">
+                    {r.is_active ? '9:00 AM' : 'Pausado'}
+                  </Text>
+                </View>
+              </TouchableOpacity>
+            ))}
+      </ScrollView>
+
+      <View className="mt-3">
+        <PrimaryButton onPress={handleCreate}>
+          {mode === 'transactions' ? 'Crear transacción' : 'Crear recordatorio'}
+        </PrimaryButton>
+      </View>
+    </BottomSheet>
+  )
+}

--- a/components/ui/BottomSheet.tsx
+++ b/components/ui/BottomSheet.tsx
@@ -1,5 +1,6 @@
 import { useEffect, type ReactNode } from 'react'
 import { Modal, Pressable, View, useWindowDimensions } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -27,6 +28,13 @@ interface BottomSheetProps {
  *
  * NO incluye drag-to-dismiss ni snap points (para eso `@gorhom/bottom-sheet`).
  * Sirve para menús de acciones rápidas, action sheets simples y pickers.
+ *
+ * **Bug fix:** sin `presentationStyle="overFullScreen"` en iOS, el Modal NO
+ * cubre el área del tab bar / safe area inferior — el overlay queda "corto"
+ * y el tab bar se ve dimmed pero visible debajo del card. Con overFullScreen
+ * el modal sí cubre toda la ventana. Además aplicamos `paddingBottom` con
+ * el safe area inset para que el contenido del card no quede pegado al
+ * home indicator.
  */
 export function BottomSheet({
   visible,
@@ -35,6 +43,7 @@ export function BottomSheet({
   maxHeightPercent = 60,
 }: BottomSheetProps) {
   const { height } = useWindowDimensions()
+  const insets = useSafeAreaInsets()
   const translateY = useSharedValue(height) // empieza fuera de pantalla (abajo)
 
   useEffect(() => {
@@ -76,6 +85,7 @@ export function BottomSheet({
       animationType="none" // animamos nosotros con reanimated
       onRequestClose={handleClose}
       statusBarTranslucent
+      presentationStyle="overFullScreen"
     >
       {/* Overlay tap-to-close */}
       <Pressable
@@ -88,6 +98,10 @@ export function BottomSheet({
             style={[
               {
                 maxHeight: `${maxHeightPercent}%`,
+                // El safe area inferior se mete dentro del card como padding
+                // — así el card se extiende a la base de la pantalla y los
+                // botones quedan por encima del home indicator / tab bar.
+                paddingBottom: insets.bottom,
               },
               animatedStyle,
             ]}

--- a/components/ui/BottomSheet.tsx
+++ b/components/ui/BottomSheet.tsx
@@ -87,20 +87,25 @@ export function BottomSheet({
       statusBarTranslucent
       presentationStyle="overFullScreen"
     >
-      {/* Overlay tap-to-close */}
-      <Pressable
-        className="flex-1 bg-black/60 justify-end"
-        onPress={handleClose}
-      >
-        {/* El card mismo no propaga el tap */}
-        <Pressable onPress={() => {}}>
+      {/* Overlay tap-to-close — cubre toda la ventana */}
+      <Pressable className="flex-1 bg-black/60" onPress={handleClose}>
+        {/*
+          Container del card con posicionamiento absoluto al borde inferior
+          REAL de la ventana. Usar `justify-end` en el flex parent deja un
+          gap cuando el modal no cubre exactamente todo el viewport
+          (caso típico cuando el tab bar de expo-router se renderiza en
+          una capa intermedia). Con `bottom: 0` absoluto el card siempre
+          queda pegado al borde de la pantalla y el safe area inset se
+          mete como padding interno para los botones.
+        */}
+        <Pressable
+          onPress={() => {}}
+          style={{ position: 'absolute', bottom: 0, left: 0, right: 0 }}
+        >
           <Animated.View
             style={[
               {
                 maxHeight: `${maxHeightPercent}%`,
-                // El safe area inferior se mete dentro del card como padding
-                // — así el card se extiende a la base de la pantalla y los
-                // botones quedan por encima del home indicator / tab bar.
                 paddingBottom: insets.bottom,
               },
               animatedStyle,

--- a/components/ui/Icon.tsx
+++ b/components/ui/Icon.tsx
@@ -20,6 +20,7 @@ import {
   HandCoins,
   FolderTree,
   Bell,
+  Calendar as CalendarIcon,
 } from 'lucide-react-native'
 
 /**
@@ -54,6 +55,7 @@ const ICONS = {
   'hand-coins': HandCoins,
   'folder-tree': FolderTree,
   bell: Bell,
+  calendar: CalendarIcon,
 } as const
 
 export type IconName = keyof typeof ICONS

--- a/lib/utils/reminderMatchesDate.ts
+++ b/lib/utils/reminderMatchesDate.ts
@@ -1,0 +1,41 @@
+import type { Reminder } from '@/types/database.types'
+
+/**
+ * Devuelve true si el reminder dispara en la fecha dada.
+ *
+ * Para cada frequency hace el matching correspondiente:
+ *   - once: date == specific_date exacto
+ *   - weekly: date.getDay() == day_of_week (JS convention 0-6, Sunday=0)
+ *   - monthly: date.getDate() == day_of_month
+ *   - yearly: date.getMonth()+1 == month_of_year AND date.getDate() == day_of_month
+ *
+ * No mira `is_active` — el caller decide si filtrar inactivos antes.
+ */
+export function reminderMatchesDate(reminder: Reminder, date: Date): boolean {
+  switch (reminder.frequency) {
+    case 'once': {
+      if (!reminder.specific_date) return false
+      const iso = date.toISOString().slice(0, 10)
+      return iso === reminder.specific_date
+    }
+    case 'weekly':
+      return reminder.day_of_week === date.getDay()
+    case 'monthly':
+      return reminder.day_of_month === date.getDate()
+    case 'yearly':
+      return (
+        reminder.month_of_year === date.getMonth() + 1 &&
+        reminder.day_of_month === date.getDate()
+      )
+    default:
+      return false
+  }
+}
+
+/**
+ * Helper utilitario: convierte 'YYYY-MM-DD' (formato de react-native-calendars
+ * para días) en Date local sin time zone shift.
+ */
+export function parseDateString(iso: string): Date {
+  return new Date(`${iso}T00:00:00`)
+}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "nativewind": "^4.2.3",
     "react": "19.1.0",
     "react-native": "0.81.5",
+    "react-native-calendars": "^1.1314.0",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       react-native:
         specifier: 0.81.5
         version: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
+      react-native-calendars:
+        specifier: ^1.1314.0
+        version: 1.1314.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native-gesture-handler:
         specifier: ~2.28.0
         version: 2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -2616,6 +2619,9 @@ packages:
   lodash.throttle@4.1.1:
     resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
 
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
   log-symbols@2.2.0:
     resolution: {integrity: sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==}
     engines: {node: '>=4'}
@@ -2894,6 +2900,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  moment@2.30.1:
+    resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
+
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
@@ -3164,6 +3173,9 @@ packages:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
 
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -3215,6 +3227,10 @@ packages:
 
   react-is@19.2.5:
     resolution: {integrity: sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==}
+
+  react-native-calendars@1.1314.0:
+    resolution: {integrity: sha512-4DLAVto8Qo9L3ggL2vsY9Gk8FFpJWtne8F/3wN8yUb7Xha9/SKS4B+vs7xlhWjKeqZUHws/Vi/q/6IZ8s60kcQ==}
+    engines: {node: '>=18'}
 
   react-native-css-interop@0.2.3:
     resolution: {integrity: sha512-wc+JI7iUfdFBqnE18HhMTtD0q9vkhuMczToA87UdHGWwMyxdT5sCcNy+i4KInPCE855IY0Ic8kLQqecAIBWz7w==}
@@ -3280,6 +3296,9 @@ packages:
     peerDependencies:
       react: '*'
       react-native: '*'
+
+  react-native-swipe-gestures@1.0.5:
+    resolution: {integrity: sha512-Ns7Bn9H/Tyw278+5SQx9oAblDZ7JixyzeOczcBK8dipQk2pD7Djkcfnf1nB/8RErAmMLL9iXgW0QHqiII8AhKw==}
 
   react-native-worklets@0.5.1:
     resolution: {integrity: sha512-lJG6Uk9YuojjEX/tQrCbcbmpdLCSFxDK1rJlkDhgqkVi1KZzG7cdcBFQRqyNOOzR9Y0CXNuldmtWTGOyM0k0+w==}
@@ -3349,6 +3368,12 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
+
+  recyclerlistview@4.2.3:
+    resolution: {integrity: sha512-STR/wj/FyT8EMsBzzhZ1l2goYirMkIgfV3gYEPxI3Kf3lOnu6f7Dryhyw7/IkQrgX5xtTcDrZMqytvteH9rL3g==}
+    peerDependencies:
+      react: '>= 15.2.1'
+      react-native: '>= 0.30.0'
 
   regenerate-unicode-properties@10.2.2:
     resolution: {integrity: sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==}
@@ -3684,6 +3709,9 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
+  ts-object-utils@0.0.5:
+    resolution: {integrity: sha512-iV0GvHqOmilbIKJsfyfJY9/dNHCs969z3so90dQWsO1eMMozvTpnB1MEaUbb3FYtZTGjv5sIy/xmslEz0Rg2TA==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -3907,6 +3935,9 @@ packages:
   xcode@3.0.1:
     resolution: {integrity: sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==}
     engines: {node: '>=10.0.0'}
+
+  xdate@0.8.3:
+    resolution: {integrity: sha512-1NhJWPJwN+VjbkACT9XHbQK4o6exeSVtS2CxhMPwUE7xQakoEFTlwra9YcqV/uHQVyeEUYoYC46VGDJ+etnIiw==}
 
   xml2js@0.6.0:
     resolution: {integrity: sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==}
@@ -6970,6 +7001,8 @@ snapshots:
 
   lodash.throttle@4.1.1: {}
 
+  lodash@4.18.1: {}
+
   log-symbols@2.2.0:
     dependencies:
       chalk: 2.4.2
@@ -7590,6 +7623,9 @@ snapshots:
 
   mkdirp@1.0.4: {}
 
+  moment@2.30.1:
+    optional: true
+
   ms@2.0.0: {}
 
   ms@2.1.3: {}
@@ -7834,6 +7870,12 @@ snapshots:
       kleur: 3.0.3
       sisteransi: 1.0.5
 
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+
   punycode@2.3.1: {}
 
   qrcode-terminal@0.11.0: {}
@@ -7884,6 +7926,21 @@ snapshots:
   react-is@18.3.1: {}
 
   react-is@19.2.5: {}
+
+  react-native-calendars@1.1314.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+    dependencies:
+      hoist-non-react-statics: 3.3.2
+      lodash: 4.18.1
+      memoize-one: 5.2.1
+      prop-types: 15.8.1
+      react-native-swipe-gestures: 1.0.5
+      recyclerlistview: 4.2.3(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      xdate: 0.8.3
+    optionalDependencies:
+      moment: 2.30.1
+    transitivePeerDependencies:
+      - react
+      - react-native
 
   react-native-css-interop@0.2.3(react-native-reanimated@4.1.7(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.19(yaml@2.8.3)):
     dependencies:
@@ -7952,6 +8009,8 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
       warn-once: 0.1.1
+
+  react-native-swipe-gestures@1.0.5: {}
 
   react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -8062,6 +8121,14 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.2
+
+  recyclerlistview@4.2.3(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+    dependencies:
+      lodash.debounce: 4.0.8
+      prop-types: 15.8.1
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
+      ts-object-utils: 0.0.5
 
   regenerate-unicode-properties@10.2.2:
     dependencies:
@@ -8414,6 +8481,8 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
+  ts-object-utils@0.0.5: {}
+
   tslib@2.8.1: {}
 
   type-detect@4.0.8: {}
@@ -8584,6 +8653,8 @@ snapshots:
     dependencies:
       simple-plist: 1.3.1
       uuid: 7.0.3
+
+  xdate@0.8.3: {}
 
   xml2js@0.6.0:
     dependencies:


### PR DESCRIPTION
Closes #93 · Related to #86 (FASE 5) · **Última tarea de FASE 5**

## Cambios

### Deps
- \`react-native-calendars\` v1.13x — vista mensual estándar de Wix. JS puro, sin prebuild necesario.

### Backend / helpers
- **\`lib/utils/reminderMatchesDate.ts\`** — helper puro que dado un reminder y una Date devuelve si dispara ese día. Switch por frequency (once / weekly / monthly / yearly).

### UI
- **\`components/calendar/CalendarHeader.tsx\`** — segmented control 2 tabs (Transacciones / Recordatorios), mismo patrón visual que RangeSelector de Reports.
- **\`components/calendar/DayDetailSheet.tsx\`** — reusa \`<BottomSheet />\` con modo bifurcado. Muestra items del día (tx o reminders) + botón "Crear X aquí" que navega a la ruta de creación.
- **\`app/(dashboard)/calendar/\`** — _layout.tsx + index.tsx con:
  - LocaleConfig español al module-load.
  - Theme dark del calendar.
  - markedDates memoizadas:
    - Tx: multi-dot por color de categoría (máx 4 dots por día).
    - Reminders: derivados — iteramos cada día del mes visible y filtramos reminders activos cuyo \`reminderMatchesDate\` es true.
  - onMonthChange recalcula reminder markers.
  - Tap día → DayDetailSheet.

### Tab bar
- Antes: Dashboard · Transacciones · Reportes · Menú
- Después: **Dashboard · Transacciones · Calendario · Reportes · Menú** (5 tabs)
- Icono nuevo \`calendar\` (Calendar de lucide).

## Comportamiento visible

1. Tap tab Calendario → calendario mensual con dots según el tab activo.
2. Toggle entre tabs → markers cambian (tx por categoría color / reminders por categoría color o pink fallback).
3. Cambiar de mes → reminder markers se recalculan para el nuevo mes.
4. Tap día → bottom sheet con la lista del día.
5. Tap item del sheet → detalle.
6. Tap "Crear X aquí" → form de creación.

## Verificación

- [x] \`npx tsc --noEmit\` limpio
- [ ] Smoke test (requiere reload Metro — no rebuild):
  - [ ] 5 tabs visibles en bottom bar
  - [ ] Calendario navega meses
  - [ ] Tab Transacciones muestra dots en días con tx
  - [ ] Tab Recordatorios muestra dots en días que matchean (probar weekly el día actual)
  - [ ] Tap día abre sheet
  - [ ] Botones de creación funcionan

## Notas para Obsidian

- 🆕 [[react-native-calendars]] en \`10 - Concepts/React Native/\`
- Bitácora \`T-5.4 — Calendario.md\`

## Cierre de FASE 5

Después del merge: PR \`develop → main\` titulado \`FASE 5: Productividad + Polish UX\` con stop+aprobación.