### PR TITLE
Hub de Planificación (tabs Metas + Presupuestos)

### DIFF
--- a/app/(dashboard)/_layout.tsx
+++ b/app/(dashboard)/_layout.tsx
@@ -108,6 +108,7 @@ export default function DashboardLayout() {
         <Tabs.Screen name="categories" options={{ href: null }} />
         <Tabs.Screen name="budgets" options={{ href: null }} />
         <Tabs.Screen name="savings" options={{ href: null }} />
+        <Tabs.Screen name="planning" options={{ href: null }} />
         <Tabs.Screen name="loans" options={{ href: null }} />
         <Tabs.Screen name="reminders" options={{ href: null }} />
       </Tabs>

--- a/app/(dashboard)/budgets/index.tsx
+++ b/app/(dashboard)/budgets/index.tsx
@@ -1,32 +1,17 @@
+// app/(dashboard)/budgets/index.tsx
+//
+// Pantalla dedicada de Presupuestos. Mantiene header con back + FAB.
+// El contenido del listado lo provee <BudgetsList /> (reutilizable, también
+// usado por el hub /planning).
 import { useCallback, useState } from 'react'
-import {
-  View,
-  Text,
-  FlatList,
-  TouchableOpacity,
-  ActivityIndicator,
-  RefreshControl,
-} from 'react-native'
+import { View, Text, TouchableOpacity } from 'react-native'
 import { router, useFocusEffect } from 'expo-router'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useAuth } from '@/context/AuthContext'
 import { getBudgets } from '@/lib/actions/budgets.actions'
-import { ProgressBar, defaultColor } from '@/components/ui/ProgressBar'
-import { EmptyState } from '@/components/ui/EmptyState'
-import { ListLoadingSkeleton } from '@/components/ui/ListLoadingSkeleton'
+import { BudgetsList } from '@/components/budgets/BudgetsList'
 import { toast } from '@/components/ui/Toast'
-import { formatCurrency } from '@/lib/utils/currency'
 import type { BudgetWithSpent } from '@/types/database.types'
-
-const PERIOD_LABEL: Record<'monthly' | 'yearly', string> = {
-  monthly: 'Mensual',
-  yearly: 'Anual',
-}
-
-function formatShortDate(iso: string): string {
-  const d = new Date(iso)
-  return d.toLocaleDateString('es', { day: 'numeric', month: 'short' })
-}
 
 export default function BudgetsScreen() {
   const { user } = useAuth()
@@ -55,19 +40,6 @@ export default function BudgetsScreen() {
     }, [loadBudgets])
   )
 
-  if (loading) {
-    return (
-      <SafeAreaView edges={['top']} className="flex-1 bg-bg">
-        <View className="flex-row items-center justify-between px-4 py-3 border-b border-border">
-          <View style={{ width: 60 }} />
-          <Text className="text-white text-base font-bold">Presupuestos</Text>
-          <View style={{ width: 60 }} />
-        </View>
-        <ListLoadingSkeleton />
-      </SafeAreaView>
-    )
-  }
-
   return (
     <SafeAreaView edges={['top']} className="flex-1 bg-bg">
       {/* Header */}
@@ -79,31 +51,15 @@ export default function BudgetsScreen() {
         <View style={{ width: 60 }} />
       </View>
 
-      <FlatList
-        data={budgets}
-        keyExtractor={(b) => b.id}
-        contentContainerStyle={
-          budgets.length === 0 ? { flex: 1 } : { paddingVertical: 12 }
-        }
-        ListEmptyComponent={
-          <EmptyState
-            icon="🎯"
-            title="Sin presupuestos"
-            description="Toca + para crear tu primer presupuesto"
-          />
-        }
-        renderItem={({ item }) => <BudgetCard budget={item} />}
-        refreshControl={
-          <RefreshControl
-            refreshing={refreshing}
-            onRefresh={async () => {
-              setRefreshing(true)
-              await loadBudgets()
-              setRefreshing(false)
-            }}
-            tintColor="#4F46E5"
-          />
-        }
+      <BudgetsList
+        budgets={budgets}
+        loading={loading}
+        refreshing={refreshing}
+        onRefresh={async () => {
+          setRefreshing(true)
+          await loadBudgets()
+          setRefreshing(false)
+        }}
       />
 
       {/* FAB */}
@@ -126,72 +82,5 @@ export default function BudgetsScreen() {
         </Text>
       </TouchableOpacity>
     </SafeAreaView>
-  )
-}
-
-function BudgetCard({ budget }: { budget: BudgetWithSpent }) {
-  const ratio = budget.amount > 0 ? budget.spent / budget.amount : 0
-  const color = defaultColor(ratio)
-  const exceeded = ratio >= 1
-  const remaining = budget.amount - budget.spent
-
-  return (
-    <TouchableOpacity
-      onPress={() => router.push(`/budgets/${budget.id}`)}
-      activeOpacity={0.7}
-      className="mx-4 mb-3 bg-surface border border-border rounded-2xl p-4"
-    >
-      {/* Header card */}
-      <View className="flex-row items-center mb-3">
-        <View
-          style={{ backgroundColor: budget.category.color ?? '#4F46E5' }}
-          className="w-10 h-10 rounded-full items-center justify-center mr-3"
-        >
-          <Text className="text-xl">{budget.category.icon ?? '📂'}</Text>
-        </View>
-        <View className="flex-1">
-          <Text className="text-white text-base font-semibold">
-            {budget.category.name}
-          </Text>
-          <Text className="text-muted text-xs">
-            {PERIOD_LABEL[budget.period]} · {formatShortDate(budget.periodStart)} —{' '}
-            {formatShortDate(budget.periodEnd)}
-          </Text>
-        </View>
-        <Text style={{ color }} className="text-base font-bold">
-          {Math.round(ratio * 100)}%
-        </Text>
-      </View>
-
-      <ProgressBar value={ratio} />
-
-      {/* Footer */}
-      <View className="flex-row justify-between mt-3">
-        <Text className="text-muted text-xs">
-          Gastado{' '}
-          <Text className="text-white text-sm">
-            {formatCurrency(budget.spent, budget.currency)}
-          </Text>
-        </Text>
-        <Text className="text-muted text-xs">
-          de{' '}
-          <Text className="text-white text-sm">
-            {formatCurrency(budget.amount, budget.currency)}
-          </Text>
-        </Text>
-      </View>
-
-      {exceeded ? (
-        <View className="mt-2 px-3 py-1.5 rounded-lg bg-red-500/10 border border-red-500/40">
-          <Text className="text-red-400 text-xs">
-            Excedido por {formatCurrency(budget.spent - budget.amount, budget.currency)}
-          </Text>
-        </View>
-      ) : (
-        <Text className="text-muted text-xs mt-2">
-          Restante {formatCurrency(remaining, budget.currency)}
-        </Text>
-      )}
-    </TouchableOpacity>
   )
 }

--- a/app/(dashboard)/planning/_layout.tsx
+++ b/app/(dashboard)/planning/_layout.tsx
@@ -1,0 +1,13 @@
+import { Stack } from 'expo-router'
+import { colors } from '@/constants/theme'
+
+export default function PlanningLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: colors.bg },
+      }}
+    />
+  )
+}

--- a/app/(dashboard)/planning/index.tsx
+++ b/app/(dashboard)/planning/index.tsx
@@ -1,0 +1,167 @@
+// app/(dashboard)/planning/index.tsx
+//
+// Hub de Planificación: agrupa Metas de Ahorro + Presupuestos detrás
+// de un segmented control. Equivalente al `/(dashboard)/planificacion`
+// del web con sus dos tabs.
+//
+// Carga ambos datasets en paralelo al enfocar la pantalla. El FAB
+// apunta dinámicamente a /savings/new o /budgets/new según el tab activo.
+// Las rutas legacy /savings y /budgets siguen funcionando para deep
+// links y para volver desde las pantallas de detalle.
+import { useCallback, useState } from 'react'
+import { View, Text, TouchableOpacity } from 'react-native'
+import { router, useFocusEffect } from 'expo-router'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useAuth } from '@/context/AuthContext'
+import { getSavingsGoals } from '@/lib/actions/savings.actions'
+import { getBudgets } from '@/lib/actions/budgets.actions'
+import { SavingsList } from '@/components/savings/SavingsList'
+import { BudgetsList } from '@/components/budgets/BudgetsList'
+import { toast } from '@/components/ui/Toast'
+import type { BudgetWithSpent, SavingsGoal } from '@/types/database.types'
+
+type Tab = 'savings' | 'budgets'
+
+const TABS: { key: Tab; label: string }[] = [
+  { key: 'savings', label: 'Metas' },
+  { key: 'budgets', label: 'Presupuestos' },
+]
+
+export default function PlanningScreen() {
+  const { user } = useAuth()
+  const [tab, setTab] = useState<Tab>('savings')
+  const [goals, setGoals] = useState<SavingsGoal[]>([])
+  const [budgets, setBudgets] = useState<BudgetWithSpent[]>([])
+  const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
+
+  const loadData = useCallback(async () => {
+    if (!user) return
+    const [goalsRes, budgetsRes] = await Promise.all([
+      getSavingsGoals(user.id),
+      getBudgets(user.id),
+    ])
+    if (goalsRes.success && goalsRes.data) setGoals(goalsRes.data)
+    else if (!goalsRes.success) toast.error(goalsRes.error ?? 'Error al cargar metas')
+
+    if (budgetsRes.success && budgetsRes.data) setBudgets(budgetsRes.data)
+    else if (!budgetsRes.success)
+      toast.error(budgetsRes.error ?? 'Error al cargar presupuestos')
+
+    setLoading(false)
+  }, [user])
+
+  useFocusEffect(
+    useCallback(() => {
+      let cancelled = false
+      ;(async () => {
+        await loadData()
+        if (cancelled) return
+      })()
+      return () => {
+        cancelled = true
+      }
+    }, [loadData])
+  )
+
+  const fabTarget = tab === 'savings' ? '/savings/new' : '/budgets/new'
+  const fabLabel =
+    tab === 'savings'
+      ? 'Crear nueva meta de ahorro'
+      : 'Crear nuevo presupuesto'
+
+  return (
+    <SafeAreaView edges={['top']} className="flex-1 bg-bg">
+      {/* Header */}
+      <View className="flex-row items-center justify-between px-4 py-3 border-b border-border">
+        <TouchableOpacity onPress={() => router.back()} activeOpacity={0.7}>
+          <Text className="text-primary text-base">← Volver</Text>
+        </TouchableOpacity>
+        <Text className="text-white text-base font-bold">Planificación</Text>
+        <View style={{ width: 60 }} />
+      </View>
+
+      {/* Segmented control */}
+      <View className="flex-row gap-2 px-4 pt-3 pb-1">
+        {TABS.map((t) => {
+          const active = t.key === tab
+          return (
+            <TouchableOpacity
+              key={t.key}
+              onPress={() => setTab(t.key)}
+              activeOpacity={0.7}
+              className={`flex-1 py-2 rounded-xl items-center border ${
+                active
+                  ? 'bg-primary border-primary'
+                  : 'bg-transparent border-border'
+              }`}
+            >
+              <Text
+                className={
+                  active
+                    ? 'text-white text-sm font-semibold'
+                    : 'text-muted text-sm'
+                }
+              >
+                {t.label}
+              </Text>
+            </TouchableOpacity>
+          )
+        })}
+      </View>
+
+      {/* Body — un listado a la vez. Mantenemos ambos montados para
+          preservar scroll position al toggle, vía display none/flex. */}
+      <View className="flex-1">
+        <View
+          style={{ flex: tab === 'savings' ? 1 : 0, display: tab === 'savings' ? 'flex' : 'none' }}
+        >
+          <SavingsList
+            goals={goals}
+            loading={loading}
+            refreshing={refreshing}
+            onRefresh={async () => {
+              setRefreshing(true)
+              await loadData()
+              setRefreshing(false)
+            }}
+          />
+        </View>
+        <View
+          style={{ flex: tab === 'budgets' ? 1 : 0, display: tab === 'budgets' ? 'flex' : 'none' }}
+        >
+          <BudgetsList
+            budgets={budgets}
+            loading={loading}
+            refreshing={refreshing}
+            onRefresh={async () => {
+              setRefreshing(true)
+              await loadData()
+              setRefreshing(false)
+            }}
+          />
+        </View>
+      </View>
+
+      {/* FAB dinámico */}
+      <TouchableOpacity
+        onPress={() => router.push(fabTarget)}
+        activeOpacity={0.8}
+        accessibilityRole="button"
+        accessibilityLabel={fabLabel}
+        className="absolute bottom-6 right-6 w-14 h-14 rounded-full bg-primary items-center justify-center shadow-lg"
+        style={{
+          shadowColor: '#000',
+          shadowOffset: { width: 0, height: 4 },
+          shadowOpacity: 0.3,
+          shadowRadius: 6,
+          elevation: 6,
+        }}
+      >
+        <Text className="text-white text-3xl font-bold" style={{ lineHeight: 32 }}>
+          +
+        </Text>
+      </TouchableOpacity>
+    </SafeAreaView>
+  )
+}

--- a/app/(dashboard)/savings/index.tsx
+++ b/app/(dashboard)/savings/index.tsx
@@ -1,39 +1,17 @@
+// app/(dashboard)/savings/index.tsx
+//
+// Pantalla dedicada de Metas de Ahorro. Mantiene header con back + FAB.
+// El contenido del listado lo provee <SavingsList /> (reutilizable, también
+// usado por el hub /planning).
 import { useCallback, useState } from 'react'
-import {
-  View,
-  Text,
-  FlatList,
-  TouchableOpacity,
-  ActivityIndicator,
-  RefreshControl,
-} from 'react-native'
+import { View, Text, TouchableOpacity } from 'react-native'
 import { router, useFocusEffect } from 'expo-router'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { useAuth } from '@/context/AuthContext'
 import { getSavingsGoals } from '@/lib/actions/savings.actions'
-import { ProgressBar } from '@/components/ui/ProgressBar'
-import { EmptyState } from '@/components/ui/EmptyState'
-import { ListLoadingSkeleton } from '@/components/ui/ListLoadingSkeleton'
+import { SavingsList } from '@/components/savings/SavingsList'
 import { toast } from '@/components/ui/Toast'
-import { formatCurrency } from '@/lib/utils/currency'
 import type { SavingsGoal } from '@/types/database.types'
-
-/** Devuelve "Faltan X días", "Vence hoy", "Vencida hace Y días", o null si no hay deadline. */
-function formatDeadline(deadline: string | null): {
-  text: string
-  overdue: boolean
-} | null {
-  if (!deadline) return null
-  const today = new Date()
-  today.setHours(0, 0, 0, 0)
-  const target = new Date(`${deadline}T00:00:00`)
-  const diffMs = target.getTime() - today.getTime()
-  const days = Math.round(diffMs / (1000 * 60 * 60 * 24))
-
-  if (days === 0) return { text: 'Vence hoy', overdue: false }
-  if (days > 0) return { text: `Faltan ${days} días`, overdue: false }
-  return { text: `Vencida hace ${Math.abs(days)} días`, overdue: true }
-}
 
 export default function SavingsScreen() {
   const { user } = useAuth()
@@ -62,19 +40,6 @@ export default function SavingsScreen() {
     }, [loadGoals])
   )
 
-  if (loading) {
-    return (
-      <SafeAreaView edges={['top']} className="flex-1 bg-bg">
-        <View className="flex-row items-center justify-between px-4 py-3 border-b border-border">
-          <View style={{ width: 60 }} />
-          <Text className="text-white text-base font-bold">Metas de ahorro</Text>
-          <View style={{ width: 60 }} />
-        </View>
-        <ListLoadingSkeleton />
-      </SafeAreaView>
-    )
-  }
-
   return (
     <SafeAreaView edges={['top']} className="flex-1 bg-bg">
       {/* Header */}
@@ -86,31 +51,15 @@ export default function SavingsScreen() {
         <View style={{ width: 60 }} />
       </View>
 
-      <FlatList
-        data={goals}
-        keyExtractor={(g) => g.id}
-        contentContainerStyle={
-          goals.length === 0 ? { flex: 1 } : { paddingVertical: 12 }
-        }
-        ListEmptyComponent={
-          <EmptyState
-            icon="🐖"
-            title="Sin metas"
-            description="Toca + para crear tu primera meta de ahorro"
-          />
-        }
-        renderItem={({ item }) => <GoalCard goal={item} />}
-        refreshControl={
-          <RefreshControl
-            refreshing={refreshing}
-            onRefresh={async () => {
-              setRefreshing(true)
-              await loadGoals()
-              setRefreshing(false)
-            }}
-            tintColor="#4F46E5"
-          />
-        }
+      <SavingsList
+        goals={goals}
+        loading={loading}
+        refreshing={refreshing}
+        onRefresh={async () => {
+          setRefreshing(true)
+          await loadGoals()
+          setRefreshing(false)
+        }}
       />
 
       {/* FAB */}
@@ -133,76 +82,5 @@ export default function SavingsScreen() {
         </Text>
       </TouchableOpacity>
     </SafeAreaView>
-  )
-}
-
-function GoalCard({ goal }: { goal: SavingsGoal }) {
-  const target = Number(goal.target_amount)
-  const current = Number(goal.current_amount)
-  const ratio = target > 0 ? current / target : 0
-  const remaining = Math.max(0, target - current)
-  const deadline = formatDeadline(goal.deadline)
-  const completed = goal.is_completed || ratio >= 1
-
-  return (
-    <TouchableOpacity
-      onPress={() => router.push(`/savings/${goal.id}`)}
-      activeOpacity={0.7}
-      className="mx-4 mb-3 bg-surface border border-border rounded-2xl p-4"
-    >
-      <View className="flex-row items-center mb-3">
-        <View className="flex-1">
-          <View className="flex-row items-center gap-2">
-            <Text className="text-white text-base font-semibold">
-              {goal.name}
-            </Text>
-            {completed ? (
-              <View className="px-2 py-0.5 rounded-full bg-green-500/15 border border-green-500/40">
-                <Text className="text-green-400 text-xs font-semibold">
-                  Completada
-                </Text>
-              </View>
-            ) : null}
-          </View>
-          {deadline ? (
-            <Text
-              className={
-                deadline.overdue
-                  ? 'text-red-400 text-xs mt-0.5'
-                  : 'text-muted text-xs mt-0.5'
-              }
-            >
-              {deadline.text}
-            </Text>
-          ) : null}
-        </View>
-        <Text className="text-green-400 text-base font-bold">
-          {Math.round(ratio * 100)}%
-        </Text>
-      </View>
-
-      <ProgressBar value={ratio} color="#10b981" />
-
-      <View className="flex-row justify-between mt-3">
-        <Text className="text-muted text-xs">
-          Ahorrado{' '}
-          <Text className="text-white text-sm">
-            {formatCurrency(current, goal.currency)}
-          </Text>
-        </Text>
-        <Text className="text-muted text-xs">
-          de{' '}
-          <Text className="text-white text-sm">
-            {formatCurrency(target, goal.currency)}
-          </Text>
-        </Text>
-      </View>
-
-      {!completed ? (
-        <Text className="text-muted text-xs mt-2">
-          Restante {formatCurrency(remaining, goal.currency)}
-        </Text>
-      ) : null}
-    </TouchableOpacity>
   )
 }

--- a/components/budgets/BudgetsList.tsx
+++ b/components/budgets/BudgetsList.tsx
@@ -1,0 +1,129 @@
+// components/budgets/BudgetsList.tsx
+//
+// Lista reutilizable de presupuestos. Sin header ni FAB — solo el
+// FlatList + EmptyState + skeleton + BudgetCard. Se usa tanto en la
+// pantalla dedicada /budgets como en el hub /planning.
+//
+// Loading / refresh / data viven en el padre — este componente solo renderiza.
+import { View, Text, FlatList, TouchableOpacity, RefreshControl } from 'react-native'
+import { router } from 'expo-router'
+import { ProgressBar, defaultColor } from '@/components/ui/ProgressBar'
+import { EmptyState } from '@/components/ui/EmptyState'
+import { ListLoadingSkeleton } from '@/components/ui/ListLoadingSkeleton'
+import { formatCurrency } from '@/lib/utils/currency'
+import type { BudgetWithSpent } from '@/types/database.types'
+
+const PERIOD_LABEL: Record<'monthly' | 'yearly', string> = {
+  monthly: 'Mensual',
+  yearly: 'Anual',
+}
+
+function formatShortDate(iso: string): string {
+  const d = new Date(iso)
+  return d.toLocaleDateString('es', { day: 'numeric', month: 'short' })
+}
+
+interface Props {
+  budgets: BudgetWithSpent[]
+  loading: boolean
+  refreshing: boolean
+  onRefresh: () => void | Promise<void>
+}
+
+export function BudgetsList({ budgets, loading, refreshing, onRefresh }: Props) {
+  if (loading) {
+    return <ListLoadingSkeleton />
+  }
+
+  return (
+    <FlatList
+      data={budgets}
+      keyExtractor={(b) => b.id}
+      contentContainerStyle={
+        budgets.length === 0 ? { flex: 1 } : { paddingVertical: 12 }
+      }
+      ListEmptyComponent={
+        <EmptyState
+          icon="🎯"
+          title="Sin presupuestos"
+          description="Toca + para crear tu primer presupuesto"
+        />
+      }
+      renderItem={({ item }) => <BudgetCard budget={item} />}
+      refreshControl={
+        <RefreshControl
+          refreshing={refreshing}
+          onRefresh={onRefresh}
+          tintColor="#4F46E5"
+        />
+      }
+    />
+  )
+}
+
+function BudgetCard({ budget }: { budget: BudgetWithSpent }) {
+  const ratio = budget.amount > 0 ? budget.spent / budget.amount : 0
+  const color = defaultColor(ratio)
+  const exceeded = ratio >= 1
+  const remaining = budget.amount - budget.spent
+
+  return (
+    <TouchableOpacity
+      onPress={() => router.push(`/budgets/${budget.id}`)}
+      activeOpacity={0.7}
+      className="mx-4 mb-3 bg-surface border border-border rounded-2xl p-4"
+    >
+      {/* Header card */}
+      <View className="flex-row items-center mb-3">
+        <View
+          style={{ backgroundColor: budget.category.color ?? '#4F46E5' }}
+          className="w-10 h-10 rounded-full items-center justify-center mr-3"
+        >
+          <Text className="text-xl">{budget.category.icon ?? '📂'}</Text>
+        </View>
+        <View className="flex-1">
+          <Text className="text-white text-base font-semibold">
+            {budget.category.name}
+          </Text>
+          <Text className="text-muted text-xs">
+            {PERIOD_LABEL[budget.period]} · {formatShortDate(budget.periodStart)} —{' '}
+            {formatShortDate(budget.periodEnd)}
+          </Text>
+        </View>
+        <Text style={{ color }} className="text-base font-bold">
+          {Math.round(ratio * 100)}%
+        </Text>
+      </View>
+
+      <ProgressBar value={ratio} />
+
+      {/* Footer */}
+      <View className="flex-row justify-between mt-3">
+        <Text className="text-muted text-xs">
+          Gastado{' '}
+          <Text className="text-white text-sm">
+            {formatCurrency(budget.spent, budget.currency)}
+          </Text>
+        </Text>
+        <Text className="text-muted text-xs">
+          de{' '}
+          <Text className="text-white text-sm">
+            {formatCurrency(budget.amount, budget.currency)}
+          </Text>
+        </Text>
+      </View>
+
+      {exceeded ? (
+        <View className="mt-2 px-3 py-1.5 rounded-lg bg-red-500/10 border border-red-500/40">
+          <Text className="text-red-400 text-xs">
+            Excedido por {formatCurrency(budget.spent - budget.amount, budget.currency)}
+          </Text>
+        </View>
+      ) : (
+        <Text className="text-muted text-xs mt-2">
+          Restante {formatCurrency(remaining, budget.currency)}
+        </Text>
+      )}
+    </TouchableOpacity>
+  )
+}

--- a/components/quick-actions/QuickActionsSheet.tsx
+++ b/components/quick-actions/QuickActionsSheet.tsx
@@ -48,15 +48,9 @@ const TILES: ActionTile[] = [
   },
   {
     icon: 'target',
-    label: 'Presupuestos',
-    route: '/budgets',
+    label: 'Planificación',
+    route: '/planning',
     color: '#f59e0b',
-  },
-  {
-    icon: 'piggy',
-    label: 'Metas de ahorro',
-    route: '/savings',
-    color: '#10b981',
   },
   {
     icon: 'hand-coins',

--- a/components/savings/SavingsList.tsx
+++ b/components/savings/SavingsList.tsx
@@ -1,0 +1,140 @@
+// components/savings/SavingsList.tsx
+//
+// Lista reutilizable de metas de ahorro. Sin header ni FAB — solo el
+// FlatList + EmptyState + skeleton + GoalCard. Se usa tanto en la
+// pantalla dedicada /savings como en el hub /planning.
+//
+// Loading / refresh / data viven en el padre — este componente solo renderiza.
+import { View, Text, FlatList, TouchableOpacity, RefreshControl } from 'react-native'
+import { router } from 'expo-router'
+import { ProgressBar } from '@/components/ui/ProgressBar'
+import { EmptyState } from '@/components/ui/EmptyState'
+import { ListLoadingSkeleton } from '@/components/ui/ListLoadingSkeleton'
+import { formatCurrency } from '@/lib/utils/currency'
+import type { SavingsGoal } from '@/types/database.types'
+
+/** Devuelve "Faltan X días", "Vence hoy", "Vencida hace Y días", o null si no hay deadline. */
+function formatDeadline(deadline: string | null): {
+  text: string
+  overdue: boolean
+} | null {
+  if (!deadline) return null
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  const target = new Date(`${deadline}T00:00:00`)
+  const diffMs = target.getTime() - today.getTime()
+  const days = Math.round(diffMs / (1000 * 60 * 60 * 24))
+
+  if (days === 0) return { text: 'Vence hoy', overdue: false }
+  if (days > 0) return { text: `Faltan ${days} días`, overdue: false }
+  return { text: `Vencida hace ${Math.abs(days)} días`, overdue: true }
+}
+
+interface Props {
+  goals: SavingsGoal[]
+  loading: boolean
+  refreshing: boolean
+  onRefresh: () => void | Promise<void>
+}
+
+export function SavingsList({ goals, loading, refreshing, onRefresh }: Props) {
+  if (loading) {
+    return <ListLoadingSkeleton />
+  }
+
+  return (
+    <FlatList
+      data={goals}
+      keyExtractor={(g) => g.id}
+      contentContainerStyle={
+        goals.length === 0 ? { flex: 1 } : { paddingVertical: 12 }
+      }
+      ListEmptyComponent={
+        <EmptyState
+          icon="🐖"
+          title="Sin metas"
+          description="Toca + para crear tu primera meta de ahorro"
+        />
+      }
+      renderItem={({ item }) => <GoalCard goal={item} />}
+      refreshControl={
+        <RefreshControl
+          refreshing={refreshing}
+          onRefresh={onRefresh}
+          tintColor="#4F46E5"
+        />
+      }
+    />
+  )
+}
+
+function GoalCard({ goal }: { goal: SavingsGoal }) {
+  const target = Number(goal.target_amount)
+  const current = Number(goal.current_amount)
+  const ratio = target > 0 ? current / target : 0
+  const remaining = Math.max(0, target - current)
+  const deadline = formatDeadline(goal.deadline)
+  const completed = goal.is_completed || ratio >= 1
+
+  return (
+    <TouchableOpacity
+      onPress={() => router.push(`/savings/${goal.id}`)}
+      activeOpacity={0.7}
+      className="mx-4 mb-3 bg-surface border border-border rounded-2xl p-4"
+    >
+      <View className="flex-row items-center mb-3">
+        <View className="flex-1">
+          <View className="flex-row items-center gap-2">
+            <Text className="text-white text-base font-semibold">
+              {goal.name}
+            </Text>
+            {completed ? (
+              <View className="px-2 py-0.5 rounded-full bg-green-500/15 border border-green-500/40">
+                <Text className="text-green-400 text-xs font-semibold">
+                  Completada
+                </Text>
+              </View>
+            ) : null}
+          </View>
+          {deadline ? (
+            <Text
+              className={
+                deadline.overdue
+                  ? 'text-red-400 text-xs mt-0.5'
+                  : 'text-muted text-xs mt-0.5'
+              }
+            >
+              {deadline.text}
+            </Text>
+          ) : null}
+        </View>
+        <Text className="text-green-400 text-base font-bold">
+          {Math.round(ratio * 100)}%
+        </Text>
+      </View>
+
+      <ProgressBar value={ratio} color="#10b981" />
+
+      <View className="flex-row justify-between mt-3">
+        <Text className="text-muted text-xs">
+          Ahorrado{' '}
+          <Text className="text-white text-sm">
+            {formatCurrency(current, goal.currency)}
+          </Text>
+        </Text>
+        <Text className="text-muted text-xs">
+          de{' '}
+          <Text className="text-white text-sm">
+            {formatCurrency(target, goal.currency)}
+          </Text>
+        </Text>
+      </View>
+
+      {!completed ? (
+        <Text className="text-muted text-xs mt-2">
+          Restante {formatCurrency(remaining, goal.currency)}
+        </Text>
+      ) : null}
+    </TouchableOpacity>
+  )
+}


### PR DESCRIPTION
## Cambios
- `components/savings/SavingsList.tsx` y `components/budgets/BudgetsList.tsx`: nuevos componentes reutilizables con la `FlatList` + cards + loading + empty state. No traen header ni FAB — eso queda en el padre.
- `app/(dashboard)/savings/index.tsx` y `budgets/index.tsx`: refactorizados para importar los nuevos componentes. Mantienen su header con back y su FAB → comportamiento idéntico al de antes (deep links y navegación desde detalle siguen funcionando).
- `app/(dashboard)/planning/_layout.tsx` + `index.tsx`: nuevo hub con header propio, segmented control entre los dos tabs, ambos listados montados con `display: none/flex` (preserva scroll position al togglear), FAB dinámico que apunta a `/savings/new` o `/budgets/new`.
- `app/(dashboard)/_layout.tsx`: registrado `planning` con `href: null`.
- `components/quick-actions/QuickActionsSheet.tsx`: reemplazados los 2 tiles 'Presupuestos' y 'Metas de ahorro' por **un solo tile 'Planificación'** → apunta al nuevo hub.

## Decisiones de diseño
- **Sin `@react-navigation/material-top-tabs`**: el toggle interno es state-based con un par de chips. Evita dependencia nueva y se siente más nativo al estilo del proyecto.
- **Ambos listados montados con `display`**: cambiar entre tabs no recarga ni resetea scroll. Ambos datasets se cargan en paralelo al enfocar.
- **Rutas legacy conservadas**: `/savings` y `/budgets` siguen funcionando independientes (deep links de notifs futuras, navegación back desde detalles).

## Testing
- ✅ `npx tsc --noEmit` sin errores
- Pendiente verificar visualmente: tile 'Planificación' abre el hub, toggle funciona, FAB navega correctamente al form del tab activo, deep link a `/savings/abc` muestra el detalle correctamente.

Closes #110