### PR TITLE
fix(build): quitar plugin expo-notifications para builds con Apple ID gratis

### DIFF
--- a/app.json
+++ b/app.json
@@ -45,14 +45,7 @@
       "expo-router",
       "expo-secure-store",
       "expo-web-browser",
-      "@react-native-community/datetimepicker",
-      [
-        "expo-notifications",
-        {
-          "icon": "./assets/icon.png",
-          "color": "#4F46E5"
-        }
-      ]
+      "@react-native-community/datetimepicker"
     ]
   }
 }


### PR DESCRIPTION
El plugin de \`expo-notifications\` en \`app.json\` agrega \`aps-environment\` al entitlements file, que requiere Apple Developer Program (\$99/año). Bloquea builds locales con Apple ID gratis con el error:

\`\`\`
Personal development teams do not support the Push Notifications capability.
Entitlements file defines the value 'aps-environment' which is not registered.
\`\`\`

## Cambio

Quitar el entry de \`expo-notifications\` del array \`plugins\` en \`app.json\`.

## Trade-off

| Antes | Después |
|---|---|
| ✅ Push notifications remotas posibles (cuando haya cuenta dev) | ❌ Sin push remotas |
| ❌ Build bloqueado con Apple ID gratis | ✅ Build funciona |
| ✅ Icon custom de notifications Android | ❌ Icon default |

**Notifications locales SIGUEN funcionando** — autolinking enlaza el módulo nativo sin necesidad del plugin. Las funciones \`scheduleNotificationAsync\`, \`cancelScheduledNotificationAsync\`, etc. usadas en \`lib/utils/notifications.ts\` funcionan a runtime.

## Para revertir cuando se obtenga cuenta dev (\$99/año)

Re-agregar en \`app.json\`:

\`\`\`json
"plugins": [
  ...,
  [
    "expo-notifications",
    { "icon": "./assets/icon.png", "color": "#4F46E5" }
  ]
]
\`\`\`

## Verificación

- [x] \`npx expo prebuild --clean --platform ios\` no añade aps-environment a entitlements
- [ ] \`npx expo run:ios --device --configuration Release\` builds OK con Apple ID gratis
- [ ] Crear un reminder en runtime y verificar que la local notification se programa correctamente