### PR TITLE
Cards de totales (ReportStatistics) en pantalla de Reportes

### DIFF
--- a/app/(dashboard)/reports/index.tsx
+++ b/app/(dashboard)/reports/index.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/lib/utils/dashboard'
 import {
   buildMonthlyAggregates,
+  buildRangeTotals,
   RANGE_DAYS,
   RANGE_MONTHS,
   RANGE_LABEL,
@@ -29,6 +30,7 @@ import { AccumulatedBalanceChart } from '@/components/charts/AccumulatedBalanceC
 import { ExpensesByCategoryChart } from '@/components/charts/ExpensesByCategoryChart'
 import { MonthlyComparisonChart } from '@/components/charts/MonthlyComparisonChart'
 import { RangeSelector } from '@/components/reports/RangeSelector'
+import { ReportStatistics } from '@/components/reports/ReportStatistics'
 import { toast } from '@/components/ui/Toast'
 import type { TransactionWithCategory } from '@/types/database.types'
 
@@ -101,6 +103,16 @@ export default function ReportsScreen() {
     [transactions, range, preferredCurrency, rates]
   )
 
+  const rangeTotals = useMemo(
+    () =>
+      buildRangeTotals(transactions, {
+        days: RANGE_DAYS[range],
+        targetCurrency: preferredCurrency,
+        rates,
+      }),
+    [transactions, range, preferredCurrency, rates]
+  )
+
   if (loading) {
     return (
       <SafeAreaView edges={['top']} className="flex-1 bg-bg">
@@ -136,6 +148,8 @@ export default function ReportsScreen() {
         }
       >
         <RangeSelector value={range} onChange={setRange} />
+
+        <ReportStatistics totals={rangeTotals} currency={preferredCurrency} />
 
         <AccumulatedBalanceChart
           data={balanceSeries}

--- a/components/reports/ReportStatistics.tsx
+++ b/components/reports/ReportStatistics.tsx
@@ -1,0 +1,85 @@
+// components/reports/ReportStatistics.tsx
+//
+// 3 cards de resumen del rango activo del reporte:
+//   - Balance neto (hero card, full-width)
+//   - Ingresos + Gastos (lado a lado)
+//
+// Diseño consistente con SummaryCards del dashboard, pero el cálculo
+// usa buildRangeTotals (rango por días, no por mes) y convierte todas
+// las tx a la preferred currency del usuario.
+import { View, Text } from 'react-native'
+import { formatCurrency } from '@/lib/utils/currency'
+import type { Currency } from '@/types/database.types'
+import type { RangeTotals } from '@/lib/utils/reports'
+
+interface Props {
+  totals: RangeTotals
+  currency: Currency
+}
+
+export function ReportStatistics({ totals, currency }: Props) {
+  const positive = totals.balance >= 0
+
+  return (
+    <View className="gap-3">
+      {/* Balance — hero card */}
+      <View className="bg-surface border border-border rounded-2xl p-5">
+        <Text className="text-muted text-xs uppercase tracking-wider">
+          Balance del rango
+        </Text>
+        <Text
+          className={`text-3xl font-bold mt-1 ${
+            positive ? 'text-white' : 'text-red-400'
+          }`}
+        >
+          {formatCurrency(totals.balance, currency)}
+        </Text>
+        <Text className="text-muted text-xs mt-1">
+          {totals.transactionCount}{' '}
+          {totals.transactionCount === 1 ? 'transacción' : 'transacciones'}
+        </Text>
+      </View>
+
+      {/* Income + Expense lado a lado */}
+      <View className="flex-row gap-3">
+        <StatItem
+          label="Ingresos"
+          value={formatCurrency(totals.totalIncome, currency)}
+          accent="green"
+        />
+        <StatItem
+          label="Gastos"
+          value={formatCurrency(totals.totalExpense, currency)}
+          accent="red"
+        />
+      </View>
+    </View>
+  )
+}
+
+function StatItem({
+  label,
+  value,
+  accent,
+}: {
+  label: string
+  value: string
+  accent: 'green' | 'red'
+}) {
+  return (
+    <View className="flex-1 bg-surface border border-border rounded-2xl p-4">
+      <Text className="text-muted text-xs uppercase tracking-wider">
+        {label}
+      </Text>
+      <Text
+        className={`text-base font-bold mt-1 ${
+          accent === 'green' ? 'text-green-400' : 'text-red-400'
+        }`}
+        numberOfLines={1}
+        adjustsFontSizeToFit
+      >
+        {value}
+      </Text>
+    </View>
+  )
+}

--- a/lib/utils/reports.ts
+++ b/lib/utils/reports.ts
@@ -109,3 +109,52 @@ export function buildMonthlyAggregates(
     }
   })
 }
+
+export interface RangeTotals {
+  totalIncome: number
+  totalExpense: number
+  balance: number
+  transactionCount: number
+}
+
+/**
+ * Suma ingresos / gastos / balance de las transactions que caen dentro
+ * de los últimos `days` días, convertidos a `targetCurrency`.
+ *
+ * Cutoff inclusivo: `cutoff = today - (days - 1)` para que `days=30`
+ * cubra 30 días completos incluyendo hoy.
+ */
+export function buildRangeTotals(
+  transactions: TransactionWithCategory[],
+  options: {
+    days: number
+    targetCurrency: Currency
+    rates: ExchangeRate[]
+  }
+): RangeTotals {
+  const { days, targetCurrency, rates } = options
+  const cutoff = new Date()
+  cutoff.setHours(0, 0, 0, 0)
+  cutoff.setDate(cutoff.getDate() - (days - 1))
+  const cutoffISO = `${cutoff.getFullYear()}-${String(cutoff.getMonth() + 1).padStart(2, '0')}-${String(cutoff.getDate()).padStart(2, '0')}`
+
+  let totalIncome = 0
+  let totalExpense = 0
+  let transactionCount = 0
+
+  for (const t of transactions) {
+    if (t.date < cutoffISO) continue
+    const amount =
+      Number(t.amount) * getRate(t.currency, targetCurrency, rates)
+    if (t.type === 'income') totalIncome += amount
+    else if (t.type === 'expense') totalExpense += amount
+    transactionCount++
+  }
+
+  return {
+    totalIncome,
+    totalExpense,
+    balance: totalIncome - totalExpense,
+    transactionCount,
+  }
+}


### PR DESCRIPTION
## Cambios
- `lib/utils/reports.ts`: nueva función `buildRangeTotals()` que devuelve `{ totalIncome, totalExpense, balance, transactionCount }` filtrando por cutoff de días (inclusivo) y aplicando conversión multi-moneda.
- `components/reports/ReportStatistics.tsx`: nuevo componente con 3 cards (balance hero full-width + ingresos/gastos lado a lado).
- `app/(dashboard)/reports/index.tsx`: integrado entre el `RangeSelector` y los charts.

## Decisiones de diseño
- Estilo consistente con `SummaryCards` del dashboard para mantener coherencia visual.
- Se respeta `preferred_currency` del usuario (no se cae al "dominant currency" como hace web — mobile prioriza la moneda configurada del user, comportamiento ya establecido en el dashboard).
- No agregué filtros de tipo (income/expense) ni de categoría en esta iteración para mantener el PR enfocado. Quedan documentados como futura mejora.

## Testing
- ✅ `npx tsc --noEmit` sin errores
- Pendiente verificar visualmente: cambiar rango → cards se actualizan; transacciones en USD se ven convertidas a COP.

Closes #108