### PR TITLE
Ordenar transacciones por date DESC, created_at DESC (paridad web)

### DIFF
--- a/lib/actions/transactions.actions.ts
+++ b/lib/actions/transactions.actions.ts
@@ -73,7 +73,10 @@ export async function getTransactions(
     const from = (page - 1) * pageSize
     const to = from + pageSize // pedimos 1 extra para detectar hasMore
 
-    const { data, error } = await query.order('date', { ascending: false }).range(from, to)
+    const { data, error } = await query
+      .order('date', { ascending: false })
+      .order('created_at', { ascending: false })
+      .range(from, to)
     if (error) throw error
 
     const rows = (data ?? []) as TransactionWithCategory[]


### PR DESCRIPTION
## Cambios
- Encadenado segundo \`.order('created_at', { ascending: false })\` en \`getTransactions()\` de \`lib/actions/transactions.actions.ts\`
- Mismo criterio que la versión web: empates por fecha se rompen por fecha de creación descendente

## Testing
- ✅ \`npx tsc --noEmit\` sin errores
- Pendiente verificar en simulador con dos transacciones del mismo día

## Notas
- Revisé otros queries con \`.order('date')\`. El único en \`lib/utils/balance-updater.ts:38\` es sobre \`exchange_rates\` (no transactions) y ya tiene \`.limit(1).single()\`, no aplica el cambio.

Closes #104