### PR TITLE
FASE 5: Productividad + Polish UX

### DIFF
--- a/app.json
+++ b/app.json
@@ -42,7 +42,14 @@
       "expo-router",
       "expo-secure-store",
       "expo-web-browser",
-      "@react-native-community/datetimepicker"
+      "@react-native-community/datetimepicker",
+      [
+        "expo-notifications",
+        {
+          "icon": "./assets/icon.png",
+          "color": "#4F46E5"
+        }
+      ]
     ]
   }
 }

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -94,7 +94,11 @@ export default function LoginScreen() {
         throw new Error('Tu email no está autorizado para usar la app')
       }
 
-      // Create user in our users table if not exists
+      // Sync user row con los claims más recientes de Google. Para users
+      // existentes: actualiza name + avatar_url (importante para que se
+      // refleje cuando el user cambia su foto en Google, o para arreglar
+      // users legacy que se crearon sin avatar). Para users nuevos: crea
+      // la fila con los defaults.
       const { data: existingUser } = await insforge.database
         .from('users')
         .select('id')
@@ -108,6 +112,16 @@ export default function LoginScreen() {
           avatar_url,
           preferred_currency: 'COP',
         }])
+      } else if (name || avatar_url) {
+        // Solo actualizamos los campos que llegaron — evitamos sobreescribir
+        // con null si Google no devolvió alguno.
+        const patch: Record<string, string> = {}
+        if (name) patch.name = name
+        if (avatar_url) patch.avatar_url = avatar_url
+        await insforge.database
+          .from('users')
+          .update(patch)
+          .eq('email', email)
       }
 
       // Persist session (email-based) and load user profile

--- a/app/(dashboard)/_layout.tsx
+++ b/app/(dashboard)/_layout.tsx
@@ -56,6 +56,15 @@ export default function DashboardLayout() {
           }}
         />
         <Tabs.Screen
+          name="calendar"
+          options={{
+            title: 'Calendario',
+            tabBarIcon: ({ color, size }) => (
+              <Icon name="calendar" color={color} size={size} />
+            ),
+          }}
+        />
+        <Tabs.Screen
           name="reports"
           options={{
             title: 'Reportes',

--- a/app/(dashboard)/_layout.tsx
+++ b/app/(dashboard)/_layout.tsx
@@ -76,9 +76,9 @@ export default function DashboardLayout() {
         <Tabs.Screen
           name="quick-actions"
           options={{
-            title: 'Crear',
+            title: 'Menú',
             tabBarIcon: ({ color, size }) => (
-              <Icon name="plus" color={color} size={size + 4} />
+              <Icon name="menu" color={color} size={size} />
             ),
           }}
           listeners={{

--- a/app/(dashboard)/_layout.tsx
+++ b/app/(dashboard)/_layout.tsx
@@ -1,12 +1,19 @@
 // app/(dashboard)/_layout.tsx
+//
+// Tab bar principal. El tab "+" (Crear) intercepta el tap y abre un bottom
+// sheet con quick actions en lugar de navegar — patrón documentado en
+// Obsidian: 30 - Patterns/Tab-intercepted modal sheet.md
 import { Tabs, router } from 'expo-router'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
+import { View } from 'react-native'
 import { useAuth } from '@/context/AuthContext'
 import { colors } from '@/constants/theme'
 import { Icon } from '@/components/ui/Icon'
+import { QuickActionsSheet } from '@/components/quick-actions/QuickActionsSheet'
 
 export default function DashboardLayout() {
   const { user, loading } = useAuth()
+  const [sheetVisible, setSheetVisible] = useState(false)
 
   useEffect(() => {
     if (!loading && !user) {
@@ -17,66 +24,88 @@ export default function DashboardLayout() {
   if (loading || !user) return null
 
   return (
-    <Tabs
-      screenOptions={{
-        headerShown: false,
-        tabBarStyle: {
-          backgroundColor: colors.surface,
-          borderTopColor: colors.border,
-        },
-        tabBarActiveTintColor: colors.primary,
-        tabBarInactiveTintColor: colors.muted,
-        tabBarLabelStyle: { fontSize: 11 },
-      }}
-    >
-      <Tabs.Screen
-        name="index"
-        options={{
-          title: 'Dashboard',
-          tabBarIcon: ({ color, size }) => (
-            <Icon name="dashboard" color={color} size={size} />
-          ),
+    <View style={{ flex: 1 }}>
+      <Tabs
+        screenOptions={{
+          headerShown: false,
+          tabBarStyle: {
+            backgroundColor: colors.surface,
+            borderTopColor: colors.border,
+          },
+          tabBarActiveTintColor: colors.primary,
+          tabBarInactiveTintColor: colors.muted,
+          tabBarLabelStyle: { fontSize: 11 },
         }}
-      />
-      <Tabs.Screen
-        name="transactions"
-        options={{
-          title: 'Transacciones',
-          tabBarIcon: ({ color, size }) => (
-            <Icon name="transactions" color={color} size={size} />
-          ),
-        }}
-      />
-      <Tabs.Screen
-        name="reports"
-        options={{
-          title: 'Reportes',
-          tabBarIcon: ({ color, size }) => (
-            <Icon name="chart" color={color} size={size} />
-          ),
-        }}
-      />
-      <Tabs.Screen
-        name="more"
-        options={{
-          title: 'Más',
-          tabBarIcon: ({ color, size }) => (
-            <Icon name="menu" color={color} size={size} />
-          ),
-        }}
-      />
+      >
+        <Tabs.Screen
+          name="index"
+          options={{
+            title: 'Dashboard',
+            tabBarIcon: ({ color, size }) => (
+              <Icon name="dashboard" color={color} size={size} />
+            ),
+          }}
+        />
+        <Tabs.Screen
+          name="transactions"
+          options={{
+            title: 'Transacciones',
+            tabBarIcon: ({ color, size }) => (
+              <Icon name="transactions" color={color} size={size} />
+            ),
+          }}
+        />
+        <Tabs.Screen
+          name="reports"
+          options={{
+            title: 'Reportes',
+            tabBarIcon: ({ color, size }) => (
+              <Icon name="chart" color={color} size={size} />
+            ),
+          }}
+        />
 
-      {/*
-        Hubs accesibles desde la pantalla "Más" — NO se exponen como tabs
-        directos para mantener el bottom bar limpio. expo-router los
-        descubre automáticamente al tener _layout.tsx; href: null los
-        oculta del tab bar pero quedan navegables con router.push('/xxx').
-      */}
-      <Tabs.Screen name="accounts" options={{ href: null }} />
-      <Tabs.Screen name="categories" options={{ href: null }} />
-      <Tabs.Screen name="budgets" options={{ href: null }} />
-      <Tabs.Screen name="savings" options={{ href: null }} />
-      <Tabs.Screen name="loans" options={{ href: null }} />
-    </Tabs>
+        {/*
+          Tab "+" — intercepta el tabPress para abrir el sheet de quick
+          actions en lugar de navegar. `href: null` previene el navigate;
+          el listener captura el tap antes de cualquier navegación.
+
+          Apunta a `profile` solo para tener una ruta válida — pero el
+          listener cancela el navigate y abre el sheet.
+        */}
+        <Tabs.Screen
+          name="quick-actions"
+          options={{
+            title: 'Crear',
+            tabBarIcon: ({ color, size }) => (
+              <Icon name="plus" color={color} size={size + 4} />
+            ),
+          }}
+          listeners={{
+            tabPress: (e) => {
+              e.preventDefault()
+              setSheetVisible(true)
+            },
+          }}
+        />
+
+        {/*
+          Hubs accesibles vía router.push, no en el tab bar.
+          - profile: accesible desde el sheet de quick actions
+          - el resto: desde profile > Datos
+        */}
+        <Tabs.Screen name="profile" options={{ href: null }} />
+        <Tabs.Screen name="accounts" options={{ href: null }} />
+        <Tabs.Screen name="categories" options={{ href: null }} />
+        <Tabs.Screen name="budgets" options={{ href: null }} />
+        <Tabs.Screen name="savings" options={{ href: null }} />
+        <Tabs.Screen name="loans" options={{ href: null }} />
+      </Tabs>
+
+      <QuickActionsSheet
+        visible={sheetVisible}
+        onClose={() => setSheetVisible(false)}
+      />
+    </View>
   )
 }

--- a/app/(dashboard)/_layout.tsx
+++ b/app/(dashboard)/_layout.tsx
@@ -100,6 +100,7 @@ export default function DashboardLayout() {
         <Tabs.Screen name="budgets" options={{ href: null }} />
         <Tabs.Screen name="savings" options={{ href: null }} />
         <Tabs.Screen name="loans" options={{ href: null }} />
+        <Tabs.Screen name="reminders" options={{ href: null }} />
       </Tabs>
 
       <QuickActionsSheet

--- a/app/(dashboard)/calendar/_layout.tsx
+++ b/app/(dashboard)/calendar/_layout.tsx
@@ -1,0 +1,13 @@
+import { Stack } from 'expo-router'
+import { colors } from '@/constants/theme'
+
+export default function CalendarLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: colors.bg },
+      }}
+    />
+  )
+}

--- a/app/(dashboard)/calendar/index.tsx
+++ b/app/(dashboard)/calendar/index.tsx
@@ -1,0 +1,217 @@
+// app/(dashboard)/calendar/index.tsx
+//
+// Calendario con 2 tabs (Transacciones / Recordatorios) usando
+// react-native-calendars. Markers según el tab activo; tap día abre
+// DayDetailSheet con la lista del día + botón de crear.
+import { useCallback, useMemo, useState } from 'react'
+import { View, Text, ActivityIndicator } from 'react-native'
+import { Calendar, LocaleConfig } from 'react-native-calendars'
+import { useFocusEffect } from 'expo-router'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useAuth } from '@/context/AuthContext'
+import { getTransactions } from '@/lib/actions/transactions.actions'
+import { getReminders } from '@/lib/actions/reminders.actions'
+import { CalendarHeader, type CalendarTab } from '@/components/calendar/CalendarHeader'
+import { DayDetailSheet } from '@/components/calendar/DayDetailSheet'
+import { reminderMatchesDate } from '@/lib/utils/reminderMatchesDate'
+import { colors } from '@/constants/theme'
+import type {
+  ReminderWithCategory,
+  TransactionWithCategory,
+} from '@/types/database.types'
+
+// ---------------------------------------------------------------------------
+// Locale español para react-native-calendars
+// ---------------------------------------------------------------------------
+LocaleConfig.locales['es'] = {
+  monthNames: [
+    'Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio',
+    'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre',
+  ],
+  monthNamesShort: [
+    'Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun',
+    'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic',
+  ],
+  dayNames: [
+    'Domingo', 'Lunes', 'Martes', 'Miércoles', 'Jueves', 'Viernes', 'Sábado',
+  ],
+  dayNamesShort: ['D', 'L', 'M', 'M', 'J', 'V', 'S'],
+  today: 'Hoy',
+}
+LocaleConfig.defaultLocale = 'es'
+
+// Theme dark adaptado a los tokens del proyecto
+const CALENDAR_THEME = {
+  backgroundColor: colors.bg,
+  calendarBackground: colors.bg,
+  textSectionTitleColor: colors.muted,
+  selectedDayBackgroundColor: colors.primary,
+  selectedDayTextColor: '#fff',
+  todayTextColor: colors.primary,
+  dayTextColor: '#fff',
+  textDisabledColor: '#3f3f46',
+  arrowColor: colors.primary,
+  monthTextColor: '#fff',
+  textMonthFontWeight: 'bold' as const,
+  textDayFontSize: 14,
+  textMonthFontSize: 16,
+}
+
+function currentMonthIso(): string {
+  // YYYY-MM-DD del primer día del mes actual
+  const d = new Date()
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-01`
+}
+
+export default function CalendarScreen() {
+  const { user } = useAuth()
+  const [tab, setTab] = useState<CalendarTab>('transactions')
+  const [loading, setLoading] = useState(true)
+  const [transactions, setTransactions] = useState<TransactionWithCategory[]>([])
+  const [reminders, setReminders] = useState<ReminderWithCategory[]>([])
+  const [visibleMonth, setVisibleMonth] = useState<string>(currentMonthIso())
+
+  const [selectedDay, setSelectedDay] = useState<string | null>(null)
+
+  // Cargamos datasets completos al focus — el calendario es vista panorámica,
+  // no se beneficia mucho de paginar por mes (los reminders no tienen filtro
+  // de mes en backend y las tx son < 500 en general).
+  const loadData = useCallback(async () => {
+    if (!user) return
+    const [txRes, remRes] = await Promise.all([
+      getTransactions(user.id, {}, { page: 1, pageSize: 500 }),
+      getReminders(user.id),
+    ])
+    if (txRes.success && txRes.data) setTransactions(txRes.data.items)
+    if (remRes.success && remRes.data) setReminders(remRes.data)
+    setLoading(false)
+  }, [user])
+
+  useFocusEffect(
+    useCallback(() => {
+      let cancelled = false
+      ;(async () => {
+        if (cancelled) return
+        await loadData()
+      })()
+      return () => {
+        cancelled = true
+      }
+    }, [loadData])
+  )
+
+  // ---------------------------------------------------------------------------
+  // markedDates por tab
+  // ---------------------------------------------------------------------------
+  /**
+   * Para transacciones: multi-dot por día con el color de cada categoría
+   * presente. Si hay más de 4 categorías distintas en el día, mostramos las
+   * primeras 4 (react-native-calendars limita visualmente igual).
+   */
+  const transactionMarkers = useMemo(() => {
+    const map: Record<string, { dots: { color: string; key: string }[] }> = {}
+    for (const tx of transactions) {
+      const date = tx.date.slice(0, 10)
+      if (!map[date]) map[date] = { dots: [] }
+      const color = tx.category?.color ?? '#4F46E5'
+      const key = tx.category?.id ?? 'sin-cat'
+      // Evitar duplicar dots de la misma categoría en el mismo día
+      if (!map[date].dots.find((d) => d.key === key)) {
+        if (map[date].dots.length < 4) {
+          map[date].dots.push({ color, key })
+        }
+      }
+    }
+    return map
+  }, [transactions])
+
+  /**
+   * Para reminders: dots por día donde algún reminder activo dispara.
+   * Filtramos solo los activos. Iteramos los días visibles del mes (suficiente
+   * para una vista mensual — para anuales recordatorios futuros también
+   * marcamos su día del mes actual).
+   */
+  const reminderMarkers = useMemo(() => {
+    const map: Record<string, { dots: { color: string; key: string }[] }> = {}
+    if (!visibleMonth) return map
+    const [year, month] = visibleMonth.split('-').map(Number)
+    const daysInMonth = new Date(year, month, 0).getDate()
+    const active = reminders.filter((r) => r.is_active)
+
+    for (let day = 1; day <= daysInMonth; day++) {
+      const date = new Date(year, month - 1, day)
+      const matching = active.filter((r) => reminderMatchesDate(r, date))
+      if (matching.length === 0) continue
+      const iso = `${year}-${String(month).padStart(2, '0')}-${String(day).padStart(2, '0')}`
+      map[iso] = {
+        dots: matching.slice(0, 4).map((r) => ({
+          color: r.category?.color ?? '#ec4899',
+          key: r.id,
+        })),
+      }
+    }
+    return map
+  }, [reminders, visibleMonth])
+
+  const markedDates = tab === 'transactions' ? transactionMarkers : reminderMarkers
+
+  // ---------------------------------------------------------------------------
+  // Items del día seleccionado
+  // ---------------------------------------------------------------------------
+  const selectedDayTransactions = useMemo(() => {
+    if (!selectedDay) return []
+    return transactions.filter((t) => t.date.slice(0, 10) === selectedDay)
+  }, [transactions, selectedDay])
+
+  const selectedDayReminders = useMemo(() => {
+    if (!selectedDay) return []
+    const date = new Date(`${selectedDay}T00:00:00`)
+    return reminders.filter((r) => r.is_active && reminderMatchesDate(r, date))
+  }, [reminders, selectedDay])
+
+  if (loading) {
+    return (
+      <SafeAreaView edges={['top']} className="flex-1 bg-bg">
+        <View className="flex-1 items-center justify-center">
+          <ActivityIndicator color="#4F46E5" />
+        </View>
+      </SafeAreaView>
+    )
+  }
+
+  return (
+    <SafeAreaView edges={['top']} className="flex-1 bg-bg">
+      <View className="px-4 py-3 border-b border-border">
+        <Text className="text-white text-xl font-bold">Calendario</Text>
+      </View>
+
+      <CalendarHeader value={tab} onChange={setTab} />
+
+      <Calendar
+        // Usamos la primera fecha del mes para que react-native-calendars
+        // sepa qué mes mostrar inicialmente
+        current={visibleMonth}
+        markedDates={markedDates}
+        markingType="multi-dot"
+        firstDay={1}
+        theme={CALENDAR_THEME}
+        onDayPress={(day) => setSelectedDay(day.dateString)}
+        onMonthChange={(month) => {
+          setVisibleMonth(`${month.year}-${String(month.month).padStart(2, '0')}-01`)
+        }}
+        style={{
+          backgroundColor: colors.bg,
+        }}
+      />
+
+      <DayDetailSheet
+        visible={selectedDay !== null}
+        onClose={() => setSelectedDay(null)}
+        dayIso={selectedDay}
+        mode={tab}
+        transactions={selectedDayTransactions}
+        reminders={selectedDayReminders}
+      />
+    </SafeAreaView>
+  )
+}

--- a/app/(dashboard)/calendar/index.tsx
+++ b/app/(dashboard)/calendar/index.tsx
@@ -3,10 +3,10 @@
 // Calendario con 2 tabs (Transacciones / Recordatorios) usando
 // react-native-calendars. Markers según el tab activo; tap día abre
 // DayDetailSheet con la lista del día + botón de crear.
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { View, Text, ActivityIndicator } from 'react-native'
 import { Calendar, LocaleConfig } from 'react-native-calendars'
-import { useFocusEffect } from 'expo-router'
+import { useFocusEffect, useNavigation } from 'expo-router'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useAuth } from '@/context/AuthContext'
 import { getTransactions } from '@/lib/actions/transactions.actions'
@@ -65,6 +65,7 @@ function currentMonthIso(): string {
 
 export default function CalendarScreen() {
   const { user } = useAuth()
+  const navigation = useNavigation()
   const [tab, setTab] = useState<CalendarTab>('transactions')
   const [loading, setLoading] = useState(true)
   const [transactions, setTransactions] = useState<TransactionWithCategory[]>([])
@@ -72,6 +73,27 @@ export default function CalendarScreen() {
   const [visibleMonth, setVisibleMonth] = useState<string>(currentMonthIso())
 
   const [selectedDay, setSelectedDay] = useState<string | null>(null)
+
+  /**
+   * Cuando el DayDetailSheet está abierto, ocultamos el tab bar del navegador
+   * padre. Esto resuelve el bug de "transparencia debajo del card" que aparece
+   * cuando un Modal se monta dentro de un screen de tab navigator — el tab
+   * bar se renderiza en una capa intermedia que el modal no cubre.
+   *
+   * Al cerrarse el sheet (selectedDay === null), restauramos el tab bar.
+   */
+  useEffect(() => {
+    const parent = navigation.getParent()
+    if (!parent) return
+    parent.setOptions({
+      tabBarStyle: selectedDay
+        ? { display: 'none' }
+        : {
+            backgroundColor: colors.surface,
+            borderTopColor: colors.border,
+          },
+    })
+  }, [selectedDay, navigation])
 
   // Cargamos datasets completos al focus — el calendario es vista panorámica,
   // no se beneficia mucho de paginar por mes (los reminders no tienen filtro

--- a/app/(dashboard)/profile/_layout.tsx
+++ b/app/(dashboard)/profile/_layout.tsx
@@ -1,0 +1,13 @@
+import { Stack } from 'expo-router'
+import { colors } from '@/constants/theme'
+
+export default function ProfileLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: colors.bg },
+      }}
+    />
+  )
+}

--- a/app/(dashboard)/profile/index.tsx
+++ b/app/(dashboard)/profile/index.tsx
@@ -1,4 +1,7 @@
-// app/(dashboard)/more.tsx
+// app/(dashboard)/profile/index.tsx
+//
+// Pantalla de perfil/configuración. Reemplaza al tab "Más" eliminado en
+// T-5.2 — ahora se accede desde el sheet de Quick Actions (último tile).
 import { useState } from 'react'
 import {
   View,
@@ -33,7 +36,7 @@ function formatDate(iso: string | null): string {
   })
 }
 
-export default function MoreScreen() {
+export default function ProfileScreen() {
   const { user, signOut, refreshUser } = useAuth()
   const [showCurrency, setShowCurrency] = useState(false)
   const [savingCurrency, setSavingCurrency] = useState(false)
@@ -67,8 +70,13 @@ export default function MoreScreen() {
 
   return (
     <SafeAreaView edges={['top']} className="flex-1 bg-bg">
-      <View className="px-4 py-3 border-b border-border">
-        <Text className="text-white text-xl font-bold">Más opciones</Text>
+      {/* Header con back */}
+      <View className="flex-row items-center justify-between px-4 py-3 border-b border-border">
+        <TouchableOpacity onPress={() => router.back()} activeOpacity={0.7}>
+          <Text className="text-primary text-base">← Volver</Text>
+        </TouchableOpacity>
+        <Text className="text-white text-base font-bold">Perfil</Text>
+        <View style={{ width: 60 }} />
       </View>
 
       <ScrollView

--- a/app/(dashboard)/profile/index.tsx
+++ b/app/(dashboard)/profile/index.tsx
@@ -20,6 +20,10 @@ import { Icon, type IconName } from '@/components/ui/Icon'
 import { toast } from '@/components/ui/Toast'
 import type { Currency } from '@/types/database.types'
 
+// Los hubs (Cuentas, Categorías, Presupuestos, Metas, Préstamos) están en
+// el menú principal del bottom bar. Esta pantalla se enfoca solo en perfil,
+// preferencias y conexiones del user.
+
 const CURRENCY_OPTIONS: { label: string; value: string }[] = [
   { label: 'COP — Peso Colombiano', value: 'COP' },
   { label: 'USD — Dólar', value: 'USD' },
@@ -146,34 +150,6 @@ export default function ProfileScreen() {
             </View>
           ) : null}
         </View>
-
-        {/* Datos */}
-        <SectionHeader title="Datos" />
-        <SettingsRow
-          icon="wallet"
-          label="Cuentas"
-          onPress={() => router.push('/accounts')}
-        />
-        <SettingsRow
-          icon="folder-tree"
-          label="Categorías"
-          onPress={() => router.push('/categories')}
-        />
-        <SettingsRow
-          icon="target"
-          label="Presupuestos"
-          onPress={() => router.push('/budgets')}
-        />
-        <SettingsRow
-          icon="piggy"
-          label="Metas de ahorro"
-          onPress={() => router.push('/savings')}
-        />
-        <SettingsRow
-          icon="hand-coins"
-          label="Préstamos"
-          onPress={() => router.push('/loans')}
-        />
 
         {/* Sign out */}
         <View className="px-4 pt-10">

--- a/app/(dashboard)/quick-actions.tsx
+++ b/app/(dashboard)/quick-actions.tsx
@@ -1,0 +1,13 @@
+// app/(dashboard)/quick-actions.tsx
+//
+// Ruta dummy — nunca se renderiza en práctica. El tabPress del tab "Crear"
+// se intercepta en _layout.tsx con e.preventDefault() y abre el
+// QuickActionsSheet en su lugar. expo-router exige que el tab apunte a una
+// ruta válida; esta vive solo para satisfacer ese requisito.
+//
+// Ver: 30 - Patterns/Tab-intercepted modal sheet.md
+import { View } from 'react-native'
+
+export default function QuickActionsPlaceholder() {
+  return <View className="flex-1 bg-bg" />
+}

--- a/app/(dashboard)/reminders/[id].tsx
+++ b/app/(dashboard)/reminders/[id].tsx
@@ -1,0 +1,424 @@
+import { useEffect, useState } from 'react'
+import {
+  View,
+  Text,
+  ScrollView,
+  TouchableOpacity,
+  KeyboardAvoidingView,
+  Platform,
+  ActivityIndicator,
+  Switch,
+} from 'react-native'
+import { useLocalSearchParams, router } from 'expo-router'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useAuth } from '@/context/AuthContext'
+import {
+  getReminderById,
+  createReminder,
+  updateReminder,
+  deleteReminder,
+} from '@/lib/actions/reminders.actions'
+import { getCategories } from '@/lib/actions/categories.actions'
+import { FormInput } from '@/components/ui/FormInput'
+import { SelectModal } from '@/components/ui/SelectModal'
+import { DateInput } from '@/components/ui/DateInput'
+import { PrimaryButton } from '@/components/ui/PrimaryButton'
+import { confirmDialog } from '@/components/ui/ConfirmDialog'
+import { toast } from '@/components/ui/Toast'
+import type {
+  Category,
+  ReminderFrequency,
+} from '@/types/database.types'
+
+const FREQUENCY_OPTIONS: { value: ReminderFrequency; label: string }[] = [
+  { value: 'once', label: 'Una vez' },
+  { value: 'weekly', label: 'Semanal' },
+  { value: 'monthly', label: 'Mensual' },
+  { value: 'yearly', label: 'Anual' },
+]
+
+const WEEKDAY_OPTIONS = [
+  { label: 'Domingo', value: '0' },
+  { label: 'Lunes', value: '1' },
+  { label: 'Martes', value: '2' },
+  { label: 'Miércoles', value: '3' },
+  { label: 'Jueves', value: '4' },
+  { label: 'Viernes', value: '5' },
+  { label: 'Sábado', value: '6' },
+]
+
+const MONTH_OPTIONS = [
+  { label: 'Enero', value: '1' },
+  { label: 'Febrero', value: '2' },
+  { label: 'Marzo', value: '3' },
+  { label: 'Abril', value: '4' },
+  { label: 'Mayo', value: '5' },
+  { label: 'Junio', value: '6' },
+  { label: 'Julio', value: '7' },
+  { label: 'Agosto', value: '8' },
+  { label: 'Septiembre', value: '9' },
+  { label: 'Octubre', value: '10' },
+  { label: 'Noviembre', value: '11' },
+  { label: 'Diciembre', value: '12' },
+]
+
+// Helper para generar días del mes 1-31
+const DAY_OPTIONS = Array.from({ length: 31 }, (_, i) => ({
+  label: String(i + 1),
+  value: String(i + 1),
+}))
+
+export default function ReminderFormScreen() {
+  const { id } = useLocalSearchParams<{ id: string }>()
+  const { user } = useAuth()
+  const isNew = id === 'new'
+
+  const [initialLoading, setInitialLoading] = useState(!isNew)
+  const [saving, setSaving] = useState(false)
+  const [categories, setCategories] = useState<Category[]>([])
+
+  // Form state
+  const [description, setDescription] = useState('')
+  const [frequency, setFrequency] = useState<ReminderFrequency>('monthly')
+  const [dayOfWeek, setDayOfWeek] = useState<number | null>(null)
+  const [dayOfMonth, setDayOfMonth] = useState<number | null>(null)
+  const [monthOfYear, setMonthOfYear] = useState<number | null>(null)
+  const [specificDate, setSpecificDate] = useState<string>('')
+  const [categoryId, setCategoryId] = useState<string>('')
+  const [isActive, setIsActive] = useState(true)
+
+  // Modal toggles
+  const [showFreqPicker, setShowFreqPicker] = useState(false)
+  const [showDayWeekPicker, setShowDayWeekPicker] = useState(false)
+  const [showDayMonthPicker, setShowDayMonthPicker] = useState(false)
+  const [showMonthPicker, setShowMonthPicker] = useState(false)
+  const [showCategoryPicker, setShowCategoryPicker] = useState(false)
+
+  useEffect(() => {
+    if (!user) return
+    let cancelled = false
+
+    getCategories(user.id).then((res) => {
+      if (cancelled) return
+      if (res.success && res.data) setCategories(res.data)
+    })
+
+    if (!isNew) {
+      getReminderById(id, user.id).then((res) => {
+        if (cancelled) return
+        if (res.success && res.data) {
+          const r = res.data
+          setDescription(r.description)
+          setFrequency(r.frequency)
+          setDayOfWeek(r.day_of_week)
+          setDayOfMonth(r.day_of_month)
+          setMonthOfYear(r.month_of_year)
+          setSpecificDate(r.specific_date ?? '')
+          setCategoryId(r.category_id ?? '')
+          setIsActive(r.is_active)
+        } else {
+          toast.error(res.error ?? 'Recordatorio no encontrado')
+          router.back()
+        }
+        setInitialLoading(false)
+      })
+    }
+
+    return () => {
+      cancelled = true
+    }
+  }, [user, id, isNew])
+
+  function validate(): string | null {
+    if (!description.trim()) return 'La descripción es requerida'
+    if (frequency === 'once' && !specificDate) return 'Selecciona la fecha'
+    if (frequency === 'weekly' && dayOfWeek === null) return 'Selecciona el día de la semana'
+    if (frequency === 'monthly' && !dayOfMonth) return 'Selecciona el día del mes'
+    if (frequency === 'yearly' && (!dayOfMonth || !monthOfYear)) return 'Selecciona mes y día'
+    return null
+  }
+
+  async function handleSubmit() {
+    if (!user) return
+    const err = validate()
+    if (err) {
+      toast.error(err)
+      return
+    }
+    setSaving(true)
+
+    // Solo enviamos los campos relevantes para la frequency — los demás van null
+    const input = {
+      description: description.trim(),
+      frequency,
+      day_of_week: frequency === 'weekly' ? dayOfWeek : null,
+      day_of_month: frequency === 'monthly' || frequency === 'yearly' ? dayOfMonth : null,
+      month_of_year: frequency === 'yearly' ? monthOfYear : null,
+      specific_date: frequency === 'once' ? specificDate : null,
+      category_id: categoryId || null,
+      is_active: isActive,
+    }
+    const result = isNew
+      ? await createReminder(user.id, input)
+      : await updateReminder(id, user.id, input)
+    setSaving(false)
+
+    if (result.success) {
+      toast.success(isNew ? 'Recordatorio creado' : 'Recordatorio actualizado')
+      router.back()
+    } else {
+      toast.error(result.error ?? 'Error al guardar')
+    }
+  }
+
+  async function handleDelete() {
+    if (!user || isNew) return
+    const ok = await confirmDialog({
+      title: 'Eliminar recordatorio',
+      message: 'Se cancelará la notificación programada.',
+      confirmLabel: 'Eliminar',
+      destructive: true,
+    })
+    if (!ok) return
+
+    setSaving(true)
+    const result = await deleteReminder(id, user.id)
+    setSaving(false)
+    if (result.success) {
+      toast.success('Recordatorio eliminado')
+      router.back()
+    } else {
+      toast.error(result.error ?? 'Error al eliminar')
+    }
+  }
+
+  const categoryOptions = [
+    { label: 'Sin categoría', value: '' },
+    ...categories.map((c) => ({
+      label: `${c.icon ?? ''} ${c.name}`.trim(),
+      value: c.id,
+    })),
+  ]
+  const selectedCategory = categories.find((c) => c.id === categoryId)
+
+  if (initialLoading) {
+    return (
+      <View className="flex-1 bg-bg items-center justify-center">
+        <ActivityIndicator color="#4F46E5" />
+      </View>
+    )
+  }
+
+  return (
+    <SafeAreaView edges={['top', 'bottom']} className="flex-1 bg-bg">
+      {/* Header */}
+      <View className="flex-row items-center justify-between px-4 py-3 border-b border-border">
+        <TouchableOpacity onPress={() => router.back()} activeOpacity={0.7}>
+          <Text className="text-primary text-base">← Volver</Text>
+        </TouchableOpacity>
+        <Text className="text-white text-base font-bold">
+          {isNew ? 'Nuevo recordatorio' : 'Editar recordatorio'}
+        </Text>
+        {!isNew ? (
+          <TouchableOpacity onPress={handleDelete} disabled={saving} activeOpacity={0.7}>
+            <Text className="text-red-400 text-sm">Eliminar</Text>
+          </TouchableOpacity>
+        ) : (
+          <View style={{ width: 60 }} />
+        )}
+      </View>
+
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+        className="flex-1"
+      >
+        <ScrollView
+          className="flex-1 px-4"
+          contentContainerStyle={{ paddingVertical: 16, paddingBottom: 40 }}
+          keyboardShouldPersistTaps="handled"
+        >
+          <FormInput
+            label="Descripción *"
+            value={description}
+            onChangeText={setDescription}
+            placeholder="Ej: Pagar arriendo"
+          />
+
+          {/* Frequency */}
+          <View className="mb-4">
+            <Text className="text-muted text-sm mb-1">Frecuencia *</Text>
+            <TouchableOpacity
+              onPress={() => setShowFreqPicker(true)}
+              activeOpacity={0.7}
+              className="bg-surface border border-border rounded-xl px-4 py-3"
+            >
+              <Text className="text-white">
+                {FREQUENCY_OPTIONS.find((o) => o.value === frequency)?.label}
+              </Text>
+            </TouchableOpacity>
+          </View>
+
+          {/* Campos condicionales según frequency */}
+          {frequency === 'once' ? (
+            <DateInput
+              label="Fecha *"
+              value={specificDate}
+              onChange={setSpecificDate}
+              minimumDate={new Date()}
+            />
+          ) : null}
+
+          {frequency === 'weekly' ? (
+            <View className="mb-4">
+              <Text className="text-muted text-sm mb-1">Día de la semana *</Text>
+              <TouchableOpacity
+                onPress={() => setShowDayWeekPicker(true)}
+                activeOpacity={0.7}
+                className="bg-surface border border-border rounded-xl px-4 py-3"
+              >
+                <Text className={dayOfWeek !== null ? 'text-white' : 'text-muted'}>
+                  {dayOfWeek !== null
+                    ? WEEKDAY_OPTIONS.find((o) => o.value === String(dayOfWeek))?.label
+                    : 'Seleccionar día...'}
+                </Text>
+              </TouchableOpacity>
+            </View>
+          ) : null}
+
+          {(frequency === 'monthly' || frequency === 'yearly') ? (
+            <View className="mb-4">
+              <Text className="text-muted text-sm mb-1">Día del mes *</Text>
+              <TouchableOpacity
+                onPress={() => setShowDayMonthPicker(true)}
+                activeOpacity={0.7}
+                className="bg-surface border border-border rounded-xl px-4 py-3"
+              >
+                <Text className={dayOfMonth ? 'text-white' : 'text-muted'}>
+                  {dayOfMonth ? `Día ${dayOfMonth}` : 'Seleccionar día...'}
+                </Text>
+              </TouchableOpacity>
+            </View>
+          ) : null}
+
+          {frequency === 'yearly' ? (
+            <View className="mb-4">
+              <Text className="text-muted text-sm mb-1">Mes *</Text>
+              <TouchableOpacity
+                onPress={() => setShowMonthPicker(true)}
+                activeOpacity={0.7}
+                className="bg-surface border border-border rounded-xl px-4 py-3"
+              >
+                <Text className={monthOfYear ? 'text-white' : 'text-muted'}>
+                  {monthOfYear
+                    ? MONTH_OPTIONS.find((o) => o.value === String(monthOfYear))?.label
+                    : 'Seleccionar mes...'}
+                </Text>
+              </TouchableOpacity>
+            </View>
+          ) : null}
+
+          {/* Categoría opcional */}
+          <View className="mb-4">
+            <Text className="text-muted text-sm mb-1">Categoría (opcional)</Text>
+            <TouchableOpacity
+              onPress={() => setShowCategoryPicker(true)}
+              activeOpacity={0.7}
+              className="bg-surface border border-border rounded-xl px-4 py-3"
+            >
+              <Text className={selectedCategory ? 'text-white' : 'text-muted'}>
+                {selectedCategory
+                  ? `${selectedCategory.icon ?? ''} ${selectedCategory.name}`.trim()
+                  : 'Sin categoría'}
+              </Text>
+            </TouchableOpacity>
+          </View>
+
+          {/* is_active toggle */}
+          <View className="mb-6 bg-surface border border-border rounded-xl px-4 py-3 flex-row items-center">
+            <View className="flex-1">
+              <Text className="text-white text-base">Activo</Text>
+              <Text className="text-muted text-xs mt-0.5">
+                Si lo desactivas, no recibirás la notificación
+              </Text>
+            </View>
+            <Switch
+              value={isActive}
+              onValueChange={setIsActive}
+              trackColor={{ false: '#3f3f46', true: '#4F46E5' }}
+              thumbColor="#fff"
+            />
+          </View>
+
+          <Text className="text-muted text-xs mb-4">
+            🔔 Las notificaciones se disparan a las 9:00 AM hora local.
+          </Text>
+
+          <PrimaryButton
+            onPress={handleSubmit}
+            loading={saving}
+            disabled={!description.trim()}
+          >
+            {isNew ? 'Crear recordatorio' : 'Guardar cambios'}
+          </PrimaryButton>
+        </ScrollView>
+      </KeyboardAvoidingView>
+
+      {/* Pickers */}
+      <SelectModal
+        visible={showFreqPicker}
+        onClose={() => setShowFreqPicker(false)}
+        title="Frecuencia"
+        options={FREQUENCY_OPTIONS.map((o) => ({ label: o.label, value: o.value }))}
+        selected={frequency}
+        onSelect={(v) => {
+          setFrequency(v as ReminderFrequency)
+          setShowFreqPicker(false)
+        }}
+      />
+      <SelectModal
+        visible={showDayWeekPicker}
+        onClose={() => setShowDayWeekPicker(false)}
+        title="Día de la semana"
+        options={WEEKDAY_OPTIONS}
+        selected={dayOfWeek !== null ? String(dayOfWeek) : ''}
+        onSelect={(v) => {
+          setDayOfWeek(parseInt(v, 10))
+          setShowDayWeekPicker(false)
+        }}
+      />
+      <SelectModal
+        visible={showDayMonthPicker}
+        onClose={() => setShowDayMonthPicker(false)}
+        title="Día del mes"
+        options={DAY_OPTIONS}
+        selected={dayOfMonth ? String(dayOfMonth) : ''}
+        onSelect={(v) => {
+          setDayOfMonth(parseInt(v, 10))
+          setShowDayMonthPicker(false)
+        }}
+      />
+      <SelectModal
+        visible={showMonthPicker}
+        onClose={() => setShowMonthPicker(false)}
+        title="Mes"
+        options={MONTH_OPTIONS}
+        selected={monthOfYear ? String(monthOfYear) : ''}
+        onSelect={(v) => {
+          setMonthOfYear(parseInt(v, 10))
+          setShowMonthPicker(false)
+        }}
+      />
+      <SelectModal
+        visible={showCategoryPicker}
+        onClose={() => setShowCategoryPicker(false)}
+        title="Categoría"
+        options={categoryOptions}
+        selected={categoryId}
+        onSelect={(v) => {
+          setCategoryId(v)
+          setShowCategoryPicker(false)
+        }}
+      />
+    </SafeAreaView>
+  )
+}

--- a/app/(dashboard)/reminders/_layout.tsx
+++ b/app/(dashboard)/reminders/_layout.tsx
@@ -1,0 +1,13 @@
+import { Stack } from 'expo-router'
+import { colors } from '@/constants/theme'
+
+export default function RemindersLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: colors.bg },
+      }}
+    />
+  )
+}

--- a/app/(dashboard)/reminders/index.tsx
+++ b/app/(dashboard)/reminders/index.tsx
@@ -1,0 +1,192 @@
+import { useCallback, useState } from 'react'
+import {
+  View,
+  Text,
+  FlatList,
+  TouchableOpacity,
+  ActivityIndicator,
+} from 'react-native'
+import { router, useFocusEffect } from 'expo-router'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useAuth } from '@/context/AuthContext'
+import { getReminders } from '@/lib/actions/reminders.actions'
+import { EmptyState } from '@/components/ui/EmptyState'
+import type {
+  ReminderFrequency,
+  ReminderWithCategory,
+} from '@/types/database.types'
+
+const FREQUENCY_LABEL: Record<ReminderFrequency, string> = {
+  once: 'Una vez',
+  weekly: 'Semanal',
+  monthly: 'Mensual',
+  yearly: 'Anual',
+}
+
+const WEEKDAY_NAMES = [
+  'Domingo',
+  'Lunes',
+  'Martes',
+  'Miércoles',
+  'Jueves',
+  'Viernes',
+  'Sábado',
+]
+
+const MONTH_NAMES = [
+  'enero',
+  'febrero',
+  'marzo',
+  'abril',
+  'mayo',
+  'junio',
+  'julio',
+  'agosto',
+  'septiembre',
+  'octubre',
+  'noviembre',
+  'diciembre',
+]
+
+function describeReminder(r: ReminderWithCategory): string {
+  switch (r.frequency) {
+    case 'once':
+      return r.specific_date
+        ? `El ${new Date(`${r.specific_date}T00:00:00`).toLocaleDateString('es', { day: 'numeric', month: 'long', year: 'numeric' })}`
+        : 'Una vez'
+    case 'weekly':
+      return r.day_of_week !== null && r.day_of_week !== undefined
+        ? `Todos los ${WEEKDAY_NAMES[r.day_of_week]}`
+        : 'Semanal'
+    case 'monthly':
+      return r.day_of_month
+        ? `Día ${r.day_of_month} de cada mes`
+        : 'Mensual'
+    case 'yearly':
+      return r.day_of_month && r.month_of_year
+        ? `${r.day_of_month} de ${MONTH_NAMES[r.month_of_year - 1]}`
+        : 'Anual'
+  }
+}
+
+export default function RemindersScreen() {
+  const { user } = useAuth()
+  const [reminders, setReminders] = useState<ReminderWithCategory[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const loadReminders = useCallback(async () => {
+    if (!user) return
+    const res = await getReminders(user.id)
+    if (res.success && res.data) setReminders(res.data)
+    setLoading(false)
+  }, [user])
+
+  useFocusEffect(
+    useCallback(() => {
+      let cancelled = false
+      ;(async () => {
+        await loadReminders()
+        if (cancelled) return
+      })()
+      return () => {
+        cancelled = true
+      }
+    }, [loadReminders])
+  )
+
+  if (loading) {
+    return (
+      <View className="flex-1 bg-bg items-center justify-center">
+        <ActivityIndicator color="#4F46E5" />
+      </View>
+    )
+  }
+
+  return (
+    <SafeAreaView edges={['top']} className="flex-1 bg-bg">
+      {/* Header */}
+      <View className="flex-row items-center justify-between px-4 py-3 border-b border-border">
+        <TouchableOpacity onPress={() => router.back()} activeOpacity={0.7}>
+          <Text className="text-primary text-base">← Volver</Text>
+        </TouchableOpacity>
+        <Text className="text-white text-base font-bold">Recordatorios</Text>
+        <View style={{ width: 60 }} />
+      </View>
+
+      <FlatList
+        data={reminders}
+        keyExtractor={(r) => r.id}
+        contentContainerStyle={
+          reminders.length === 0 ? { flex: 1 } : { paddingVertical: 12 }
+        }
+        ListEmptyComponent={
+          <EmptyState
+            icon="🔔"
+            title="Sin recordatorios"
+            description="Toca + para crear tu primer recordatorio"
+          />
+        }
+        renderItem={({ item }) => <ReminderCard reminder={item} />}
+      />
+
+      {/* FAB */}
+      <TouchableOpacity
+        onPress={() => router.push('/reminders/new')}
+        activeOpacity={0.8}
+        className="absolute bottom-6 right-6 w-14 h-14 rounded-full bg-primary items-center justify-center shadow-lg"
+        style={{
+          shadowColor: '#000',
+          shadowOffset: { width: 0, height: 4 },
+          shadowOpacity: 0.3,
+          shadowRadius: 6,
+          elevation: 6,
+        }}
+      >
+        <Text className="text-white text-3xl font-bold" style={{ lineHeight: 32 }}>
+          +
+        </Text>
+      </TouchableOpacity>
+    </SafeAreaView>
+  )
+}
+
+function ReminderCard({ reminder }: { reminder: ReminderWithCategory }) {
+  const inactive = !reminder.is_active
+  return (
+    <TouchableOpacity
+      onPress={() => router.push(`/reminders/${reminder.id}`)}
+      activeOpacity={0.7}
+      className="mx-4 mb-3 bg-surface border border-border rounded-2xl p-4"
+      style={{ opacity: inactive ? 0.5 : 1 }}
+    >
+      <View className="flex-row items-center mb-1">
+        <Text className="text-2xl mr-3">🔔</Text>
+        <View className="flex-1">
+          <Text className="text-white text-base font-semibold" numberOfLines={1}>
+            {reminder.description}
+          </Text>
+          <Text className="text-muted text-xs mt-0.5">
+            {describeReminder(reminder)} · {FREQUENCY_LABEL[reminder.frequency]}
+          </Text>
+        </View>
+        {inactive ? (
+          <View className="px-2 py-0.5 rounded-full bg-border">
+            <Text className="text-muted text-xs">Pausado</Text>
+          </View>
+        ) : null}
+      </View>
+
+      {reminder.category ? (
+        <View className="flex-row items-center mt-2 ml-9">
+          <View
+            style={{ backgroundColor: reminder.category.color ?? '#4F46E5' }}
+            className="w-5 h-5 rounded-full items-center justify-center mr-1.5"
+          >
+            <Text className="text-xs">{reminder.category.icon ?? '📂'}</Text>
+          </View>
+          <Text className="text-muted text-xs">{reminder.category.name}</Text>
+        </View>
+      ) : null}
+    </TouchableOpacity>
+  )
+}

--- a/app/(dashboard)/reminders/index.tsx
+++ b/app/(dashboard)/reminders/index.tsx
@@ -152,6 +152,12 @@ export default function RemindersScreen() {
 
 function ReminderCard({ reminder }: { reminder: ReminderWithCategory }) {
   const inactive = !reminder.is_active
+  // Avatar = icono + color de la categoría (mismo patrón que transacciones).
+  // Fallback a campanita si el recordatorio no tiene categoría asignada.
+  const hasCategory = !!reminder.category
+  const avatarColor = reminder.category?.color ?? '#4F46E5'
+  const avatarIcon = reminder.category?.icon ?? '🔔'
+
   return (
     <TouchableOpacity
       onPress={() => router.push(`/reminders/${reminder.id}`)}
@@ -159,13 +165,19 @@ function ReminderCard({ reminder }: { reminder: ReminderWithCategory }) {
       className="mx-4 mb-3 bg-surface border border-border rounded-2xl p-4"
       style={{ opacity: inactive ? 0.5 : 1 }}
     >
-      <View className="flex-row items-center mb-1">
-        <Text className="text-2xl mr-3">🔔</Text>
+      <View className="flex-row items-center">
+        <View
+          style={{ backgroundColor: avatarColor }}
+          className="w-10 h-10 rounded-full items-center justify-center mr-3"
+        >
+          <Text className="text-xl">{avatarIcon}</Text>
+        </View>
         <View className="flex-1">
           <Text className="text-white text-base font-semibold" numberOfLines={1}>
             {reminder.description}
           </Text>
-          <Text className="text-muted text-xs mt-0.5">
+          <Text className="text-muted text-xs mt-0.5" numberOfLines={1}>
+            {hasCategory ? `${reminder.category!.name} · ` : ''}
             {describeReminder(reminder)} · {FREQUENCY_LABEL[reminder.frequency]}
           </Text>
         </View>
@@ -175,18 +187,6 @@ function ReminderCard({ reminder }: { reminder: ReminderWithCategory }) {
           </View>
         ) : null}
       </View>
-
-      {reminder.category ? (
-        <View className="flex-row items-center mt-2 ml-9">
-          <View
-            style={{ backgroundColor: reminder.category.color ?? '#4F46E5' }}
-            className="w-5 h-5 rounded-full items-center justify-center mr-1.5"
-          >
-            <Text className="text-xs">{reminder.category.icon ?? '📂'}</Text>
-          </View>
-          <Text className="text-muted text-xs">{reminder.category.name}</Text>
-        </View>
-      ) : null}
     </TouchableOpacity>
   )
 }

--- a/app/(dashboard)/transactions/[id].tsx
+++ b/app/(dashboard)/transactions/[id].tsx
@@ -15,6 +15,8 @@ import { FormInput } from '@/components/ui/FormInput'
 import { SelectModal } from '@/components/ui/SelectModal'
 import { PrimaryButton } from '@/components/ui/PrimaryButton'
 import { Icon } from '@/components/ui/Icon'
+import { CurrencyPreview } from '@/components/transactions/CurrencyPreview'
+import { formatCurrency } from '@/lib/utils/currency'
 import type { Category, Account, Currency } from '@/types/database.types'
 
 const CURRENCY_OPTIONS = [
@@ -115,6 +117,20 @@ export default function TransactionFormScreen() {
     ])
   }
 
+  /**
+   * Al elegir una cuenta, hereda la currency de la cuenta. Bloquea el
+   * picker de currency mientras haya cuenta — cada cuenta tiene su moneda
+   * fija, no tiene sentido permitir registrar una tx en USD contra una
+   * cuenta COP. Si el user quiere otra currency, primero quita la cuenta.
+   */
+  function handleAccountChange(newAccountId: string) {
+    setAccountId(newAccountId)
+    if (newAccountId) {
+      const acc = accounts.find((a) => a.id === newAccountId)
+      if (acc) setCurrency(acc.currency)
+    }
+  }
+
   const filteredCategories = categories.filter((c) => c.type === type || c.type === 'both')
   const categoryOptions = filteredCategories.map((c) => ({
     label: `${c.icon ?? ''} ${c.name}`.trim(),
@@ -129,6 +145,14 @@ export default function TransactionFormScreen() {
   ]
   const selectedCategory = categories.find((c) => c.id === categoryId)
   const selectedAccount = accounts.find((a) => a.id === accountId)
+
+  // Derivados de validación UX
+  const accountLocksCurrency = !!accountId
+  const parsedAmount = parseFloat(amount) || 0
+  const cardOverLimit =
+    type === 'expense' &&
+    selectedAccount?.type === 'card' &&
+    parsedAmount > Number(selectedAccount.balance ?? 0)
 
   if (initialLoading) {
     return (
@@ -202,13 +226,23 @@ export default function TransactionFormScreen() {
           placeholder="0.00"
         />
 
-        {/* Moneda */}
+        {/* Equivalente en otras monedas — solo si amount > 0 */}
+        <CurrencyPreview amount={parsedAmount} fromCurrency={currency} />
+
+        {/* Moneda — bloqueada si hay cuenta seleccionada */}
         <View className="mb-4">
-          <Text className="text-muted text-sm mb-1">Moneda</Text>
+          <Text className="text-muted text-sm mb-1">
+            Moneda{accountLocksCurrency ? ' (heredada de la cuenta)' : ''}
+          </Text>
           <TouchableOpacity
-            onPress={() => setShowCurrencyPicker(true)}
-            activeOpacity={0.7}
+            onPress={() => {
+              if (accountLocksCurrency) return
+              setShowCurrencyPicker(true)
+            }}
+            activeOpacity={accountLocksCurrency ? 1 : 0.7}
+            disabled={accountLocksCurrency}
             className="bg-surface border border-border rounded-xl px-4 py-3"
+            style={{ opacity: accountLocksCurrency ? 0.5 : 1 }}
           >
             <Text className="text-white">
               {CURRENCY_OPTIONS.find((o) => o.value === currency)?.label ?? currency}
@@ -242,11 +276,21 @@ export default function TransactionFormScreen() {
           >
             <Text className="text-white">
               {selectedAccount
-                ? `${selectedAccount.icon ?? '💳'} ${selectedAccount.name}`
+                ? `${selectedAccount.icon ?? '💳'} ${selectedAccount.name} (${selectedAccount.currency})`
                 : 'Sin cuenta'}
             </Text>
           </TouchableOpacity>
         </View>
+
+        {/* Card overlimit warning */}
+        {cardOverLimit && selectedAccount ? (
+          <View className="mb-4 px-3 py-2 rounded-xl bg-red-500/10 border border-red-500/40">
+            <Text className="text-red-400 text-xs">
+              El monto excede el cupo disponible (
+              {formatCurrency(Number(selectedAccount.balance), selectedAccount.currency)})
+            </Text>
+          </View>
+        ) : null}
 
         <FormInput
           label="Fecha *"
@@ -297,7 +341,7 @@ export default function TransactionFormScreen() {
         title="Seleccionar Cuenta"
         options={accountOptions}
         selected={accountId}
-        onSelect={(v) => { setAccountId(v); setShowAccountPicker(false) }}
+        onSelect={(v) => { handleAccountChange(v); setShowAccountPicker(false) }}
       />
     </SafeAreaView>
   )

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,11 +1,41 @@
 // app/_layout.tsx
-import { Stack } from 'expo-router'
+import { useEffect } from 'react'
+import { Stack, router } from 'expo-router'
 import { SafeAreaProvider } from 'react-native-safe-area-context'
+import * as Notifications from 'expo-notifications'
 import { AuthProvider } from '@/context/AuthContext'
 import { AppToaster } from '@/components/ui/Toast'
+import { ensureAndroidChannel } from '@/lib/utils/notifications'
 import '../global.css'
 
 export default function RootLayout() {
+  /**
+   * Setup global de notifications:
+   *   1. Crear canal Android (idempotente).
+   *   2. Listener para deep-link cuando el user TAPS una notification.
+   *      El payload contiene `data.url` = '/reminders/<id>'.
+   *
+   * El listener funciona tanto si la app está en foreground como background
+   * o killed. Si fue killed, el listener se llama al boot con el último
+   * `notificationResponse` que la disparó.
+   */
+  useEffect(() => {
+    ensureAndroidChannel()
+
+    const subscription = Notifications.addNotificationResponseReceivedListener(
+      (response) => {
+        const data = response.notification.request.content.data as
+          | { url?: string }
+          | null
+        if (data?.url) {
+          router.push(data.url as `/${string}`)
+        }
+      }
+    )
+
+    return () => subscription.remove()
+  }, [])
+
   return (
     <SafeAreaProvider>
       <AuthProvider>

--- a/components/calendar/CalendarHeader.tsx
+++ b/components/calendar/CalendarHeader.tsx
@@ -1,0 +1,47 @@
+import { View, Text, TouchableOpacity } from 'react-native'
+
+export type CalendarTab = 'transactions' | 'reminders'
+
+interface Props {
+  value: CalendarTab
+  onChange: (tab: CalendarTab) => void
+}
+
+const TABS: { value: CalendarTab; label: string }[] = [
+  { value: 'transactions', label: 'Transacciones' },
+  { value: 'reminders', label: 'Recordatorios' },
+]
+
+/**
+ * Segmented control con 2 opciones: Transacciones / Recordatorios.
+ * Mismo patrón visual que `RangeSelector` de Reports.
+ */
+export function CalendarHeader({ value, onChange }: Props) {
+  return (
+    <View className="flex-row gap-2 px-4 py-3 border-b border-border">
+      {TABS.map((tab) => {
+        const active = tab.value === value
+        return (
+          <TouchableOpacity
+            key={tab.value}
+            onPress={() => onChange(tab.value)}
+            activeOpacity={0.7}
+            className={`flex-1 py-2 rounded-xl items-center border ${
+              active
+                ? 'bg-primary border-primary'
+                : 'bg-transparent border-border'
+            }`}
+          >
+            <Text
+              className={
+                active ? 'text-white text-sm font-semibold' : 'text-muted text-sm'
+              }
+            >
+              {tab.label}
+            </Text>
+          </TouchableOpacity>
+        )
+      })}
+    </View>
+  )
+}

--- a/components/calendar/DayDetailSheet.tsx
+++ b/components/calendar/DayDetailSheet.tsx
@@ -5,7 +5,7 @@ import { BottomSheet } from '@/components/ui/BottomSheet'
 import { PrimaryButton } from '@/components/ui/PrimaryButton'
 import { formatCurrency } from '@/lib/utils/currency'
 import type {
-  Reminder,
+  ReminderWithCategory,
   TransactionWithCategory,
 } from '@/types/database.types'
 
@@ -18,7 +18,7 @@ interface Props {
   mode: 'transactions' | 'reminders'
   /** Items del día — el caller los filtra. */
   transactions?: TransactionWithCategory[]
-  reminders?: Reminder[]
+  reminders?: ReminderWithCategory[]
 }
 
 function formatLongDate(iso: string): string {
@@ -124,28 +124,39 @@ export function DayDetailSheet({
                 </Text>
               </TouchableOpacity>
             ))
-          : reminders.map((r, idx) => (
-              <TouchableOpacity
-                key={r.id}
-                onPress={() => handleItemPress(r.id)}
-                activeOpacity={0.7}
-                className={`flex-row items-center py-3 ${
-                  idx < reminders.length - 1 ? 'border-b border-border' : ''
-                }`}
-              >
-                <View className="w-9 h-9 rounded-full bg-primary items-center justify-center mr-3">
-                  <Text className="text-base">🔔</Text>
-                </View>
-                <View className="flex-1">
-                  <Text className="text-white text-sm font-medium" numberOfLines={1}>
-                    {r.description}
-                  </Text>
-                  <Text className="text-muted text-xs mt-0.5">
-                    {r.is_active ? '9:00 AM' : 'Pausado'}
-                  </Text>
-                </View>
-              </TouchableOpacity>
-            ))}
+          : reminders.map((r, idx) => {
+              // Mismo patrón que ReminderCard y RecentTransactions:
+              // avatar con icono+color de la categoría. Fallback 🔔
+              // sobre fondo primary si no tiene categoría asignada.
+              const avatarColor = r.category?.color ?? '#4F46E5'
+              const avatarIcon = r.category?.icon ?? '🔔'
+              return (
+                <TouchableOpacity
+                  key={r.id}
+                  onPress={() => handleItemPress(r.id)}
+                  activeOpacity={0.7}
+                  className={`flex-row items-center py-3 ${
+                    idx < reminders.length - 1 ? 'border-b border-border' : ''
+                  }`}
+                >
+                  <View
+                    style={{ backgroundColor: avatarColor }}
+                    className="w-9 h-9 rounded-full items-center justify-center mr-3"
+                  >
+                    <Text className="text-base">{avatarIcon}</Text>
+                  </View>
+                  <View className="flex-1">
+                    <Text className="text-white text-sm font-medium" numberOfLines={1}>
+                      {r.description}
+                    </Text>
+                    <Text className="text-muted text-xs mt-0.5">
+                      {r.category ? `${r.category.name} · ` : ''}
+                      {r.is_active ? '9:00 AM' : 'Pausado'}
+                    </Text>
+                  </View>
+                </TouchableOpacity>
+              )
+            })}
       </ScrollView>
 
       <View className="mt-3">

--- a/components/calendar/DayDetailSheet.tsx
+++ b/components/calendar/DayDetailSheet.tsx
@@ -1,0 +1,158 @@
+import { useMemo } from 'react'
+import { View, Text, TouchableOpacity, ScrollView } from 'react-native'
+import { router } from 'expo-router'
+import { BottomSheet } from '@/components/ui/BottomSheet'
+import { PrimaryButton } from '@/components/ui/PrimaryButton'
+import { formatCurrency } from '@/lib/utils/currency'
+import type {
+  Reminder,
+  TransactionWithCategory,
+} from '@/types/database.types'
+
+interface Props {
+  visible: boolean
+  onClose: () => void
+  /** YYYY-MM-DD del día seleccionado, o null si nada. */
+  dayIso: string | null
+  /** Modo del sheet — determina qué render y qué CTA. */
+  mode: 'transactions' | 'reminders'
+  /** Items del día — el caller los filtra. */
+  transactions?: TransactionWithCategory[]
+  reminders?: Reminder[]
+}
+
+function formatLongDate(iso: string): string {
+  const d = new Date(`${iso}T00:00:00`)
+  return d
+    .toLocaleDateString('es', {
+      weekday: 'long',
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+    })
+    .replace(/^\w/, (c) => c.toUpperCase())
+}
+
+/**
+ * Bottom sheet con el detalle del día seleccionado en el calendario.
+ * Reutiliza el [[Bottom Sheet (Modal-based)]] genérico.
+ *
+ * Dos modos:
+ *   - 'transactions': lista las tx del día + botón "Crear tx aquí" que
+ *     navega a /transactions/new (sin date pre-llenada por simplicidad —
+ *     el form usa hoy por default).
+ *   - 'reminders': lista los reminders que disparan en ese día + botón
+ *     "Crear recordatorio aquí".
+ */
+export function DayDetailSheet({
+  visible,
+  onClose,
+  dayIso,
+  mode,
+  transactions = [],
+  reminders = [],
+}: Props) {
+  const items = mode === 'transactions' ? transactions : reminders
+
+  const handleCreate = () => {
+    onClose()
+    setTimeout(() => {
+      router.push(mode === 'transactions' ? '/transactions/new' : '/reminders/new')
+    }, 250)
+  }
+
+  const handleItemPress = (id: string) => {
+    onClose()
+    setTimeout(() => {
+      router.push(
+        mode === 'transactions'
+          ? (`/transactions/${id}` as const)
+          : (`/reminders/${id}` as const)
+      )
+    }, 250)
+  }
+
+  const title = useMemo(() => (dayIso ? formatLongDate(dayIso) : ''), [dayIso])
+
+  return (
+    <BottomSheet visible={visible} onClose={onClose} maxHeightPercent={75}>
+      <Text className="text-white text-lg font-bold mb-1">{title}</Text>
+      <Text className="text-muted text-xs mb-3">
+        {items.length === 0
+          ? mode === 'transactions'
+            ? 'Sin transacciones este día'
+            : 'Sin recordatorios este día'
+          : `${items.length} ${items.length === 1 ? 'item' : 'items'}`}
+      </Text>
+
+      <ScrollView
+        className="max-h-80"
+        contentContainerStyle={{ paddingBottom: 8 }}
+        showsVerticalScrollIndicator={false}
+      >
+        {mode === 'transactions'
+          ? transactions.map((tx, idx) => (
+              <TouchableOpacity
+                key={tx.id}
+                onPress={() => handleItemPress(tx.id)}
+                activeOpacity={0.7}
+                className={`flex-row items-center py-3 ${
+                  idx < transactions.length - 1 ? 'border-b border-border' : ''
+                }`}
+              >
+                <View
+                  style={{ backgroundColor: tx.category?.color ?? '#4F46E5' }}
+                  className="w-9 h-9 rounded-full items-center justify-center mr-3"
+                >
+                  <Text className="text-base">{tx.category?.icon ?? '📂'}</Text>
+                </View>
+                <View className="flex-1">
+                  <Text className="text-white text-sm font-medium" numberOfLines={1}>
+                    {tx.description}
+                  </Text>
+                  <Text className="text-muted text-xs mt-0.5">
+                    {tx.category?.name ?? 'Sin categoría'}
+                  </Text>
+                </View>
+                <Text
+                  className={`text-sm font-semibold ${
+                    tx.type === 'income' ? 'text-green-400' : 'text-red-400'
+                  }`}
+                >
+                  {tx.type === 'income' ? '+' : '−'}{' '}
+                  {formatCurrency(Number(tx.amount), tx.currency)}
+                </Text>
+              </TouchableOpacity>
+            ))
+          : reminders.map((r, idx) => (
+              <TouchableOpacity
+                key={r.id}
+                onPress={() => handleItemPress(r.id)}
+                activeOpacity={0.7}
+                className={`flex-row items-center py-3 ${
+                  idx < reminders.length - 1 ? 'border-b border-border' : ''
+                }`}
+              >
+                <View className="w-9 h-9 rounded-full bg-primary items-center justify-center mr-3">
+                  <Text className="text-base">🔔</Text>
+                </View>
+                <View className="flex-1">
+                  <Text className="text-white text-sm font-medium" numberOfLines={1}>
+                    {r.description}
+                  </Text>
+                  <Text className="text-muted text-xs mt-0.5">
+                    {r.is_active ? '9:00 AM' : 'Pausado'}
+                  </Text>
+                </View>
+              </TouchableOpacity>
+            ))}
+      </ScrollView>
+
+      <View className="mt-3">
+        <PrimaryButton onPress={handleCreate}>
+          {mode === 'transactions' ? 'Crear transacción' : 'Crear recordatorio'}
+        </PrimaryButton>
+      </View>
+    </BottomSheet>
+  )
+}

--- a/components/quick-actions/QuickActionsSheet.tsx
+++ b/components/quick-actions/QuickActionsSheet.tsx
@@ -65,7 +65,7 @@ const TILES: ActionTile[] = [
     color: '#a855f7',
   },
   {
-    icon: 'arrow-up-circle',
+    icon: 'bell',
     label: 'Recordatorios',
     route: '/reminders',
     color: '#ec4899',

--- a/components/quick-actions/QuickActionsSheet.tsx
+++ b/components/quick-actions/QuickActionsSheet.tsx
@@ -20,40 +20,53 @@ interface ActionTile {
   color: string
 }
 
+/**
+ * Tiles del menú principal. Mezcla de **accesos directos** (Transacción nueva,
+ * único shortcut a creación porque es la acción más frecuente) y **navegación
+ * a listados** (el resto — para ver, gestionar o crear desde su pantalla).
+ *
+ * No incluimos Transacciones como listado porque ya es un tab del bottom bar.
+ */
 const TILES: ActionTile[] = [
   {
-    icon: 'transactions',
-    label: 'Transacción',
+    icon: 'plus',
+    label: 'Nueva transacción',
     route: '/transactions/new',
     color: '#4F46E5',
   },
   {
+    icon: 'wallet',
+    label: 'Cuentas',
+    route: '/accounts',
+    color: '#0ea5e9',
+  },
+  {
     icon: 'folder-tree',
-    label: 'Categoría',
-    route: '/categories/new',
+    label: 'Categorías',
+    route: '/categories',
     color: '#06b6d4',
   },
   {
     icon: 'target',
-    label: 'Presupuesto',
-    route: '/budgets/new',
+    label: 'Presupuestos',
+    route: '/budgets',
     color: '#f59e0b',
   },
   {
     icon: 'piggy',
-    label: 'Meta de ahorro',
-    route: '/savings/new',
+    label: 'Metas de ahorro',
+    route: '/savings',
     color: '#10b981',
   },
   {
     icon: 'hand-coins',
-    label: 'Préstamo',
-    route: '/loans/new',
+    label: 'Préstamos',
+    route: '/loans',
     color: '#a855f7',
   },
   {
     icon: 'arrow-up-circle',
-    label: 'Recordatorio',
+    label: 'Recordatorios',
     comingSoon: 'Recordatorios disponibles próximamente (T-5.3)',
     color: '#ec4899',
   },
@@ -84,9 +97,9 @@ export function QuickActionsSheet({ visible, onClose }: QuickActionsSheetProps) 
 
   return (
     <BottomSheet visible={visible} onClose={onClose} maxHeightPercent={75}>
-      <Text className="text-white text-lg font-bold mb-1">Crear nuevo</Text>
+      <Text className="text-white text-lg font-bold mb-1">Menú principal</Text>
       <Text className="text-muted text-xs mb-4">
-        Elige qué quieres registrar
+        Accesos rápidos y secciones de tu app
       </Text>
 
       {/* Grid 2 col de tiles */}

--- a/components/quick-actions/QuickActionsSheet.tsx
+++ b/components/quick-actions/QuickActionsSheet.tsx
@@ -67,7 +67,7 @@ const TILES: ActionTile[] = [
   {
     icon: 'arrow-up-circle',
     label: 'Recordatorios',
-    comingSoon: 'Recordatorios disponibles próximamente (T-5.3)',
+    route: '/reminders',
     color: '#ec4899',
   },
 ]

--- a/components/quick-actions/QuickActionsSheet.tsx
+++ b/components/quick-actions/QuickActionsSheet.tsx
@@ -1,0 +1,142 @@
+import { View, Text, TouchableOpacity } from 'react-native'
+import { router } from 'expo-router'
+import { BottomSheet } from '@/components/ui/BottomSheet'
+import { Icon, type IconName } from '@/components/ui/Icon'
+import { toast } from '@/components/ui/Toast'
+
+interface QuickActionsSheetProps {
+  visible: boolean
+  onClose: () => void
+}
+
+interface ActionTile {
+  icon: IconName
+  label: string
+  /** Si está disponible, se navega a esta ruta al tap. */
+  route?: string
+  /** Si no hay ruta, este mensaje se muestra como toast. */
+  comingSoon?: string
+  /** Color del badge del icono. */
+  color: string
+}
+
+const TILES: ActionTile[] = [
+  {
+    icon: 'transactions',
+    label: 'Transacción',
+    route: '/transactions/new',
+    color: '#4F46E5',
+  },
+  {
+    icon: 'folder-tree',
+    label: 'Categoría',
+    route: '/categories/new',
+    color: '#06b6d4',
+  },
+  {
+    icon: 'target',
+    label: 'Presupuesto',
+    route: '/budgets/new',
+    color: '#f59e0b',
+  },
+  {
+    icon: 'piggy',
+    label: 'Meta de ahorro',
+    route: '/savings/new',
+    color: '#10b981',
+  },
+  {
+    icon: 'hand-coins',
+    label: 'Préstamo',
+    route: '/loans/new',
+    color: '#a855f7',
+  },
+  {
+    icon: 'arrow-up-circle',
+    label: 'Recordatorio',
+    comingSoon: 'Recordatorios disponibles próximamente (T-5.3)',
+    color: '#ec4899',
+  },
+]
+
+/**
+ * Bottom sheet de acciones rápidas — grid 2 columnas de tiles + un row
+ * full-width al final para "Configuración y perfil".
+ *
+ * Cada tile cierra el sheet y navega a la ruta de creación. El item de
+ * Recordatorios todavía no existe (T-5.3) — muestra un toast informativo.
+ */
+export function QuickActionsSheet({ visible, onClose }: QuickActionsSheetProps) {
+  function handleTilePress(tile: ActionTile) {
+    onClose()
+    if (tile.route) {
+      // Pequeño delay para que cierre la animación antes de navegar.
+      setTimeout(() => router.push(tile.route!), 250)
+    } else if (tile.comingSoon) {
+      setTimeout(() => toast(tile.comingSoon!), 250)
+    }
+  }
+
+  function handleProfilePress() {
+    onClose()
+    setTimeout(() => router.push('/profile'), 250)
+  }
+
+  return (
+    <BottomSheet visible={visible} onClose={onClose} maxHeightPercent={75}>
+      <Text className="text-white text-lg font-bold mb-1">Crear nuevo</Text>
+      <Text className="text-muted text-xs mb-4">
+        Elige qué quieres registrar
+      </Text>
+
+      {/* Grid 2 col de tiles */}
+      <View className="flex-row flex-wrap" style={{ marginHorizontal: -4 }}>
+        {TILES.map((tile) => (
+          <View key={tile.label} className="w-1/2 p-1">
+            <TouchableOpacity
+              onPress={() => handleTilePress(tile)}
+              activeOpacity={0.7}
+              className="bg-bg border border-border rounded-2xl p-4 items-center"
+            >
+              <View
+                style={{ backgroundColor: `${tile.color}22` }}
+                className="w-12 h-12 rounded-full items-center justify-center mb-2"
+              >
+                <Icon name={tile.icon} color={tile.color} size={22} />
+              </View>
+              <Text className="text-white text-sm font-medium">
+                {tile.label}
+              </Text>
+            </TouchableOpacity>
+          </View>
+        ))}
+      </View>
+
+      {/* Separador */}
+      <View className="h-px bg-border my-4" />
+
+      {/* Profile — full width */}
+      <TouchableOpacity
+        onPress={handleProfilePress}
+        activeOpacity={0.7}
+        className="bg-bg border border-border rounded-2xl px-4 py-3 flex-row items-center"
+      >
+        <View
+          style={{ backgroundColor: '#6b728022' }}
+          className="w-10 h-10 rounded-full items-center justify-center mr-3"
+        >
+          <Icon name="settings" color="#9ca3af" size={20} />
+        </View>
+        <View className="flex-1">
+          <Text className="text-white text-base font-medium">
+            Configuración y perfil
+          </Text>
+          <Text className="text-muted text-xs">
+            Preferencias, cuenta, datos
+          </Text>
+        </View>
+        <Icon name="chevron-right" color="#6b7280" size={18} />
+      </TouchableOpacity>
+    </BottomSheet>
+  )
+}

--- a/components/transactions/CurrencyPreview.tsx
+++ b/components/transactions/CurrencyPreview.tsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'react'
+import { View, Text } from 'react-native'
+import { convertCurrency } from '@/lib/actions/exchangeRates.actions'
+import { formatCurrency } from '@/lib/utils/currency'
+import type { Currency } from '@/types/database.types'
+
+const CURRENCIES: Currency[] = ['COP', 'USD', 'VES']
+
+interface Props {
+  amount: number
+  fromCurrency: Currency
+}
+
+/**
+ * Muestra el equivalente del `amount` en las **otras** monedas soportadas
+ * (excluye la `fromCurrency`).
+ *
+ * Fetcha conversiones via `convertCurrency` (action que lee exchange_rates).
+ * Si la rate no existe, `convertCurrency` devuelve el amount sin cambios
+ * (degradación graceful — el componente sigue funcionando pero la cifra
+ * no es real).
+ *
+ * Se oculta solo si amount <= 0 — evitamos parpadeo cuando el user borra
+ * el input.
+ */
+export function CurrencyPreview({ amount, fromCurrency }: Props) {
+  const [conversions, setConversions] = useState<Record<string, number>>({})
+
+  useEffect(() => {
+    if (!amount || amount <= 0) {
+      setConversions({})
+      return
+    }
+
+    let cancelled = false
+    const targets = CURRENCIES.filter((c) => c !== fromCurrency)
+
+    Promise.all(
+      targets.map(async (to) => {
+        const converted = await convertCurrency(amount, fromCurrency, to)
+        return [to, converted] as [Currency, number]
+      })
+    ).then((results) => {
+      if (cancelled) return
+      setConversions(Object.fromEntries(results))
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [amount, fromCurrency])
+
+  if (!amount || amount <= 0 || Object.keys(conversions).length === 0) {
+    return null
+  }
+
+  return (
+    <View className="bg-surface border border-border rounded-xl px-3 py-2 mb-4">
+      <Text className="text-muted text-xs mb-1">Equivalente aproximado</Text>
+      <View className="flex-row flex-wrap gap-4">
+        {Object.entries(conversions).map(([currency, value]) => (
+          <Text key={currency} className="text-white text-sm">
+            {formatCurrency(value, currency as Currency)}
+          </Text>
+        ))}
+      </View>
+    </View>
+  )
+}

--- a/components/ui/BottomSheet.tsx
+++ b/components/ui/BottomSheet.tsx
@@ -1,5 +1,6 @@
 import { useEffect, type ReactNode } from 'react'
 import { Modal, Pressable, View, useWindowDimensions } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -27,6 +28,13 @@ interface BottomSheetProps {
  *
  * NO incluye drag-to-dismiss ni snap points (para eso `@gorhom/bottom-sheet`).
  * Sirve para menús de acciones rápidas, action sheets simples y pickers.
+ *
+ * **Bug fix:** sin `presentationStyle="overFullScreen"` en iOS, el Modal NO
+ * cubre el área del tab bar / safe area inferior — el overlay queda "corto"
+ * y el tab bar se ve dimmed pero visible debajo del card. Con overFullScreen
+ * el modal sí cubre toda la ventana. Además aplicamos `paddingBottom` con
+ * el safe area inset para que el contenido del card no quede pegado al
+ * home indicator.
  */
 export function BottomSheet({
   visible,
@@ -35,6 +43,7 @@ export function BottomSheet({
   maxHeightPercent = 60,
 }: BottomSheetProps) {
   const { height } = useWindowDimensions()
+  const insets = useSafeAreaInsets()
   const translateY = useSharedValue(height) // empieza fuera de pantalla (abajo)
 
   useEffect(() => {
@@ -76,6 +85,7 @@ export function BottomSheet({
       animationType="none" // animamos nosotros con reanimated
       onRequestClose={handleClose}
       statusBarTranslucent
+      presentationStyle="overFullScreen"
     >
       {/* Overlay tap-to-close */}
       <Pressable
@@ -88,6 +98,10 @@ export function BottomSheet({
             style={[
               {
                 maxHeight: `${maxHeightPercent}%`,
+                // El safe area inferior se mete dentro del card como padding
+                // — así el card se extiende a la base de la pantalla y los
+                // botones quedan por encima del home indicator / tab bar.
+                paddingBottom: insets.bottom,
               },
               animatedStyle,
             ]}

--- a/components/ui/BottomSheet.tsx
+++ b/components/ui/BottomSheet.tsx
@@ -1,0 +1,106 @@
+import { useEffect, type ReactNode } from 'react'
+import { Modal, Pressable, View, useWindowDimensions } from 'react-native'
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  Easing,
+  runOnJS,
+} from 'react-native-reanimated'
+
+interface BottomSheetProps {
+  visible: boolean
+  onClose: () => void
+  children: ReactNode
+  /** Altura máxima en % del viewport. Default 60%. */
+  maxHeightPercent?: number
+}
+
+/**
+ * Bottom sheet simple — Modal RN + Animated.View que entra desde abajo con
+ * reanimated. Tap fuera del card cierra.
+ *
+ * Distinto a [[FormDialog]]:
+ * - FormDialog ocupa toda la pantalla (modal full-screen).
+ * - BottomSheet ocupa solo la parte inferior, deja la pantalla visible atrás
+ *   (con un overlay semi-transparente).
+ *
+ * NO incluye drag-to-dismiss ni snap points (para eso `@gorhom/bottom-sheet`).
+ * Sirve para menús de acciones rápidas, action sheets simples y pickers.
+ */
+export function BottomSheet({
+  visible,
+  onClose,
+  children,
+  maxHeightPercent = 60,
+}: BottomSheetProps) {
+  const { height } = useWindowDimensions()
+  const translateY = useSharedValue(height) // empieza fuera de pantalla (abajo)
+
+  useEffect(() => {
+    if (visible) {
+      translateY.value = withTiming(0, {
+        duration: 280,
+        easing: Easing.out(Easing.cubic),
+      })
+    } else {
+      translateY.value = withTiming(height, {
+        duration: 220,
+        easing: Easing.in(Easing.cubic),
+      })
+    }
+  }, [visible, height, translateY])
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateY: translateY.value }],
+  }))
+
+  /**
+   * Cerrar con la animación inversa antes de llamar onClose. Si llamamos
+   * onClose directo el Modal se desmonta de golpe y se ve el "salto".
+   */
+  function handleClose() {
+    translateY.value = withTiming(
+      height,
+      { duration: 220, easing: Easing.in(Easing.cubic) },
+      (finished) => {
+        if (finished) runOnJS(onClose)()
+      }
+    )
+  }
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="none" // animamos nosotros con reanimated
+      onRequestClose={handleClose}
+      statusBarTranslucent
+    >
+      {/* Overlay tap-to-close */}
+      <Pressable
+        className="flex-1 bg-black/60 justify-end"
+        onPress={handleClose}
+      >
+        {/* El card mismo no propaga el tap */}
+        <Pressable onPress={() => {}}>
+          <Animated.View
+            style={[
+              {
+                maxHeight: `${maxHeightPercent}%`,
+              },
+              animatedStyle,
+            ]}
+            className="bg-surface border-t border-border rounded-t-3xl"
+          >
+            {/* Handle visual (no funcional, solo affordance) */}
+            <View className="items-center pt-3 pb-1">
+              <View className="w-10 h-1 bg-border rounded-full" />
+            </View>
+            <View className="px-4 pb-6 pt-2">{children}</View>
+          </Animated.View>
+        </Pressable>
+      </Pressable>
+    </Modal>
+  )
+}

--- a/components/ui/BottomSheet.tsx
+++ b/components/ui/BottomSheet.tsx
@@ -87,20 +87,25 @@ export function BottomSheet({
       statusBarTranslucent
       presentationStyle="overFullScreen"
     >
-      {/* Overlay tap-to-close */}
-      <Pressable
-        className="flex-1 bg-black/60 justify-end"
-        onPress={handleClose}
-      >
-        {/* El card mismo no propaga el tap */}
-        <Pressable onPress={() => {}}>
+      {/* Overlay tap-to-close — cubre toda la ventana */}
+      <Pressable className="flex-1 bg-black/60" onPress={handleClose}>
+        {/*
+          Container del card con posicionamiento absoluto al borde inferior
+          REAL de la ventana. Usar `justify-end` en el flex parent deja un
+          gap cuando el modal no cubre exactamente todo el viewport
+          (caso típico cuando el tab bar de expo-router se renderiza en
+          una capa intermedia). Con `bottom: 0` absoluto el card siempre
+          queda pegado al borde de la pantalla y el safe area inset se
+          mete como padding interno para los botones.
+        */}
+        <Pressable
+          onPress={() => {}}
+          style={{ position: 'absolute', bottom: 0, left: 0, right: 0 }}
+        >
           <Animated.View
             style={[
               {
                 maxHeight: `${maxHeightPercent}%`,
-                // El safe area inferior se mete dentro del card como padding
-                // — así el card se extiende a la base de la pantalla y los
-                // botones quedan por encima del home indicator / tab bar.
                 paddingBottom: insets.bottom,
               },
               animatedStyle,

--- a/components/ui/Icon.tsx
+++ b/components/ui/Icon.tsx
@@ -19,6 +19,7 @@ import {
   PiggyBank,
   HandCoins,
   FolderTree,
+  Bell,
 } from 'lucide-react-native'
 
 /**
@@ -52,6 +53,7 @@ const ICONS = {
   piggy: PiggyBank,
   'hand-coins': HandCoins,
   'folder-tree': FolderTree,
+  bell: Bell,
 } as const
 
 export type IconName = keyof typeof ICONS

--- a/components/ui/Icon.tsx
+++ b/components/ui/Icon.tsx
@@ -20,6 +20,7 @@ import {
   HandCoins,
   FolderTree,
   Bell,
+  Calendar as CalendarIcon,
 } from 'lucide-react-native'
 
 /**
@@ -54,6 +55,7 @@ const ICONS = {
   'hand-coins': HandCoins,
   'folder-tree': FolderTree,
   bell: Bell,
+  calendar: CalendarIcon,
 } as const
 
 export type IconName = keyof typeof ICONS

--- a/lib/actions/reminders.actions.ts
+++ b/lib/actions/reminders.actions.ts
@@ -1,0 +1,141 @@
+import { insforge } from '@/lib/insforge'
+import {
+  createReminderSchema,
+  updateReminderSchema,
+  type CreateReminderInput,
+  type UpdateReminderInput,
+} from '@/lib/validations/reminder'
+import type { Reminder, ReminderWithCategory } from '@/types/database.types'
+import {
+  cancelReminderNotification,
+  rescheduleReminderNotification,
+  scheduleReminderNotification,
+} from '@/lib/utils/notifications'
+
+interface Result<T = void> {
+  success: boolean
+  data?: T
+  error?: string
+}
+
+export async function getReminders(
+  userId: string
+): Promise<Result<ReminderWithCategory[]>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const { data, error } = await insforge.database
+      .from('reminders')
+      .select('*, category:categories(*)')
+      .eq('user_id', userId)
+      .order('created_at', { ascending: false })
+    if (error) throw error
+    return { success: true, data: (data ?? []) as ReminderWithCategory[] }
+  } catch {
+    return { success: false, error: 'Error al cargar recordatorios' }
+  }
+}
+
+export async function getReminderById(
+  id: string,
+  userId: string
+): Promise<Result<ReminderWithCategory>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const { data, error } = await insforge.database
+      .from('reminders')
+      .select('*, category:categories(*)')
+      .eq('id', id)
+      .eq('user_id', userId)
+      .maybeSingle()
+    if (error) throw error
+    if (!data) return { success: false, error: 'Recordatorio no encontrado' }
+    return { success: true, data: data as ReminderWithCategory }
+  } catch {
+    return { success: false, error: 'Error al cargar recordatorio' }
+  }
+}
+
+/**
+ * Crea el reminder + programa la notification local.
+ *
+ * Acción multi-step ([[Acciones multi-step sin transacciones]]):
+ *   1. Insert en DB (orden importante — sin row no hay deep-link válido).
+ *   2. Schedule notification (con `data.reminderId` para deep-link).
+ *
+ * Si el schedule falla (permisos negados, OS limita, etc.), el reminder
+ * queda creado pero sin notification. Degradación graceful.
+ */
+export async function createReminder(
+  userId: string,
+  input: CreateReminderInput
+): Promise<Result<Reminder>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const validated = createReminderSchema.parse(input)
+    const { data, error } = await insforge.database
+      .from('reminders')
+      .insert([{ ...validated, user_id: userId }])
+      .select()
+      .single()
+    if (error) throw error
+
+    const reminder = data as Reminder
+    await scheduleReminderNotification(reminder)
+    return { success: true, data: reminder }
+  } catch {
+    return { success: false, error: 'Error al crear recordatorio' }
+  }
+}
+
+/**
+ * Update + reschedule. Reschedule cancela la notification anterior
+ * (buscando por reminderId en el data del payload) y crea una nueva con
+ * la nueva config.
+ */
+export async function updateReminder(
+  id: string,
+  userId: string,
+  input: UpdateReminderInput
+): Promise<Result<Reminder>> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    const validated = updateReminderSchema.parse(input)
+    const { data, error } = await insforge.database
+      .from('reminders')
+      .update(validated)
+      .eq('id', id)
+      .eq('user_id', userId)
+      .select()
+      .single()
+    if (error) throw error
+
+    const reminder = data as Reminder
+    await rescheduleReminderNotification(reminder)
+    return { success: true, data: reminder }
+  } catch {
+    return { success: false, error: 'Error al actualizar recordatorio' }
+  }
+}
+
+/**
+ * Delete + cancel. Cancel busca por reminderId en el payload, no necesita
+ * el `notificationId` persistido.
+ */
+export async function deleteReminder(
+  id: string,
+  userId: string
+): Promise<Result> {
+  if (!userId) return { success: false, error: 'User ID requerido' }
+  try {
+    await cancelReminderNotification(id)
+    const { error } = await insforge.database
+      .from('reminders')
+      .delete()
+      .eq('id', id)
+      .eq('user_id', userId)
+    if (error) throw error
+    return { success: true }
+  } catch {
+    return { success: false, error: 'Error al eliminar recordatorio' }
+  }
+}

--- a/lib/utils/notifications.ts
+++ b/lib/utils/notifications.ts
@@ -1,0 +1,208 @@
+// lib/utils/notifications.ts
+//
+// Wrapper sobre expo-notifications con la lógica específica del proyecto:
+// permisos, scheduling de reminders, cancelación, listener handler.
+//
+// Convención del proyecto:
+// - Toda notification se dispara a las 09:00 hora local del device.
+//   (El schema de reminders no tiene campo `time` — default razonable.)
+// - El payload incluye `{ data: { url: '/reminders/<id>' } }` para deep-link.
+// - Se cachea el `notificationId` en la DB para poder cancelar/reprogramar
+//   en updates/deletes.
+
+import * as Notifications from 'expo-notifications'
+import { Platform } from 'react-native'
+import type { Reminder, ReminderFrequency } from '@/types/database.types'
+
+// Hora fija de disparo. Configurable más adelante si se añade campo `time`.
+const DEFAULT_HOUR = 9
+const DEFAULT_MINUTE = 0
+
+// Canal Android (obligatorio para que las notifications aparezcan en
+// Android 8+). Lo creamos una sola vez al boot.
+const ANDROID_CHANNEL_ID = 'reminders'
+
+/**
+ * Configurar el handler de notifications cuando la app está en foreground.
+ * Por defecto expo-notifications NO muestra el banner si la app está abierta;
+ * con esto forzamos que se vea siempre.
+ */
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowBanner: true,
+    shouldShowList: true,
+    shouldPlaySound: true,
+    shouldSetBadge: false,
+  }),
+})
+
+/**
+ * Crear el canal Android. Idempotente — se puede llamar varias veces sin
+ * efecto. Llamar al boot (en root layout o al primer schedule).
+ */
+export async function ensureAndroidChannel(): Promise<void> {
+  if (Platform.OS !== 'android') return
+  await Notifications.setNotificationChannelAsync(ANDROID_CHANNEL_ID, {
+    name: 'Recordatorios',
+    importance: Notifications.AndroidImportance.HIGH,
+    vibrationPattern: [0, 250, 250, 250],
+    lightColor: '#4F46E5',
+  })
+}
+
+/**
+ * Pedir permisos. iOS los pide solo la primera vez; sucesivas calls
+ * devuelven el estado actual sin mostrar UI. Android 13+ requiere permiso
+ * explícito desde POST_NOTIFICATIONS (auto-managed por expo).
+ *
+ * @returns true si los permisos están concedidos.
+ */
+export async function requestNotificationPermissions(): Promise<boolean> {
+  const existing = await Notifications.getPermissionsAsync()
+  if (existing.granted) return true
+
+  const result = await Notifications.requestPermissionsAsync({
+    ios: {
+      allowAlert: true,
+      allowBadge: false,
+      allowSound: true,
+    },
+  })
+  return result.granted
+}
+
+/**
+ * Construye el trigger calendar según la frequency del reminder.
+ *
+ * - once: dispara una vez en `specific_date` a las 9:00.
+ * - weekly: cada semana en `day_of_week` a las 9:00.
+ * - monthly: cada mes en `day_of_month` a las 9:00.
+ * - yearly: cada año en `month_of_year`/`day_of_month` a las 9:00.
+ *
+ * Importante: expo-notifications usa **weekday 1-7 (Sunday=1)** en sus
+ * triggers, mientras que JS Date.getDay() devuelve 0-6 (Sunday=0). Nosotros
+ * almacenamos JS convention en `day_of_week` y convertimos al pasar.
+ */
+function buildTrigger(reminder: Reminder): Notifications.NotificationTriggerInput | null {
+  const hour = DEFAULT_HOUR
+  const minute = DEFAULT_MINUTE
+  const channelId = Platform.OS === 'android' ? ANDROID_CHANNEL_ID : undefined
+
+  switch (reminder.frequency) {
+    case 'once': {
+      if (!reminder.specific_date) return null
+      const date = new Date(`${reminder.specific_date}T${pad(hour)}:${pad(minute)}:00`)
+      if (date.getTime() <= Date.now()) return null // fecha pasada — no agendar
+      return {
+        type: Notifications.SchedulableTriggerInputTypes.DATE,
+        date,
+        channelId,
+      }
+    }
+    case 'weekly': {
+      if (reminder.day_of_week === null || reminder.day_of_week === undefined) return null
+      return {
+        type: Notifications.SchedulableTriggerInputTypes.WEEKLY,
+        weekday: reminder.day_of_week + 1, // JS 0-6 → expo 1-7
+        hour,
+        minute,
+        channelId,
+      }
+    }
+    case 'monthly': {
+      if (!reminder.day_of_month) return null
+      return {
+        type: Notifications.SchedulableTriggerInputTypes.MONTHLY,
+        day: reminder.day_of_month,
+        hour,
+        minute,
+        channelId,
+      }
+    }
+    case 'yearly': {
+      if (!reminder.day_of_month || !reminder.month_of_year) return null
+      return {
+        type: Notifications.SchedulableTriggerInputTypes.YEARLY,
+        month: reminder.month_of_year - 1, // expo usa 0-11 para month en yearly
+        day: reminder.day_of_month,
+        hour,
+        minute,
+        channelId,
+      }
+    }
+    default:
+      return null
+  }
+}
+
+function pad(n: number): string {
+  return String(n).padStart(2, '0')
+}
+
+/**
+ * Programa la notification local del reminder. Devuelve el `notificationId`
+ * generado por el OS (informativo — para cancelar después usamos
+ * `cancelReminderNotification(reminderId)` que busca por el `reminderId`
+ * embedido en el payload, sin necesidad de persistirlo).
+ *
+ * Si el reminder está inactivo, o si el trigger no se puede construir (ej.
+ * fecha en el pasado para `once`), no programa nada y devuelve null.
+ */
+export async function scheduleReminderNotification(
+  reminder: Reminder
+): Promise<string | null> {
+  if (!reminder.is_active) return null
+
+  const granted = await requestNotificationPermissions()
+  if (!granted) return null
+
+  await ensureAndroidChannel()
+
+  const trigger = buildTrigger(reminder)
+  if (!trigger) return null
+
+  return await Notifications.scheduleNotificationAsync({
+    content: {
+      title: 'Recordatorio',
+      body: reminder.description,
+      data: { url: `/reminders/${reminder.id}`, reminderId: reminder.id },
+    },
+    trigger,
+  })
+}
+
+/**
+ * Cancela todas las notifications programadas para un reminder dado.
+ *
+ * NO persistimos el `notificationId` en la DB — en su lugar embebimos el
+ * `reminderId` en el `data` del payload al schedule. Al cancelar, listamos
+ * todas las scheduled notifications, filtramos las que correspondan a este
+ * reminder, y cancelamos.
+ *
+ * Trade-off:
+ * - Pro: cero columnas nuevas en DB, cero AsyncStorage.
+ * - Con: O(N) en cada cancel donde N = scheduled notifications. Para una
+ *   app con <100 reminders esto es trivial.
+ */
+export async function cancelReminderNotification(reminderId: string): Promise<void> {
+  try {
+    const scheduled = await Notifications.getAllScheduledNotificationsAsync()
+    const toCancel = scheduled.filter(
+      (n) => (n.content.data as { reminderId?: string } | null)?.reminderId === reminderId
+    )
+    await Promise.all(
+      toCancel.map((n) => Notifications.cancelScheduledNotificationAsync(n.identifier))
+    )
+  } catch {
+    // Silencioso — best effort
+  }
+}
+
+/**
+ * Reprograma la notification: cancela la existente + programa una nueva.
+ * Útil para updates de reminders (cambió la frequency, day_of_week, etc.).
+ */
+export async function rescheduleReminderNotification(reminder: Reminder): Promise<string | null> {
+  await cancelReminderNotification(reminder.id)
+  return await scheduleReminderNotification(reminder)
+}

--- a/lib/utils/reminderMatchesDate.ts
+++ b/lib/utils/reminderMatchesDate.ts
@@ -1,0 +1,41 @@
+import type { Reminder } from '@/types/database.types'
+
+/**
+ * Devuelve true si el reminder dispara en la fecha dada.
+ *
+ * Para cada frequency hace el matching correspondiente:
+ *   - once: date == specific_date exacto
+ *   - weekly: date.getDay() == day_of_week (JS convention 0-6, Sunday=0)
+ *   - monthly: date.getDate() == day_of_month
+ *   - yearly: date.getMonth()+1 == month_of_year AND date.getDate() == day_of_month
+ *
+ * No mira `is_active` — el caller decide si filtrar inactivos antes.
+ */
+export function reminderMatchesDate(reminder: Reminder, date: Date): boolean {
+  switch (reminder.frequency) {
+    case 'once': {
+      if (!reminder.specific_date) return false
+      const iso = date.toISOString().slice(0, 10)
+      return iso === reminder.specific_date
+    }
+    case 'weekly':
+      return reminder.day_of_week === date.getDay()
+    case 'monthly':
+      return reminder.day_of_month === date.getDate()
+    case 'yearly':
+      return (
+        reminder.month_of_year === date.getMonth() + 1 &&
+        reminder.day_of_month === date.getDate()
+      )
+    default:
+      return false
+  }
+}
+
+/**
+ * Helper utilitario: convierte 'YYYY-MM-DD' (formato de react-native-calendars
+ * para días) en Date local sin time zone shift.
+ */
+export function parseDateString(iso: string): Date {
+  return new Date(`${iso}T00:00:00`)
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@shopify/react-native-skia": "^2.6.3",
     "expo": "~54.0.34",
     "expo-auth-session": "~7.0.11",
+    "expo-notifications": "~0.32.17",
     "expo-router": "~6.0.23",
     "expo-secure-store": "~15.0.8",
     "expo-status-bar": "~3.0.9",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "nativewind": "^4.2.3",
     "react": "19.1.0",
     "react-native": "0.81.5",
+    "react-native-calendars": "^1.1314.0",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       react-native:
         specifier: 0.81.5
         version: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
+      react-native-calendars:
+        specifier: ^1.1314.0
+        version: 1.1314.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       react-native-gesture-handler:
         specifier: ~2.28.0
         version: 2.28.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -2616,6 +2619,9 @@ packages:
   lodash.throttle@4.1.1:
     resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
 
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
   log-symbols@2.2.0:
     resolution: {integrity: sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==}
     engines: {node: '>=4'}
@@ -2894,6 +2900,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  moment@2.30.1:
+    resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
+
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
@@ -3164,6 +3173,9 @@ packages:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
 
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -3215,6 +3227,10 @@ packages:
 
   react-is@19.2.5:
     resolution: {integrity: sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==}
+
+  react-native-calendars@1.1314.0:
+    resolution: {integrity: sha512-4DLAVto8Qo9L3ggL2vsY9Gk8FFpJWtne8F/3wN8yUb7Xha9/SKS4B+vs7xlhWjKeqZUHws/Vi/q/6IZ8s60kcQ==}
+    engines: {node: '>=18'}
 
   react-native-css-interop@0.2.3:
     resolution: {integrity: sha512-wc+JI7iUfdFBqnE18HhMTtD0q9vkhuMczToA87UdHGWwMyxdT5sCcNy+i4KInPCE855IY0Ic8kLQqecAIBWz7w==}
@@ -3280,6 +3296,9 @@ packages:
     peerDependencies:
       react: '*'
       react-native: '*'
+
+  react-native-swipe-gestures@1.0.5:
+    resolution: {integrity: sha512-Ns7Bn9H/Tyw278+5SQx9oAblDZ7JixyzeOczcBK8dipQk2pD7Djkcfnf1nB/8RErAmMLL9iXgW0QHqiII8AhKw==}
 
   react-native-worklets@0.5.1:
     resolution: {integrity: sha512-lJG6Uk9YuojjEX/tQrCbcbmpdLCSFxDK1rJlkDhgqkVi1KZzG7cdcBFQRqyNOOzR9Y0CXNuldmtWTGOyM0k0+w==}
@@ -3349,6 +3368,12 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
+
+  recyclerlistview@4.2.3:
+    resolution: {integrity: sha512-STR/wj/FyT8EMsBzzhZ1l2goYirMkIgfV3gYEPxI3Kf3lOnu6f7Dryhyw7/IkQrgX5xtTcDrZMqytvteH9rL3g==}
+    peerDependencies:
+      react: '>= 15.2.1'
+      react-native: '>= 0.30.0'
 
   regenerate-unicode-properties@10.2.2:
     resolution: {integrity: sha512-m03P+zhBeQd1RGnYxrGyDAPpWX/epKirLrp8e3qevZdVkKtnCrjjWczIbYc8+xd6vcTStVlqfycTx1KR4LOr0g==}
@@ -3684,6 +3709,9 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
+  ts-object-utils@0.0.5:
+    resolution: {integrity: sha512-iV0GvHqOmilbIKJsfyfJY9/dNHCs969z3so90dQWsO1eMMozvTpnB1MEaUbb3FYtZTGjv5sIy/xmslEz0Rg2TA==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -3907,6 +3935,9 @@ packages:
   xcode@3.0.1:
     resolution: {integrity: sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==}
     engines: {node: '>=10.0.0'}
+
+  xdate@0.8.3:
+    resolution: {integrity: sha512-1NhJWPJwN+VjbkACT9XHbQK4o6exeSVtS2CxhMPwUE7xQakoEFTlwra9YcqV/uHQVyeEUYoYC46VGDJ+etnIiw==}
 
   xml2js@0.6.0:
     resolution: {integrity: sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==}
@@ -6970,6 +7001,8 @@ snapshots:
 
   lodash.throttle@4.1.1: {}
 
+  lodash@4.18.1: {}
+
   log-symbols@2.2.0:
     dependencies:
       chalk: 2.4.2
@@ -7590,6 +7623,9 @@ snapshots:
 
   mkdirp@1.0.4: {}
 
+  moment@2.30.1:
+    optional: true
+
   ms@2.0.0: {}
 
   ms@2.1.3: {}
@@ -7834,6 +7870,12 @@ snapshots:
       kleur: 3.0.3
       sisteransi: 1.0.5
 
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+
   punycode@2.3.1: {}
 
   qrcode-terminal@0.11.0: {}
@@ -7884,6 +7926,21 @@ snapshots:
   react-is@18.3.1: {}
 
   react-is@19.2.5: {}
+
+  react-native-calendars@1.1314.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+    dependencies:
+      hoist-non-react-statics: 3.3.2
+      lodash: 4.18.1
+      memoize-one: 5.2.1
+      prop-types: 15.8.1
+      react-native-swipe-gestures: 1.0.5
+      recyclerlistview: 4.2.3(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      xdate: 0.8.3
+    optionalDependencies:
+      moment: 2.30.1
+    transitivePeerDependencies:
+      - react
+      - react-native
 
   react-native-css-interop@0.2.3(react-native-reanimated@4.1.7(react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-svg@15.12.1(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(tailwindcss@3.4.19(yaml@2.8.3)):
     dependencies:
@@ -7952,6 +8009,8 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
       warn-once: 0.1.1
+
+  react-native-swipe-gestures@1.0.5: {}
 
   react-native-worklets@0.5.1(@babel/core@7.29.0)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
@@ -8062,6 +8121,14 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.2
+
+  recyclerlistview@4.2.3(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+    dependencies:
+      lodash.debounce: 4.0.8
+      prop-types: 15.8.1
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
+      ts-object-utils: 0.0.5
 
   regenerate-unicode-properties@10.2.2:
     dependencies:
@@ -8414,6 +8481,8 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
+  ts-object-utils@0.0.5: {}
+
   tslib@2.8.1: {}
 
   type-detect@4.0.8: {}
@@ -8584,6 +8653,8 @@ snapshots:
     dependencies:
       simple-plist: 1.3.1
       uuid: 7.0.3
+
+  xdate@0.8.3: {}
 
   xml2js@0.6.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,12 @@ importers:
       expo-auth-session:
         specifier: ~7.0.11
         version: 7.0.11(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-notifications:
+        specifier: ~0.32.17
+        version: 0.32.17(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
       expo-router:
         specifier: ~6.0.23
-        version: 6.0.23(50d6ae050edc32577f71db9557610d25)
+        version: 6.0.23(8ed3ad4190d356f0c40361b25ec1ba7d)
       expo-secure-store:
         specifier: ~15.0.8
         version: 15.0.8(expo@54.0.34)
@@ -648,6 +651,10 @@ packages:
   '@expo/env@2.0.11':
     resolution: {integrity: sha512-xV+ps6YCW7XIPVUwFVCRN2nox09dnRwy8uIjwHWTODu0zFw4kp4omnVkl0OOjuu2XOe7tdgAHxikrkJt9xB/7Q==}
 
+  '@expo/env@2.3.0':
+    resolution: {integrity: sha512-9HnnIbzwTTdbwSjNLXTk0fPm9ZwMJ7c1/31tsni8HZ8Q62KzYCyspahH+V365vg5J6lr001DzNwBxVWSaYCQLg==}
+    engines: {node: '>=20.12.0'}
+
   '@expo/fingerprint@0.15.5':
     resolution: {integrity: sha512-mdVoAMcux1WlM6kd1RoWiHRNqKqS+J6mKmWQ/BKgeh937S/fcW58EE68O6nc4KDXtWi3PBeNHskOFcgyIuD4hw==}
     hasBin: true
@@ -729,6 +736,9 @@ packages:
   '@expo/xcpretty@4.4.3':
     resolution: {integrity: sha512-wC562eD3gS6vO2tWHToFhlFnmHKfKHgF1oyvojeSkLK/ZYop1bMU+7cOMiF9Sq70CzcsLy/EMRy/uRc76QmNRw==}
     hasBin: true
+
+  '@ide/backoff@1.0.0':
+    resolution: {integrity: sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g==}
 
   '@insforge/sdk@1.2.5':
     resolution: {integrity: sha512-td9xryO7b+wR1wPVdFIaCLSKLZ+f3bzx/WpaXVrAs/ypOEJbZHQiWxK+c9Lr5WGShn2miRgSlTPrBNKe3aemlg==}
@@ -1357,8 +1367,15 @@ packages:
   asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
 
+  assert@2.1.0:
+    resolution: {integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==}
+
   async-limiter@1.0.1:
     resolution: {integrity: sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==}
+
+  available-typed-arrays@1.0.7:
+    resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
+    engines: {node: '>= 0.4'}
 
   babel-jest@29.7.0:
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
@@ -1426,6 +1443,9 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
       '@babel/core': ^7.0.0
+
+  badgin@1.2.3:
+    resolution: {integrity: sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -1499,6 +1519,18 @@ packages:
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bind@1.0.9:
+    resolution: {integrity: sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   camelcase-css@2.0.1:
     resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
@@ -1757,9 +1789,17 @@ packages:
   defaults@1.0.4:
     resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
 
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
   define-lazy-prop@2.0.0:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
     engines: {node: '>=8'}
+
+  define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -1808,6 +1848,10 @@ packages:
     resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
     engines: {node: '>=12'}
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
@@ -1843,8 +1887,16 @@ packages:
   error-stack-parser@2.1.4:
     resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
 
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
     engines: {node: '>= 0.4'}
 
   escalade@3.2.0:
@@ -1903,6 +1955,12 @@ packages:
       expo: '*'
       react-native: '*'
 
+  expo-constants@56.0.15:
+    resolution: {integrity: sha512-7187sd55swLX+CM0noAV5LreEgkUaDG/zEXy9quonfzKpJxy8zJAszp9S++xOx/FcqBVEEEcQhE8tKTujwL8fg==}
+    peerDependencies:
+      expo: '*'
+      react-native: '*'
+
   expo-crypto@15.0.9:
     resolution: {integrity: sha512-SNWKa2fXx7v9gkp1h/7nqXY5XN7qgNDn3yRc2aO0gWGbeMbvob/haMxxsPFe9f51aqH5NjNCqHf2kvLhvAd8KQ==}
     peerDependencies:
@@ -1940,6 +1998,13 @@ packages:
   expo-modules-core@3.0.30:
     resolution: {integrity: sha512-a6IrpAn/Jbmwxi9L+hMmXKpNqnkUpoF7WHOpn02rVLyax2J0gB1vvCVE5rNydplEnt41Q6WxQwvcOjZaIkcSUg==}
     peerDependencies:
+      react: '*'
+      react-native: '*'
+
+  expo-notifications@0.32.17:
+    resolution: {integrity: sha512-lwwzn7tImuzTzn9PAglZlS2VfZEvsfFGJTK9Eb8I4cqkGh2DI23YJFJH+WPEIu4QhDvk5JeBjklenJ8IZbmA4A==}
+    peerDependencies:
+      expo: '*'
       react: '*'
       react-native: '*'
 
@@ -2069,6 +2134,10 @@ packages:
   fontfaceobserver@2.3.0:
     resolution: {integrity: sha512-6FPvD/IVyT4ZlNe7Wcn5Fb/4ChigpucKYSvD6a+0iMoLn2inpo711eyIcKjmDtE5XNcgAkSH9uN/nfAeZzHEfg==}
 
+  for-each@0.3.5:
+    resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
+    engines: {node: '>= 0.4'}
+
   freeport-async@2.0.0:
     resolution: {integrity: sha512-K7od3Uw45AJg00XUmy15+Hae2hOcgKcmN3/EF6Y7i01O0gaqiRx8sUSpsb9+BRNL8RPBrhzPsVfy8q9ADlJuWQ==}
     engines: {node: '>=8'}
@@ -2088,6 +2157,10 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  generator-function@2.0.1:
+    resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
+    engines: {node: '>= 0.4'}
+
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
@@ -2096,6 +2169,10 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
@@ -2103,6 +2180,10 @@ packages:
   get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
     engines: {node: '>=8.0.0'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   getenv@2.0.0:
     resolution: {integrity: sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ==}
@@ -2124,6 +2205,10 @@ packages:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -2134,6 +2219,17 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  has-tostringtag@1.0.2:
+    resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
+    engines: {node: '>= 0.4'}
 
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
@@ -2211,12 +2307,20 @@ packages:
   invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
 
+  is-arguments@1.2.0:
+    resolution: {integrity: sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==}
+    engines: {node: '>= 0.4'}
+
   is-arrayish@0.3.4:
     resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
 
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
+
+  is-callable@1.2.7:
+    resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
+    engines: {node: '>= 0.4'}
 
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
@@ -2235,13 +2339,29 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
+  is-generator-function@1.1.2:
+    resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
+    engines: {node: '>= 0.4'}
+
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-nan@1.3.2:
+    resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
+    engines: {node: '>= 0.4'}
+
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-regex@1.2.1:
+    resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
+    engines: {node: '>= 0.4'}
+
+  is-typed-array@1.1.15:
+    resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
+    engines: {node: '>= 0.4'}
 
   is-wsl@2.2.0:
     resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
@@ -2526,6 +2646,10 @@ packages:
 
   marky@1.3.0:
     resolution: {integrity: sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
 
   mdn-data@2.0.14:
     resolution: {integrity: sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==}
@@ -2849,6 +2973,18 @@ packages:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
 
+  object-is@1.1.6:
+    resolution: {integrity: sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==}
+    engines: {node: '>= 0.4'}
+
+  object-keys@1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
+
+  object.assign@4.1.7:
+    resolution: {integrity: sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==}
+    engines: {node: '>= 0.4'}
+
   on-finished@2.3.0:
     resolution: {integrity: sha512-ikqdkGAAyf/X/gPhXGvfgAytDZtDbr+bkNUJ0N9h5MI/dmdgCs3l6hoHrcUv41sRKew3jIwrp4qQDXiK99Utww==}
     engines: {node: '>= 0.8'}
@@ -2949,6 +3085,10 @@ packages:
   pngjs@3.4.0:
     resolution: {integrity: sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w==}
     engines: {node: '>=4.0.0'}
+
+  possible-typed-array-names@1.1.0:
+    resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
+    engines: {node: '>= 0.4'}
 
   postcss-import@15.1.0:
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
@@ -3281,6 +3421,10 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
+  safe-regex-test@1.1.0:
+    resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
+    engines: {node: '>= 0.4'}
+
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
@@ -3327,6 +3471,10 @@ packages:
 
   server-only@0.0.1:
     resolution: {integrity: sha512-qepMx2JxAa5jjfzxG79yPPq+8BuFToHd1hm7kI+Z4zAq1ftQiP7HcxMhDDItrbtwVeLg/cY2JnKnrcFkmiswNA==}
+
+  set-function-length@1.2.2:
+    resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
+    engines: {node: '>= 0.4'}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -3622,6 +3770,9 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  util@0.12.5:
+    resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
+
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
@@ -3682,6 +3833,10 @@ packages:
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
+  which-typed-array@1.1.20:
+    resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
+    engines: {node: '>= 0.4'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -4490,7 +4645,7 @@ snapshots:
       wrap-ansi: 7.0.0
       ws: 8.20.0
     optionalDependencies:
-      expo-router: 6.0.23(50d6ae050edc32577f71db9557610d25)
+      expo-router: 6.0.23(8ed3ad4190d356f0c40361b25ec1ba7d)
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
     transitivePeerDependencies:
       - bufferutil
@@ -4562,6 +4717,14 @@ snapshots:
       debug: 4.4.3
       dotenv: 16.4.7
       dotenv-expand: 11.0.7
+      getenv: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@expo/env@2.3.0':
+    dependencies:
+      chalk: 4.1.2
+      debug: 4.4.3
       getenv: 2.0.0
     transitivePeerDependencies:
       - supports-color
@@ -4732,6 +4895,8 @@ snapshots:
       '@babel/code-frame': 7.29.0
       chalk: 4.1.2
       js-yaml: 4.1.1
+
+  '@ide/backoff@1.0.0': {}
 
   '@insforge/sdk@1.2.5':
     dependencies:
@@ -5490,7 +5655,19 @@ snapshots:
 
   asap@2.0.6: {}
 
+  assert@2.1.0:
+    dependencies:
+      call-bind: 1.0.9
+      is-nan: 1.3.2
+      object-is: 1.1.6
+      object.assign: 4.1.7
+      util: 0.12.5
+
   async-limiter@1.0.1: {}
+
+  available-typed-arrays@1.0.7:
+    dependencies:
+      possible-typed-array-names: 1.1.0
 
   babel-jest@29.7.0(@babel/core@7.29.0):
     dependencies:
@@ -5624,6 +5801,8 @@ snapshots:
       babel-plugin-jest-hoist: 29.6.3
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.29.0)
 
+  badgin@1.2.3: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -5691,6 +5870,23 @@ snapshots:
       ieee754: 1.2.1
 
   bytes@3.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bind@1.0.9:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      get-intrinsic: 1.3.0
+      set-function-length: 1.2.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   camelcase-css@2.0.1: {}
 
@@ -5948,7 +6144,19 @@ snapshots:
     dependencies:
       clone: 1.0.4
 
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   define-lazy-prop@2.0.0: {}
+
+  define-properties@1.2.1:
+    dependencies:
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
+      object-keys: 1.1.1
 
   depd@2.0.0: {}
 
@@ -5988,6 +6196,12 @@ snapshots:
 
   dotenv@16.4.7: {}
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   ee-first@1.1.1: {}
 
   electron-to-chromium@1.5.340: {}
@@ -6020,7 +6234,13 @@ snapshots:
     dependencies:
       stackframe: 1.3.4
 
+  es-define-property@1.0.1: {}
+
   es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
 
   escalade@3.2.0: {}
 
@@ -6076,6 +6296,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  expo-constants@56.0.15(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)):
+    dependencies:
+      '@expo/env': 2.3.0
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
+    transitivePeerDependencies:
+      - supports-color
+
   expo-crypto@15.0.9(expo@54.0.34):
     dependencies:
       base64-js: 1.5.1
@@ -6122,7 +6350,23 @@ snapshots:
       react: 19.1.0
       react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
 
-  expo-router@6.0.23(50d6ae050edc32577f71db9557610d25):
+  expo-notifications@0.32.17(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
+    dependencies:
+      '@expo/image-utils': 0.8.13(typescript@5.9.3)
+      '@ide/backoff': 1.0.0
+      abort-controller: 3.0.0
+      assert: 2.1.0
+      badgin: 1.2.3
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-application: 7.0.8(expo@54.0.34)
+      expo-constants: 18.0.13(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  expo-router@6.0.23(8ed3ad4190d356f0c40361b25ec1ba7d):
     dependencies:
       '@expo/metro-runtime': 6.1.2(expo@54.0.34)(react-dom@19.2.5(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@expo/schema-utils': 0.1.8
@@ -6135,7 +6379,7 @@ snapshots:
       debug: 4.4.3
       escape-string-regexp: 4.0.0
       expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
-      expo-constants: 18.0.13(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
+      expo-constants: 56.0.15(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
       expo-linking: 8.0.12(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       expo-server: 1.0.5
       fast-deep-equal: 3.1.3
@@ -6272,6 +6516,10 @@ snapshots:
 
   fontfaceobserver@2.3.0: {}
 
+  for-each@0.3.5:
+    dependencies:
+      is-callable: 1.2.7
+
   freeport-async@2.0.0: {}
 
   fresh@0.5.2: {}
@@ -6283,13 +6531,33 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  generator-function@2.0.1: {}
+
   gensync@1.0.0-beta.2: {}
 
   get-caller-file@2.0.5: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.3
+      math-intrinsics: 1.1.0
+
   get-nonce@1.0.1: {}
 
   get-package-type@0.1.0: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
 
   getenv@2.0.0: {}
 
@@ -6316,11 +6584,23 @@ snapshots:
       once: 1.4.0
       path-is-absolute: 1.0.1
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
 
   has-flag@3.0.0: {}
 
   has-flag@4.0.0: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.1
+
+  has-symbols@1.1.0: {}
+
+  has-tostringtag@1.0.2:
+    dependencies:
+      has-symbols: 1.1.0
 
   hasown@2.0.3:
     dependencies:
@@ -6400,11 +6680,18 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  is-arguments@1.2.0:
+    dependencies:
+      call-bound: 1.0.4
+      has-tostringtag: 1.0.2
+
   is-arrayish@0.3.4: {}
 
   is-binary-path@2.1.0:
     dependencies:
       binary-extensions: 2.3.0
+
+  is-callable@1.2.7: {}
 
   is-core-module@2.16.1:
     dependencies:
@@ -6416,11 +6703,35 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
+  is-generator-function@1.1.2:
+    dependencies:
+      call-bound: 1.0.4
+      generator-function: 2.0.1
+      get-proto: 1.0.1
+      has-tostringtag: 1.0.2
+      safe-regex-test: 1.1.0
+
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
 
+  is-nan@1.3.2:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+
   is-number@7.0.0: {}
+
+  is-regex@1.2.1:
+    dependencies:
+      call-bound: 1.0.4
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
+      hasown: 2.0.3
+
+  is-typed-array@1.1.15:
+    dependencies:
+      which-typed-array: 1.1.20
 
   is-wsl@2.2.0:
     dependencies:
@@ -6686,6 +6997,8 @@ snapshots:
       tmpl: 1.0.5
 
   marky@1.3.0: {}
+
+  math-intrinsics@1.1.0: {}
 
   mdn-data@2.0.14: {}
 
@@ -7349,6 +7662,22 @@ snapshots:
 
   object-hash@3.0.0: {}
 
+  object-is@1.1.6:
+    dependencies:
+      call-bind: 1.0.9
+      define-properties: 1.2.1
+
+  object-keys@1.1.1: {}
+
+  object.assign@4.1.7:
+    dependencies:
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      define-properties: 1.2.1
+      es-object-atoms: 1.1.2
+      has-symbols: 1.1.0
+      object-keys: 1.1.1
+
   on-finished@2.3.0:
     dependencies:
       ee-first: 1.1.1
@@ -7437,6 +7766,8 @@ snapshots:
       xmlbuilder: 15.1.1
 
   pngjs@3.4.0: {}
+
+  possible-typed-array-names@1.1.0: {}
 
   postcss-import@15.1.0(postcss@8.5.10):
     dependencies:
@@ -7799,6 +8130,12 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
+  safe-regex-test@1.1.0:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      is-regex: 1.2.1
+
   sax@1.6.0: {}
 
   scheduler@0.25.0: {}
@@ -7845,6 +8182,15 @@ snapshots:
       - supports-color
 
   server-only@0.0.1: {}
+
+  set-function-length@1.2.2:
+    dependencies:
+      define-data-property: 1.1.4
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      get-intrinsic: 1.3.0
+      gopd: 1.2.0
+      has-property-descriptors: 1.0.2
 
   setprototypeof@1.2.0: {}
 
@@ -8126,6 +8472,14 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  util@0.12.5:
+    dependencies:
+      inherits: 2.0.4
+      is-arguments: 1.2.0
+      is-generator-function: 1.1.2
+      is-typed-array: 1.1.15
+      which-typed-array: 1.1.20
+
   utils-merge@1.0.1: {}
 
   uuid@7.0.3: {}
@@ -8186,6 +8540,16 @@ snapshots:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
+
+  which-typed-array@1.1.20:
+    dependencies:
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.9
+      call-bound: 1.0.4
+      for-each: 0.3.5
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-tostringtag: 1.0.2
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
Cierre de **FASE 5** del plan rescopeado. Wins de UX rápidos en el form de transacciones + reorg del bottom bar con quick actions + recordatorios con notificaciones locales + calendario con 2 tabs.

## Tareas incluidas

- **T-5.1** — Currency UX en transaction form (#88)
- **T-5.2** — Tab "+" Quick Actions + Profile screen (#90)
- **T-5.3** — Recordatorios CRUD + push notifications (#92)
- **T-5.4** — Calendario con 2 tabs (#94)

## Cambios visibles para el usuario

### Form de transacciones
- **Auto-lock currency por cuenta** — al elegir una cuenta, la currency se hereda y el picker se deshabilita (cada cuenta tiene su moneda fija).
- **`<CurrencyPreview />`** — debajo del monto aparece el equivalente en las otras 2 monedas.
- **Warning de cupo excedido** en tarjetas — si el monto > balance disponible.

### Tab bar reorganizado
Antes: Dashboard · Transacciones · Reportes · Más
Después: **Dashboard · Transacciones · Calendario · Reportes · Menú**

- Tab "Más" reemplazado por "Menú" (icono `menu`) que abre un **bottom sheet** con accesos rápidos: Nueva transacción + listados (Cuentas, Categorías, Presupuestos, Metas, Préstamos, Recordatorios) + Configuración y perfil.
- Calendario añadido como 3er tab.

### Profile dedicado
- Contenido del antiguo "Más" movido a `/profile` (accesible desde el sheet).
- Perfil simplificado: solo perfil + preferencias + conexiones + sign out.
- **Bug fix:** avatar de Google ahora se sincroniza en cada login (antes solo se guardaba al crear el user).

### Recordatorios
- Pantalla nueva `/reminders` con CRUD completo.
- Frecuencias: una vez / semanal / mensual / anual con campos condicionales según la frequency.
- **Notificaciones locales** a las 9 AM del día programado (canal Android, permisos iOS).
- Tap en notificación → abre el detalle del recordatorio (deep-link).
- Icono `bell` en el tile del Menú; icono de categoría como avatar de cada card.

### Calendario
- Pantalla `/calendar` con 2 tabs (Transacciones / Recordatorios).
- Vista mensual con dots por día:
  - **Tx**: multi-dot por color de categoría.
  - **Reminders**: dots derivados — recurrentes calculados en cliente para el mes visible.
- Tap día → bottom sheet con la lista del día + botón "Crear X aquí".
- Locale español + theme dark.

## Componentes y patrones nuevos

- **`<BottomSheet />`** — wrapper Modal + reanimated slide-up (T-5.2). Reusado por QuickActionsSheet y DayDetailSheet.
- **Tab-intercepted modal sheet** — patrón con ruta dummy + `listeners.tabPress` + `e.preventDefault()` para que un tab abra modal en lugar de navegar.
- **Scheduled local notifications** — patrón CRUD-driven: cada operación DB se replica en el sistema de notifications (schedule / reschedule / cancel).
- **`reminderMatchesDate(reminder, date)`** — helper para evaluar si un reminder recurrente cae en una fecha.
- **Patrón de avatar con icono+color de categoría** — consistente en RecentTransactions, ReminderCard, DayDetailSheet.
- **Fix de transparencia en bottom sheets** — `presentationStyle="overFullScreen"` + `bottom: 0` absoluto + ocultar tab bar via `navigation.getParent().setOptions({ tabBarStyle: { display: 'none' } })`.

## Deps nuevas

- `expo-notifications ~0.32.x` (matchea SDK 54 — instalado vía `npx expo install`, no `pnpm add`)
- `react-native-calendars ^1.13x`

## Verificación

- [x] \`npx tsc --noEmit\` limpio en cada PR
- [x] Smoke test en simulator iOS:
  - [x] Currency lock al elegir cuenta, preview funciona
  - [x] Tap "Menú" abre el sheet, navega a cada sección
  - [x] Tab bar reorganizado correctamente
  - [x] Avatar de Google sincroniza al re-loguear
  - [x] Recordatorios CRUD con notificaciones programadas
  - [x] Tap día en calendario abre sheet con detalle
  - [x] Bottom sheet cubre toda la pantalla (sin transparencia en tab bar area)

## Notas para Obsidian (5 conceptos nuevos + 4 bitácoras)

- [[Bottom Sheet (Modal-based)]] · [[Tab-intercepted modal sheet]] · [[expo-notifications]] · [[Scheduled local notifications]] · [[react-native-calendars]]
- Bitácoras T-5.1 a T-5.4

🛑 **Stop point:** según workflow, desarrollo detenido hasta aprobación manual. Tras merge a \`main\` (con **merge commit, no squash**), arrancamos **FASE 6 — Release prep**: polish UX integral, QA en dispositivos físicos, EAS Build y primera build de TestFlight.

Closes #86