### PR TITLE
Mostrar logo de la app en login y header del dashboard

### DIFF
--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -1,5 +1,5 @@
 // app/(auth)/login.tsx
-import { View, Text } from 'react-native'
+import { View, Text, Image } from 'react-native'
 import { useState } from 'react'
 import { router } from 'expo-router'
 import * as WebBrowser from 'expo-web-browser'
@@ -139,6 +139,12 @@ export default function LoginScreen() {
   return (
     <View className="flex-1 bg-bg items-center justify-center px-8 gap-8">
       <View className="items-center gap-3">
+        <Image
+          source={require('@/assets/icon.png')}
+          style={{ width: 120, height: 120 }}
+          resizeMode="contain"
+          accessibilityLabel="Logo de Expense Manager"
+        />
         <Text className="text-white text-3xl font-bold">Expense Manager</Text>
         <Text className="text-muted text-base text-center">
           Controla tus finanzas personales

--- a/app/(dashboard)/index.tsx
+++ b/app/(dashboard)/index.tsx
@@ -10,7 +10,7 @@
 //
 // Refresh on focus con useFocusEffect — al volver al tab se actualiza.
 import { useCallback, useMemo, useState } from 'react'
-import { ScrollView, View, Text, ActivityIndicator, RefreshControl } from 'react-native'
+import { ScrollView, View, Text, Image, ActivityIndicator, RefreshControl } from 'react-native'
 import { useFocusEffect } from 'expo-router'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useAuth } from '@/context/AuthContext'
@@ -124,11 +124,19 @@ export default function DashboardScreen() {
 
   return (
     <SafeAreaView edges={['top']} className="flex-1 bg-bg">
-      <View className="px-4 py-3 border-b border-border">
-        <Text className="text-white text-xl font-bold">Dashboard</Text>
-        <Text className="text-muted text-xs mt-0.5">
-          {user?.name ? `Hola, ${user.name}` : MONTH_LABEL} · {MONTH_LABEL}
-        </Text>
+      <View className="px-4 py-3 border-b border-border flex-row items-center gap-3">
+        <Image
+          source={require('@/assets/icon.png')}
+          style={{ width: 36, height: 36 }}
+          resizeMode="contain"
+          accessibilityLabel="Logo de Expense Manager"
+        />
+        <View className="flex-1">
+          <Text className="text-white text-xl font-bold">Dashboard</Text>
+          <Text className="text-muted text-xs mt-0.5">
+            {user?.name ? `Hola, ${user.name}` : MONTH_LABEL} · {MONTH_LABEL}
+          </Text>
+        </View>
       </View>
 
       <ScrollView


### PR DESCRIPTION
## Cambios
- `app/(auth)/login.tsx`: agregado `<Image>` (120×120, `resizeMode='contain'`) sobre el texto principal.
- `app/(dashboard)/index.tsx`: header convertido en `flex-row` con logo 36×36 a la izquierda del bloque de título/subtítulo.

## Asset
- Se reusa `assets/icon.png` que ya existía. Verifiqué con md5 que es **exactamente el mismo binario** que `gh_push_money_logo.png` del proyecto web. No hubo que copiar nada nuevo.
- El splash screen ya lo usaba — no se toca.

## Testing
- ✅ `npx tsc --noEmit` sin errores
- Pendiente verificar visualmente en simulador iOS/Android

## Documentación
- Nuevo concepto registrado en Obsidian: `10 - Concepts/React Native/Image (RN).md` — diferencias vs `<img>` web, `resizeMode`, `require()`, cuándo usar `expo-image`.

Closes #106