### PR TITLE
fix(polish): UX integral pre-release (T-6.1)

### DIFF
--- a/app/(dashboard)/accounts/index.tsx
+++ b/app/(dashboard)/accounts/index.tsx
@@ -95,6 +95,8 @@ export default function AccountsScreen() {
       <TouchableOpacity
         onPress={() => router.push('/(dashboard)/accounts/new')}
         activeOpacity={0.8}
+        accessibilityRole="button"
+        accessibilityLabel="Crear nueva cuenta"
         className="absolute bottom-6 right-6 w-14 h-14 bg-primary rounded-full items-center justify-center"
         style={{ elevation: 4 }}
       >

--- a/app/(dashboard)/accounts/index.tsx
+++ b/app/(dashboard)/accounts/index.tsx
@@ -5,6 +5,7 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import { useAuth } from '@/context/AuthContext'
 import { getAccounts, deleteAccount } from '@/lib/actions/accounts.actions'
 import { AccountCard } from '@/components/accounts/AccountCard'
+import { EmptyState } from '@/components/ui/EmptyState'
 import { toast } from '@/components/ui/Toast'
 import { formatCurrency } from '@/lib/utils/currency'
 import type { Account, Currency } from '@/types/database.types'
@@ -83,10 +84,11 @@ export default function AccountsScreen() {
             />
           }
           ListEmptyComponent={
-            <View className="items-center mt-20">
-              <Text className="text-muted text-base">No hay cuentas</Text>
-              <Text className="text-muted text-sm mt-1">Toca + para crear una</Text>
-            </View>
+            <EmptyState
+              icon="💳"
+              title="Sin cuentas"
+              description="Toca + para crear tu primera cuenta"
+            />
           }
           contentContainerStyle={{ paddingBottom: 100, paddingTop: 8 }}
         />

--- a/app/(dashboard)/accounts/index.tsx
+++ b/app/(dashboard)/accounts/index.tsx
@@ -5,6 +5,7 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import { useAuth } from '@/context/AuthContext'
 import { getAccounts, deleteAccount } from '@/lib/actions/accounts.actions'
 import { AccountCard } from '@/components/accounts/AccountCard'
+import { toast } from '@/components/ui/Toast'
 import { formatCurrency } from '@/lib/utils/currency'
 import type { Account, Currency } from '@/types/database.types'
 
@@ -18,6 +19,7 @@ export default function AccountsScreen() {
     if (!user) return
     const result = await getAccounts(user.id)
     if (result.success && result.data) setAccounts(result.data)
+    else if (!result.success) toast.error(result.error ?? 'Error al cargar cuentas')
     setLoading(false)
     setRefreshing(false)
   }, [user])

--- a/app/(dashboard)/budgets/index.tsx
+++ b/app/(dashboard)/budgets/index.tsx
@@ -5,6 +5,7 @@ import {
   FlatList,
   TouchableOpacity,
   ActivityIndicator,
+  RefreshControl,
 } from 'react-native'
 import { router, useFocusEffect } from 'expo-router'
 import { SafeAreaView } from 'react-native-safe-area-context'
@@ -30,6 +31,7 @@ export default function BudgetsScreen() {
   const { user } = useAuth()
   const [budgets, setBudgets] = useState<BudgetWithSpent[]>([])
   const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
 
   const loadBudgets = useCallback(async () => {
     if (!user) return
@@ -85,6 +87,17 @@ export default function BudgetsScreen() {
           />
         }
         renderItem={({ item }) => <BudgetCard budget={item} />}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={async () => {
+              setRefreshing(true)
+              await loadBudgets()
+              setRefreshing(false)
+            }}
+            tintColor="#4F46E5"
+          />
+        }
       />
 
       {/* FAB */}

--- a/app/(dashboard)/budgets/index.tsx
+++ b/app/(dashboard)/budgets/index.tsx
@@ -91,6 +91,8 @@ export default function BudgetsScreen() {
       <TouchableOpacity
         onPress={() => router.push('/budgets/new')}
         activeOpacity={0.8}
+        accessibilityRole="button"
+        accessibilityLabel="Crear nuevo presupuesto"
         className="absolute bottom-6 right-6 w-14 h-14 rounded-full bg-primary items-center justify-center shadow-lg"
         style={{
           shadowColor: '#000',

--- a/app/(dashboard)/budgets/index.tsx
+++ b/app/(dashboard)/budgets/index.tsx
@@ -12,6 +12,7 @@ import { useAuth } from '@/context/AuthContext'
 import { getBudgets } from '@/lib/actions/budgets.actions'
 import { ProgressBar, defaultColor } from '@/components/ui/ProgressBar'
 import { EmptyState } from '@/components/ui/EmptyState'
+import { toast } from '@/components/ui/Toast'
 import { formatCurrency } from '@/lib/utils/currency'
 import type { BudgetWithSpent } from '@/types/database.types'
 
@@ -34,6 +35,7 @@ export default function BudgetsScreen() {
     if (!user) return
     const res = await getBudgets(user.id)
     if (res.success && res.data) setBudgets(res.data)
+    else if (!res.success) toast.error(res.error ?? 'Error al cargar presupuestos')
     setLoading(false)
   }, [user])
 

--- a/app/(dashboard)/budgets/index.tsx
+++ b/app/(dashboard)/budgets/index.tsx
@@ -13,6 +13,7 @@ import { useAuth } from '@/context/AuthContext'
 import { getBudgets } from '@/lib/actions/budgets.actions'
 import { ProgressBar, defaultColor } from '@/components/ui/ProgressBar'
 import { EmptyState } from '@/components/ui/EmptyState'
+import { ListLoadingSkeleton } from '@/components/ui/ListLoadingSkeleton'
 import { toast } from '@/components/ui/Toast'
 import { formatCurrency } from '@/lib/utils/currency'
 import type { BudgetWithSpent } from '@/types/database.types'
@@ -56,9 +57,14 @@ export default function BudgetsScreen() {
 
   if (loading) {
     return (
-      <View className="flex-1 bg-bg items-center justify-center">
-        <ActivityIndicator color="#4F46E5" />
-      </View>
+      <SafeAreaView edges={['top']} className="flex-1 bg-bg">
+        <View className="flex-row items-center justify-between px-4 py-3 border-b border-border">
+          <View style={{ width: 60 }} />
+          <Text className="text-white text-base font-bold">Presupuestos</Text>
+          <View style={{ width: 60 }} />
+        </View>
+        <ListLoadingSkeleton />
+      </SafeAreaView>
     )
   }
 

--- a/app/(dashboard)/calendar/index.tsx
+++ b/app/(dashboard)/calendar/index.tsx
@@ -14,6 +14,7 @@ import { getReminders } from '@/lib/actions/reminders.actions'
 import { CalendarHeader, type CalendarTab } from '@/components/calendar/CalendarHeader'
 import { DayDetailSheet } from '@/components/calendar/DayDetailSheet'
 import { reminderMatchesDate } from '@/lib/utils/reminderMatchesDate'
+import { toast } from '@/components/ui/Toast'
 import { colors } from '@/constants/theme'
 import type {
   ReminderWithCategory,
@@ -105,7 +106,9 @@ export default function CalendarScreen() {
       getReminders(user.id),
     ])
     if (txRes.success && txRes.data) setTransactions(txRes.data.items)
+    else if (!txRes.success) toast.error(txRes.error ?? 'Error al cargar transacciones')
     if (remRes.success && remRes.data) setReminders(remRes.data)
+    else if (!remRes.success) toast.error(remRes.error ?? 'Error al cargar recordatorios')
     setLoading(false)
   }, [user])
 

--- a/app/(dashboard)/categories/index.tsx
+++ b/app/(dashboard)/categories/index.tsx
@@ -5,6 +5,7 @@ import {
   FlatList,
   TouchableOpacity,
   ActivityIndicator,
+  RefreshControl,
 } from 'react-native'
 import { router, useFocusEffect } from 'expo-router'
 import { SafeAreaView } from 'react-native-safe-area-context'
@@ -30,6 +31,7 @@ export default function CategoriesScreen() {
   const { user } = useAuth()
   const [categories, setCategories] = useState<Category[]>([])
   const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
 
   const loadCategories = useCallback(async () => {
     if (!user) return
@@ -136,6 +138,17 @@ export default function CategoriesScreen() {
             </TouchableOpacity>
           )
         }}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={async () => {
+              setRefreshing(true)
+              await loadCategories()
+              setRefreshing(false)
+            }}
+            tintColor="#4F46E5"
+          />
+        }
       />
 
       {/* FAB — crear nueva */}

--- a/app/(dashboard)/categories/index.tsx
+++ b/app/(dashboard)/categories/index.tsx
@@ -142,6 +142,8 @@ export default function CategoriesScreen() {
       <TouchableOpacity
         onPress={() => router.push('/categories/new')}
         activeOpacity={0.8}
+        accessibilityRole="button"
+        accessibilityLabel="Crear nueva categoría"
         className="absolute bottom-6 right-6 w-14 h-14 rounded-full bg-primary items-center justify-center shadow-lg"
         style={{
           shadowColor: '#000',

--- a/app/(dashboard)/categories/index.tsx
+++ b/app/(dashboard)/categories/index.tsx
@@ -11,6 +11,7 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import { useAuth } from '@/context/AuthContext'
 import { getCategories } from '@/lib/actions/categories.actions'
 import { EmptyState } from '@/components/ui/EmptyState'
+import { toast } from '@/components/ui/Toast'
 import type { Category, CategoryType } from '@/types/database.types'
 
 const TYPE_LABELS: Record<CategoryType, string> = {
@@ -35,6 +36,8 @@ export default function CategoriesScreen() {
     const result = await getCategories(user.id)
     if (result.success && result.data) {
       setCategories(result.data)
+    } else if (!result.success) {
+      toast.error(result.error ?? 'Error al cargar categorías')
     }
     setLoading(false)
   }, [user])

--- a/app/(dashboard)/categories/index.tsx
+++ b/app/(dashboard)/categories/index.tsx
@@ -12,6 +12,7 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import { useAuth } from '@/context/AuthContext'
 import { getCategories } from '@/lib/actions/categories.actions'
 import { EmptyState } from '@/components/ui/EmptyState'
+import { ListLoadingSkeleton } from '@/components/ui/ListLoadingSkeleton'
 import { toast } from '@/components/ui/Toast'
 import type { Category, CategoryType } from '@/types/database.types'
 
@@ -59,9 +60,14 @@ export default function CategoriesScreen() {
 
   if (loading) {
     return (
-      <View className="flex-1 bg-bg items-center justify-center">
-        <ActivityIndicator color="#4F46E5" />
-      </View>
+      <SafeAreaView edges={['top']} className="flex-1 bg-bg">
+        <View className="flex-row items-center justify-between px-4 py-3 border-b border-border">
+          <View style={{ width: 60 }} />
+          <Text className="text-white text-base font-bold">Categorías</Text>
+          <View style={{ width: 60 }} />
+        </View>
+        <ListLoadingSkeleton />
+      </SafeAreaView>
     )
   }
 

--- a/app/(dashboard)/index.tsx
+++ b/app/(dashboard)/index.tsx
@@ -27,6 +27,7 @@ import { RecentTransactions } from '@/components/dashboard/RecentTransactions'
 import { ActiveBudgets } from '@/components/dashboard/ActiveBudgets'
 import { AccumulatedBalanceChart } from '@/components/charts/AccumulatedBalanceChart'
 import { ExpensesByCategoryChart } from '@/components/charts/ExpensesByCategoryChart'
+import { toast } from '@/components/ui/Toast'
 import type {
   BudgetWithSpent,
   TransactionWithCategory,
@@ -62,9 +63,13 @@ export default function DashboardScreen() {
 
     if (txRes.success && txRes.data) {
       setTransactions(txRes.data.items)
+    } else if (!txRes.success) {
+      toast.error(txRes.error ?? 'Error al cargar transacciones')
     }
     if (budgetsRes.success && budgetsRes.data) {
       setBudgets(budgetsRes.data)
+    } else if (!budgetsRes.success) {
+      toast.error(budgetsRes.error ?? 'Error al cargar presupuestos')
     }
     setLoading(false)
   }, [user])

--- a/app/(dashboard)/index.tsx
+++ b/app/(dashboard)/index.tsx
@@ -10,7 +10,7 @@
 //
 // Refresh on focus con useFocusEffect — al volver al tab se actualiza.
 import { useCallback, useMemo, useState } from 'react'
-import { ScrollView, View, Text, ActivityIndicator } from 'react-native'
+import { ScrollView, View, Text, ActivityIndicator, RefreshControl } from 'react-native'
 import { useFocusEffect } from 'expo-router'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useAuth } from '@/context/AuthContext'
@@ -46,6 +46,7 @@ export default function DashboardScreen() {
   const [transactions, setTransactions] = useState<TransactionWithCategory[]>([])
   const [budgets, setBudgets] = useState<BudgetWithSpent[]>([])
   const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
 
   const loadData = useCallback(async () => {
     if (!user) return
@@ -133,6 +134,17 @@ export default function DashboardScreen() {
       <ScrollView
         className="flex-1"
         contentContainerStyle={{ padding: 16, paddingBottom: 40, gap: 20 }}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={async () => {
+              setRefreshing(true)
+              await loadData()
+              setRefreshing(false)
+            }}
+            tintColor="#4F46E5"
+          />
+        }
       >
         <SummaryCards
           transactions={transactions}

--- a/app/(dashboard)/loans/index.tsx
+++ b/app/(dashboard)/loans/index.tsx
@@ -107,6 +107,8 @@ export default function LoansScreen() {
       <TouchableOpacity
         onPress={() => router.push('/loans/new')}
         activeOpacity={0.8}
+        accessibilityRole="button"
+        accessibilityLabel="Crear nuevo préstamo"
         className="absolute bottom-6 right-6 w-14 h-14 rounded-full bg-primary items-center justify-center shadow-lg"
         style={{
           shadowColor: '#000',

--- a/app/(dashboard)/loans/index.tsx
+++ b/app/(dashboard)/loans/index.tsx
@@ -12,6 +12,7 @@ import { useAuth } from '@/context/AuthContext'
 import { getLoans } from '@/lib/actions/loans.actions'
 import { ProgressBar } from '@/components/ui/ProgressBar'
 import { EmptyState } from '@/components/ui/EmptyState'
+import { toast } from '@/components/ui/Toast'
 import { formatCurrency } from '@/lib/utils/currency'
 import type { LoanWithAccount } from '@/types/database.types'
 
@@ -29,6 +30,7 @@ export default function LoansScreen() {
     if (!user) return
     const res = await getLoans(user.id)
     if (res.success && res.data) setLoans(res.data)
+    else if (!res.success) toast.error(res.error ?? 'Error al cargar préstamos')
     setLoading(false)
   }, [user])
 

--- a/app/(dashboard)/loans/index.tsx
+++ b/app/(dashboard)/loans/index.tsx
@@ -5,6 +5,7 @@ import {
   SectionList,
   TouchableOpacity,
   ActivityIndicator,
+  RefreshControl,
 } from 'react-native'
 import { router, useFocusEffect } from 'expo-router'
 import { SafeAreaView } from 'react-native-safe-area-context'
@@ -25,6 +26,7 @@ export default function LoansScreen() {
   const { user } = useAuth()
   const [loans, setLoans] = useState<LoanWithAccount[]>([])
   const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
 
   const loadLoans = useCallback(async () => {
     if (!user) return
@@ -101,6 +103,17 @@ export default function LoansScreen() {
         )}
         renderItem={({ item }) => <LoanCard loan={item} />}
         stickySectionHeadersEnabled={false}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={async () => {
+              setRefreshing(true)
+              await loadLoans()
+              setRefreshing(false)
+            }}
+            tintColor="#4F46E5"
+          />
+        }
       />
 
       {/* FAB */}

--- a/app/(dashboard)/loans/index.tsx
+++ b/app/(dashboard)/loans/index.tsx
@@ -13,6 +13,7 @@ import { useAuth } from '@/context/AuthContext'
 import { getLoans } from '@/lib/actions/loans.actions'
 import { ProgressBar } from '@/components/ui/ProgressBar'
 import { EmptyState } from '@/components/ui/EmptyState'
+import { ListLoadingSkeleton } from '@/components/ui/ListLoadingSkeleton'
 import { toast } from '@/components/ui/Toast'
 import { formatCurrency } from '@/lib/utils/currency'
 import type { LoanWithAccount } from '@/types/database.types'
@@ -64,9 +65,14 @@ export default function LoansScreen() {
 
   if (loading) {
     return (
-      <View className="flex-1 bg-bg items-center justify-center">
-        <ActivityIndicator color="#4F46E5" />
-      </View>
+      <SafeAreaView edges={['top']} className="flex-1 bg-bg">
+        <View className="flex-row items-center justify-between px-4 py-3 border-b border-border">
+          <View style={{ width: 60 }} />
+          <Text className="text-white text-base font-bold">Préstamos</Text>
+          <View style={{ width: 60 }} />
+        </View>
+        <ListLoadingSkeleton />
+      </SafeAreaView>
     )
   }
 

--- a/app/(dashboard)/reminders/index.tsx
+++ b/app/(dashboard)/reminders/index.tsx
@@ -12,6 +12,7 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import { useAuth } from '@/context/AuthContext'
 import { getReminders } from '@/lib/actions/reminders.actions'
 import { EmptyState } from '@/components/ui/EmptyState'
+import { ListLoadingSkeleton } from '@/components/ui/ListLoadingSkeleton'
 import { toast } from '@/components/ui/Toast'
 import type {
   ReminderFrequency,
@@ -100,9 +101,14 @@ export default function RemindersScreen() {
 
   if (loading) {
     return (
-      <View className="flex-1 bg-bg items-center justify-center">
-        <ActivityIndicator color="#4F46E5" />
-      </View>
+      <SafeAreaView edges={['top']} className="flex-1 bg-bg">
+        <View className="flex-row items-center justify-between px-4 py-3 border-b border-border">
+          <View style={{ width: 60 }} />
+          <Text className="text-white text-base font-bold">Recordatorios</Text>
+          <View style={{ width: 60 }} />
+        </View>
+        <ListLoadingSkeleton />
+      </SafeAreaView>
     )
   }
 

--- a/app/(dashboard)/reminders/index.tsx
+++ b/app/(dashboard)/reminders/index.tsx
@@ -135,6 +135,8 @@ export default function RemindersScreen() {
       <TouchableOpacity
         onPress={() => router.push('/reminders/new')}
         activeOpacity={0.8}
+        accessibilityRole="button"
+        accessibilityLabel="Crear nuevo recordatorio"
         className="absolute bottom-6 right-6 w-14 h-14 rounded-full bg-primary items-center justify-center shadow-lg"
         style={{
           shadowColor: '#000',

--- a/app/(dashboard)/reminders/index.tsx
+++ b/app/(dashboard)/reminders/index.tsx
@@ -11,6 +11,7 @@ import { SafeAreaView } from 'react-native-safe-area-context'
 import { useAuth } from '@/context/AuthContext'
 import { getReminders } from '@/lib/actions/reminders.actions'
 import { EmptyState } from '@/components/ui/EmptyState'
+import { toast } from '@/components/ui/Toast'
 import type {
   ReminderFrequency,
   ReminderWithCategory,
@@ -78,6 +79,7 @@ export default function RemindersScreen() {
     if (!user) return
     const res = await getReminders(user.id)
     if (res.success && res.data) setReminders(res.data)
+    else if (!res.success) toast.error(res.error ?? 'Error al cargar recordatorios')
     setLoading(false)
   }, [user])
 

--- a/app/(dashboard)/reminders/index.tsx
+++ b/app/(dashboard)/reminders/index.tsx
@@ -5,6 +5,7 @@ import {
   FlatList,
   TouchableOpacity,
   ActivityIndicator,
+  RefreshControl,
 } from 'react-native'
 import { router, useFocusEffect } from 'expo-router'
 import { SafeAreaView } from 'react-native-safe-area-context'
@@ -74,6 +75,7 @@ export default function RemindersScreen() {
   const { user } = useAuth()
   const [reminders, setReminders] = useState<ReminderWithCategory[]>([])
   const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
 
   const loadReminders = useCallback(async () => {
     if (!user) return
@@ -129,6 +131,17 @@ export default function RemindersScreen() {
           />
         }
         renderItem={({ item }) => <ReminderCard reminder={item} />}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={async () => {
+              setRefreshing(true)
+              await loadReminders()
+              setRefreshing(false)
+            }}
+            tintColor="#4F46E5"
+          />
+        }
       />
 
       {/* FAB */}

--- a/app/(dashboard)/reports/index.tsx
+++ b/app/(dashboard)/reports/index.tsx
@@ -8,7 +8,7 @@
 // Para rangos largos pedimos pageSize 500 — si el user tiene > 500 tx en
 // el rango, el chart subestima.
 import { useCallback, useMemo, useState } from 'react'
-import { ScrollView, View, Text, ActivityIndicator } from 'react-native'
+import { ScrollView, View, Text, ActivityIndicator, RefreshControl } from 'react-native'
 import { useFocusEffect } from 'expo-router'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useAuth } from '@/context/AuthContext'
@@ -37,6 +37,7 @@ export default function ReportsScreen() {
   const { rates } = useExchangeRates()
   const [transactions, setTransactions] = useState<TransactionWithCategory[]>([])
   const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
   const [range, setRange] = useState<ReportRange>('3M')
 
   const loadData = useCallback(async () => {
@@ -122,6 +123,17 @@ export default function ReportsScreen() {
       <ScrollView
         className="flex-1"
         contentContainerStyle={{ padding: 16, paddingBottom: 40, gap: 20 }}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={async () => {
+              setRefreshing(true)
+              await loadData()
+              setRefreshing(false)
+            }}
+            tintColor="#4F46E5"
+          />
+        }
       >
         <RangeSelector value={range} onChange={setRange} />
 

--- a/app/(dashboard)/reports/index.tsx
+++ b/app/(dashboard)/reports/index.tsx
@@ -29,6 +29,7 @@ import { AccumulatedBalanceChart } from '@/components/charts/AccumulatedBalanceC
 import { ExpensesByCategoryChart } from '@/components/charts/ExpensesByCategoryChart'
 import { MonthlyComparisonChart } from '@/components/charts/MonthlyComparisonChart'
 import { RangeSelector } from '@/components/reports/RangeSelector'
+import { toast } from '@/components/ui/Toast'
 import type { TransactionWithCategory } from '@/types/database.types'
 
 export default function ReportsScreen() {
@@ -47,6 +48,8 @@ export default function ReportsScreen() {
     )
     if (res.success && res.data) {
       setTransactions(res.data.items)
+    } else if (!res.success) {
+      toast.error(res.error ?? 'Error al cargar reportes')
     }
     setLoading(false)
   }, [user])

--- a/app/(dashboard)/savings/index.tsx
+++ b/app/(dashboard)/savings/index.tsx
@@ -5,6 +5,7 @@ import {
   FlatList,
   TouchableOpacity,
   ActivityIndicator,
+  RefreshControl,
 } from 'react-native'
 import { router, useFocusEffect } from 'expo-router'
 import { SafeAreaView } from 'react-native-safe-area-context'
@@ -37,6 +38,7 @@ export default function SavingsScreen() {
   const { user } = useAuth()
   const [goals, setGoals] = useState<SavingsGoal[]>([])
   const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
 
   const loadGoals = useCallback(async () => {
     if (!user) return
@@ -92,6 +94,17 @@ export default function SavingsScreen() {
           />
         }
         renderItem={({ item }) => <GoalCard goal={item} />}
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={async () => {
+              setRefreshing(true)
+              await loadGoals()
+              setRefreshing(false)
+            }}
+            tintColor="#4F46E5"
+          />
+        }
       />
 
       {/* FAB */}

--- a/app/(dashboard)/savings/index.tsx
+++ b/app/(dashboard)/savings/index.tsx
@@ -98,6 +98,8 @@ export default function SavingsScreen() {
       <TouchableOpacity
         onPress={() => router.push('/savings/new')}
         activeOpacity={0.8}
+        accessibilityRole="button"
+        accessibilityLabel="Crear nueva meta de ahorro"
         className="absolute bottom-6 right-6 w-14 h-14 rounded-full bg-primary items-center justify-center shadow-lg"
         style={{
           shadowColor: '#000',

--- a/app/(dashboard)/savings/index.tsx
+++ b/app/(dashboard)/savings/index.tsx
@@ -12,6 +12,7 @@ import { useAuth } from '@/context/AuthContext'
 import { getSavingsGoals } from '@/lib/actions/savings.actions'
 import { ProgressBar } from '@/components/ui/ProgressBar'
 import { EmptyState } from '@/components/ui/EmptyState'
+import { toast } from '@/components/ui/Toast'
 import { formatCurrency } from '@/lib/utils/currency'
 import type { SavingsGoal } from '@/types/database.types'
 
@@ -41,6 +42,7 @@ export default function SavingsScreen() {
     if (!user) return
     const res = await getSavingsGoals(user.id)
     if (res.success && res.data) setGoals(res.data)
+    else if (!res.success) toast.error(res.error ?? 'Error al cargar metas')
     setLoading(false)
   }, [user])
 

--- a/app/(dashboard)/savings/index.tsx
+++ b/app/(dashboard)/savings/index.tsx
@@ -13,6 +13,7 @@ import { useAuth } from '@/context/AuthContext'
 import { getSavingsGoals } from '@/lib/actions/savings.actions'
 import { ProgressBar } from '@/components/ui/ProgressBar'
 import { EmptyState } from '@/components/ui/EmptyState'
+import { ListLoadingSkeleton } from '@/components/ui/ListLoadingSkeleton'
 import { toast } from '@/components/ui/Toast'
 import { formatCurrency } from '@/lib/utils/currency'
 import type { SavingsGoal } from '@/types/database.types'
@@ -63,9 +64,14 @@ export default function SavingsScreen() {
 
   if (loading) {
     return (
-      <View className="flex-1 bg-bg items-center justify-center">
-        <ActivityIndicator color="#4F46E5" />
-      </View>
+      <SafeAreaView edges={['top']} className="flex-1 bg-bg">
+        <View className="flex-row items-center justify-between px-4 py-3 border-b border-border">
+          <View style={{ width: 60 }} />
+          <Text className="text-white text-base font-bold">Metas de ahorro</Text>
+          <View style={{ width: 60 }} />
+        </View>
+        <ListLoadingSkeleton />
+      </SafeAreaView>
     )
   }
 

--- a/app/(dashboard)/transactions/index.tsx
+++ b/app/(dashboard)/transactions/index.tsx
@@ -344,6 +344,8 @@ export default function TransactionsScreen() {
       <TouchableOpacity
         onPress={() => router.push('/(dashboard)/transactions/new')}
         activeOpacity={0.8}
+        accessibilityRole="button"
+        accessibilityLabel="Crear nueva transacción"
         className="absolute bottom-6 right-6 w-14 h-14 bg-primary rounded-full items-center justify-center"
         style={{ elevation: 4 }}
       >

--- a/app/(dashboard)/transactions/index.tsx
+++ b/app/(dashboard)/transactions/index.tsx
@@ -20,6 +20,7 @@ import { getAccounts } from '@/lib/actions/accounts.actions'
 import { TransactionCard } from '@/components/transactions/TransactionCard'
 import { Icon } from '@/components/ui/Icon'
 import { SelectModal } from '@/components/ui/SelectModal'
+import { toast } from '@/components/ui/Toast'
 import { useDebounce } from '@/hooks/useDebounce'
 import type {
   TransactionWithCategory,
@@ -134,6 +135,8 @@ export default function TransactionsScreen() {
         }
         setHasMore(result.data.hasMore)
         setPage(pageNum)
+      } else if (!result.success) {
+        toast.error(result.error ?? 'Error al cargar transacciones')
       }
 
       if (mode === 'append') {

--- a/app/(dashboard)/transactions/index.tsx
+++ b/app/(dashboard)/transactions/index.tsx
@@ -18,6 +18,7 @@ import {
 import { getCategories } from '@/lib/actions/categories.actions'
 import { getAccounts } from '@/lib/actions/accounts.actions'
 import { TransactionCard } from '@/components/transactions/TransactionCard'
+import { EmptyState } from '@/components/ui/EmptyState'
 import { Icon } from '@/components/ui/Icon'
 import { SelectModal } from '@/components/ui/SelectModal'
 import { toast } from '@/components/ui/Toast'
@@ -324,18 +325,19 @@ export default function TransactionsScreen() {
           onEndReachedThreshold={0.5}
           ListFooterComponent={renderFooter}
           ListEmptyComponent={
-            <View className="items-center mt-20">
-              <Text className="text-muted text-base">
-                {anyFilterActive || debouncedSearch
+            <EmptyState
+              icon={anyFilterActive || debouncedSearch ? '🔍' : '💸'}
+              title={
+                anyFilterActive || debouncedSearch
                   ? 'Sin resultados'
-                  : 'No hay transacciones'}
-              </Text>
-              <Text className="text-muted text-sm mt-1">
-                {anyFilterActive || debouncedSearch
-                  ? 'Ajustá los filtros o limpiálos'
-                  : 'Toca + para crear una'}
-              </Text>
-            </View>
+                  : 'Sin transacciones'
+              }
+              description={
+                anyFilterActive || debouncedSearch
+                  ? 'Ajusta los filtros o limpiálos para ver más'
+                  : 'Toca + para crear tu primera transacción'
+              }
+            />
           }
           contentContainerStyle={{ paddingBottom: 100, paddingTop: 4 }}
         />

--- a/components/ui/ListLoadingSkeleton.tsx
+++ b/components/ui/ListLoadingSkeleton.tsx
@@ -1,0 +1,42 @@
+import { View } from 'react-native'
+import { LoadingSkeleton } from '@/components/ui/LoadingSkeleton'
+
+interface Props {
+  /** Cantidad de filas a mostrar. Default 6. */
+  count?: number
+}
+
+/**
+ * Lista de skeleton rows para pantallas que cargan datos al focus.
+ * Cada row simula una list card típica: avatar circular + 2 líneas de texto.
+ *
+ * Reemplaza al `<ActivityIndicator>` centrado en pantallas de listas
+ * (Transactions, Budgets, Savings, Loans, Reminders, Categories, Accounts).
+ *
+ * Mejora la perception de velocidad: el user ve el shape de la lista
+ * inmediatamente, no un spinner abstracto.
+ */
+export function ListLoadingSkeleton({ count = 6 }: Props) {
+  return (
+    <View className="gap-3 px-4 pt-4">
+      {Array.from({ length: count }).map((_, i) => (
+        <View
+          key={i}
+          className="bg-surface border border-border rounded-2xl p-4 flex-row items-center"
+        >
+          <LoadingSkeleton
+            width={40}
+            height={40}
+            rounded="full"
+            className="mr-3"
+          />
+          <View style={{ flex: 1 }} className="gap-2">
+            <LoadingSkeleton height={14} width="60%" />
+            <LoadingSkeleton height={12} width="40%" />
+          </View>
+          <LoadingSkeleton width={60} height={14} />
+        </View>
+      ))}
+    </View>
+  )
+}


### PR DESCRIPTION
Closes #97 · Related to #96 (FASE 6)

## Cambios — 5 categorías de polish

### 1. Error toasts en cargas fallidas
Las 10 list screens (Dashboard, Transactions, Reports, Calendar, Accounts, Budgets, Categories, Savings, Loans, Reminders) silenciaban errores de \`getX()\` en el load inicial — la lista quedaba vacía sin feedback. Patrón aplicado:
\`\`\`ts
if (res.success && res.data) setX(res.data)
else if (!res.success) toast.error(res.error ?? '...')
\`\`\`

### 2. Accessibility labels en FABs
Los 7 FABs de crear (transactions, accounts, budgets, categories, savings, loans, reminders) tenían solo el texto "+" visible. Añadido:
\`\`\`tsx
accessibilityRole="button"
accessibilityLabel="Crear nueva <entity>"
\`\`\`

### 3. Pull-to-refresh en 7 pantallas
RefreshControl añadido a Dashboard, Reports (ScrollView), Budgets, Savings, Loans (SectionList), Categories, Reminders (FlatList). Transactions y Accounts ya lo tenían. Calendar omitido (la librería no expone refreshControl).

### 4. Empty states estandarizados
Transactions y Accounts pasan de un \`<View>+<Text>\` ad-hoc a \`<EmptyState />\` consistente con el resto. Transactions con icono dinámico según filtros activos (🔍) vs vacío real (💸).

### 5. Loading skeletons
Nuevo componente \`<ListLoadingSkeleton count={6} />\` que renderiza rows con shape de list card (avatar circular + 2 lines + cifra). Aplicado en Budgets, Savings, Loans, Categories, Reminders. Mejora perception de velocidad.

## Verificación

- [x] \`npx tsc --noEmit\` limpio
- [ ] Smoke test: reload Metro, navegar cada pantalla, ver skeletons al cargar + pull-to-refresh funcional

## Commits granulares

1. \`fix(polish): toast.error en cargas fallidas de list screens\`
2. \`fix(polish): accessibilityLabel en los 7 FABs del dashboard\`
3. \`fix(polish): pull-to-refresh en 7 pantallas de listas + dashboards\`
4. \`fix(polish): EmptyState estandarizado en Transactions y Accounts\`
5. \`fix(polish): loading skeletons en pantallas de listas\`

## Notas

Sin concepto Obsidian nuevo — todo es polish composicional de patterns existentes.