### PR TITLE
Chat IA para registro de gastos (texto + edge function Anthropic)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,18 @@ yarn-error.*
 # generated native folders
 /ios
 /android
+
+# InsForge & AI agent skills
+.insforge
+.agent
+.agents
+.augment
+.claude
+.cline
+.github/copilot*
+.kilocode
+.qoder
+.qwen
+.roo
+.trae
+.windsurf

--- a/app/(dashboard)/_layout.tsx
+++ b/app/(dashboard)/_layout.tsx
@@ -110,6 +110,7 @@ export default function DashboardLayout() {
         <Tabs.Screen name="savings" options={{ href: null }} />
         <Tabs.Screen name="loans" options={{ href: null }} />
         <Tabs.Screen name="reminders" options={{ href: null }} />
+        <Tabs.Screen name="chat" options={{ href: null }} />
       </Tabs>
 
       <QuickActionsSheet

--- a/app/(dashboard)/chat/_layout.tsx
+++ b/app/(dashboard)/chat/_layout.tsx
@@ -1,0 +1,13 @@
+import { Stack } from 'expo-router'
+import { colors } from '@/constants/theme'
+
+export default function ChatLayout() {
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        contentStyle: { backgroundColor: colors.bg },
+      }}
+    />
+  )
+}

--- a/app/(dashboard)/chat/index.tsx
+++ b/app/(dashboard)/chat/index.tsx
@@ -1,0 +1,230 @@
+// app/(dashboard)/chat/index.tsx
+//
+// Chat IA para registrar gastos. Usuario escribe texto libre, lo enviamos
+// a la edge function `ai-categorize-purchase` (Claude haiku-4-5), la IA
+// devuelve una transacción estructurada, el usuario confirma → se crea.
+//
+// La FlatList va invertida (`inverted`) — patrón estándar para chat:
+// nuevos mensajes aparecen abajo, scroll automático al final, scroll-up
+// para ver historial.
+//
+// Estado mínimo en esta versión:
+//  - Sin persistencia: el historial se pierde al cerrar la pantalla
+//  - Sin voz: solo input de texto (agregar en PR siguiente)
+import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  View,
+  Text,
+  FlatList,
+  TextInput,
+  TouchableOpacity,
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Platform,
+} from 'react-native'
+import { router } from 'expo-router'
+import { SafeAreaView } from 'react-native-safe-area-context'
+import { useAuth } from '@/context/AuthContext'
+import { getCategories } from '@/lib/actions/categories.actions'
+import { createTransaction } from '@/lib/actions/transactions.actions'
+import { categorizePurchaseText } from '@/lib/services/chat.service'
+import { MessageBubble } from '@/components/chat/MessageBubble'
+import { TransactionPreview } from '@/components/chat/TransactionPreview'
+import { Icon } from '@/components/ui/Icon'
+import { toast } from '@/components/ui/Toast'
+import type { Category } from '@/types/database.types'
+import type { CategorizedTransaction } from '@/lib/services/chat.service'
+
+type ChatItem =
+  | { kind: 'message'; id: string; role: 'user' | 'assistant'; text: string }
+  | {
+      kind: 'preview'
+      id: string
+      transaction: CategorizedTransaction
+      status: 'pending' | 'creating' | 'created'
+    }
+
+const WELCOME_TEXT =
+  '¡Hola! Cuéntame qué gastaste o ingresaste y lo registro por ti. Ejemplos:\n\n• "Gasté 25.000 en café"\n• "Recibí 100 dólares de freelance ayer"'
+
+export default function ChatScreen() {
+  const { user } = useAuth()
+  const [categories, setCategories] = useState<Category[]>([])
+  const [items, setItems] = useState<ChatItem[]>([
+    { kind: 'message', id: 'welcome', role: 'assistant', text: WELCOME_TEXT },
+  ])
+  const [input, setInput] = useState('')
+  const [sending, setSending] = useState(false)
+  const listRef = useRef<FlatList>(null)
+
+  useEffect(() => {
+    if (!user) return
+    getCategories(user.id).then((res) => {
+      if (res.success && res.data) setCategories(res.data)
+    })
+  }, [user])
+
+  const categoriesById = useCallback(
+    (id: string) => categories.find((c) => c.id === id) ?? null,
+    [categories]
+  )
+
+  const pushItems = useCallback((newItems: ChatItem[]) => {
+    setItems((prev) => [...prev, ...newItems])
+  }, [])
+
+  const updatePreview = useCallback(
+    (id: string, status: 'pending' | 'creating' | 'created') => {
+      setItems((prev) =>
+        prev.map((it) =>
+          it.kind === 'preview' && it.id === id ? { ...it, status } : it
+        )
+      )
+    },
+    []
+  )
+
+  const removePreview = useCallback((id: string) => {
+    setItems((prev) => prev.filter((it) => !(it.kind === 'preview' && it.id === id)))
+  }, [])
+
+  async function handleSend() {
+    const text = input.trim()
+    if (!text || sending || !user) return
+    setInput('')
+    setSending(true)
+
+    const userId = `m-${Date.now()}`
+    pushItems([{ kind: 'message', id: userId, role: 'user', text }])
+
+    const res = await categorizePurchaseText(text, categories)
+
+    if (!res.success) {
+      pushItems([
+        {
+          kind: 'message',
+          id: `m-${Date.now()}-err`,
+          role: 'assistant',
+          text: res.error,
+        },
+      ])
+    } else {
+      pushItems([
+        {
+          kind: 'preview',
+          id: `p-${Date.now()}`,
+          transaction: res.data,
+          status: 'pending',
+        },
+      ])
+    }
+
+    setSending(false)
+  }
+
+  async function handleConfirmPreview(
+    previewId: string,
+    transaction: CategorizedTransaction
+  ) {
+    if (!user) return
+    updatePreview(previewId, 'creating')
+
+    const createRes = await createTransaction(user.id, {
+      type: transaction.type,
+      amount: transaction.amount,
+      currency: transaction.currency,
+      description: transaction.description,
+      category_id: transaction.category_id,
+      date: transaction.date,
+    })
+
+    if (!createRes.success) {
+      updatePreview(previewId, 'pending')
+      toast.error(createRes.error ?? 'No se pudo crear la transacción')
+      return
+    }
+
+    updatePreview(previewId, 'created')
+    toast('Transacción registrada')
+  }
+
+  return (
+    <SafeAreaView edges={['top']} className="flex-1 bg-bg">
+      {/* Header */}
+      <View className="flex-row items-center justify-between px-4 py-3 border-b border-border">
+        <TouchableOpacity onPress={() => router.back()} activeOpacity={0.7}>
+          <Text className="text-primary text-base">← Volver</Text>
+        </TouchableOpacity>
+        <Text className="text-white text-base font-bold">Chat IA</Text>
+        <View style={{ width: 60 }} />
+      </View>
+
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        keyboardVerticalOffset={Platform.OS === 'ios' ? 64 : 0}
+        className="flex-1"
+      >
+        <FlatList
+          ref={listRef}
+          data={[...items].reverse()}
+          keyExtractor={(it) => it.id}
+          inverted
+          contentContainerStyle={{ paddingVertical: 12 }}
+          renderItem={({ item }) => {
+            if (item.kind === 'message') {
+              return <MessageBubble role={item.role} text={item.text} />
+            }
+            return (
+              <TransactionPreview
+                transaction={item.transaction}
+                category={categoriesById(item.transaction.category_id)}
+                status={item.status}
+                onConfirm={() => handleConfirmPreview(item.id, item.transaction)}
+                onDiscard={() => removePreview(item.id)}
+              />
+            )
+          }}
+        />
+
+        {/* Input bar */}
+        <View className="flex-row items-end gap-2 px-3 py-2 border-t border-border bg-bg">
+          <View className="flex-1 bg-surface border border-border rounded-2xl px-3 py-2">
+            <TextInput
+              value={input}
+              onChangeText={setInput}
+              placeholder="Escribe tu gasto o ingreso…"
+              placeholderTextColor="#6b7280"
+              multiline
+              maxLength={500}
+              editable={!sending}
+              className="text-white text-base"
+              style={{ maxHeight: 120, minHeight: 24 }}
+            />
+          </View>
+          <TouchableOpacity
+            onPress={handleSend}
+            disabled={sending || input.trim().length === 0}
+            activeOpacity={0.8}
+            accessibilityRole="button"
+            accessibilityLabel="Enviar mensaje"
+            className={`w-11 h-11 rounded-2xl items-center justify-center ${
+              sending || input.trim().length === 0
+                ? 'bg-surface border border-border'
+                : 'bg-primary'
+            }`}
+          >
+            {sending ? (
+              <ActivityIndicator color="#ffffff" size="small" />
+            ) : (
+              <Icon
+                name="send"
+                color={input.trim().length === 0 ? '#6b7280' : '#ffffff'}
+                size={20}
+              />
+            )}
+          </TouchableOpacity>
+        </View>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
+  )
+}

--- a/components/chat/MessageBubble.tsx
+++ b/components/chat/MessageBubble.tsx
@@ -1,0 +1,37 @@
+// components/chat/MessageBubble.tsx
+//
+// Render de un mensaje del chat. Hay dos roles:
+//  - user: burbuja alineada a la derecha, fondo primary
+//  - assistant: burbuja alineada a la izquierda, fondo surface
+//
+// El contenido es solo texto plano. Los previews de transacción los
+// renderiza un componente aparte (TransactionPreview).
+import { View, Text } from 'react-native'
+
+export type MessageRole = 'user' | 'assistant'
+
+interface Props {
+  role: MessageRole
+  text: string
+}
+
+export function MessageBubble({ role, text }: Props) {
+  const isUser = role === 'user'
+  return (
+    <View
+      className={`mx-4 my-1 ${isUser ? 'items-end' : 'items-start'}`}
+    >
+      <View
+        className={`max-w-[85%] px-4 py-2.5 rounded-2xl ${
+          isUser ? 'bg-primary' : 'bg-surface border border-border'
+        }`}
+      >
+        <Text
+          className={`${isUser ? 'text-white' : 'text-white'} text-sm leading-5`}
+        >
+          {text}
+        </Text>
+      </View>
+    </View>
+  )
+}

--- a/components/chat/TransactionPreview.tsx
+++ b/components/chat/TransactionPreview.tsx
@@ -1,0 +1,98 @@
+// components/chat/TransactionPreview.tsx
+//
+// Card de preview con el resultado de la categorización IA. El usuario
+// puede:
+//  - Confirmar → llama createTransaction
+//  - Descartar → cierra la card sin crear nada
+//
+// Mientras se está creando, los botones quedan deshabilitados y se
+// muestra ActivityIndicator. Tras confirmar exitosamente, la card pasa a
+// estado "creada" (no se puede confirmar de nuevo, evita duplicados).
+import { View, Text, TouchableOpacity, ActivityIndicator } from 'react-native'
+import { formatCurrency } from '@/lib/utils/currency'
+import type { Category } from '@/types/database.types'
+import type { CategorizedTransaction } from '@/lib/services/chat.service'
+
+interface Props {
+  transaction: CategorizedTransaction
+  category: Category | null
+  status: 'pending' | 'creating' | 'created'
+  onConfirm: () => void
+  onDiscard: () => void
+}
+
+export function TransactionPreview({
+  transaction,
+  category,
+  status,
+  onConfirm,
+  onDiscard,
+}: Props) {
+  const isIncome = transaction.type === 'income'
+  const created = status === 'created'
+  const creating = status === 'creating'
+
+  return (
+    <View className="mx-4 my-2 bg-surface border border-border rounded-2xl p-4">
+      {/* Header */}
+      <View className="flex-row items-center mb-3">
+        <View
+          style={{ backgroundColor: category?.color ?? '#4F46E5' }}
+          className="w-10 h-10 rounded-full items-center justify-center mr-3"
+        >
+          <Text className="text-xl">{category?.icon ?? '💰'}</Text>
+        </View>
+        <View className="flex-1">
+          <Text className="text-white text-base font-semibold">
+            {transaction.description}
+          </Text>
+          <Text className="text-muted text-xs mt-0.5">
+            {category?.name ?? 'Sin categoría'} · {transaction.date}
+          </Text>
+        </View>
+        <Text
+          className={`text-base font-bold ${
+            isIncome ? 'text-green-400' : 'text-red-400'
+          }`}
+        >
+          {isIncome ? '+' : '−'}
+          {formatCurrency(transaction.amount, transaction.currency)}
+        </Text>
+      </View>
+
+      {/* Estado */}
+      {created ? (
+        <View className="bg-green-500/10 border border-green-500/40 rounded-lg px-3 py-2">
+          <Text className="text-green-400 text-xs text-center">
+            Transacción registrada ✓
+          </Text>
+        </View>
+      ) : (
+        <View className="flex-row gap-2">
+          <TouchableOpacity
+            onPress={onDiscard}
+            disabled={creating}
+            activeOpacity={0.7}
+            className="flex-1 py-2.5 rounded-xl border border-border items-center"
+          >
+            <Text className="text-muted text-sm">Descartar</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={onConfirm}
+            disabled={creating}
+            activeOpacity={0.8}
+            className="flex-1 py-2.5 rounded-xl bg-primary items-center"
+          >
+            {creating ? (
+              <ActivityIndicator color="#ffffff" size="small" />
+            ) : (
+              <Text className="text-white text-sm font-semibold">
+                Confirmar
+              </Text>
+            )}
+          </TouchableOpacity>
+        </View>
+      )}
+    </View>
+  )
+}

--- a/components/quick-actions/QuickActionsSheet.tsx
+++ b/components/quick-actions/QuickActionsSheet.tsx
@@ -35,6 +35,12 @@ const TILES: ActionTile[] = [
     color: '#4F46E5',
   },
   {
+    icon: 'sparkles',
+    label: 'Chat IA',
+    route: '/chat',
+    color: '#a855f7',
+  },
+  {
     icon: 'wallet',
     label: 'Cuentas',
     route: '/accounts',

--- a/components/ui/Icon.tsx
+++ b/components/ui/Icon.tsx
@@ -21,6 +21,8 @@ import {
   FolderTree,
   Bell,
   Calendar as CalendarIcon,
+  Send,
+  Sparkles,
 } from 'lucide-react-native'
 
 /**
@@ -56,6 +58,8 @@ const ICONS = {
   'folder-tree': FolderTree,
   bell: Bell,
   calendar: CalendarIcon,
+  send: Send,
+  sparkles: Sparkles,
 } as const
 
 export type IconName = keyof typeof ICONS

--- a/insforge/functions/ai-categorize-purchase/index.ts
+++ b/insforge/functions/ai-categorize-purchase/index.ts
@@ -1,0 +1,163 @@
+// insforge/functions/ai-categorize-purchase/index.ts
+//
+// Edge function que toma el texto libre del usuario + el listado de categorías
+// y devuelve una transacción estructurada usando Claude haiku-4-5.
+//
+// Replica el comportamiento de `lib/actions/ai.actions.ts` del proyecto web.
+// La diferencia es que el web usa `@anthropic-ai/sdk`; aquí en Deno usamos
+// `fetch` directo a la API de Anthropic — el SDK funciona pero pesa más y
+// no necesitamos features avanzados.
+//
+// Auth: requiere usuario logueado (Bearer token en header). No usamos el
+// userId para nada hoy, pero la auth previene abuso de la API key.
+
+interface IncomingBody {
+  text: string
+  categories: { id: string; name: string; type: string }[]
+}
+
+interface CategorizedTransaction {
+  amount: number
+  description: string
+  category_id: string
+  type: 'income' | 'expense'
+  currency: 'COP' | 'USD' | 'VES'
+  date: string
+}
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+}
+
+function json(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...CORS_HEADERS, 'Content-Type': 'application/json' },
+  })
+}
+
+function buildPrompt(text: string, categories: IncomingBody['categories']): string {
+  const today = new Date().toISOString().split('T')[0]
+  const catLines = categories
+    .map((c) => `- ID: ${c.id} | Nombre: ${c.name} | Tipo: ${c.type}`)
+    .join('\n')
+
+  return `El usuario escribió: "${text}"
+
+Categorías disponibles:
+${catLines}
+
+Fecha actual: ${today}
+
+Responde ÚNICAMENTE con un JSON válido (sin markdown, sin explicaciones).
+
+Si el mensaje describe un gasto o ingreso, responde:
+{
+  "valid": true,
+  "amount": <número positivo>,
+  "description": "<descripción breve y clara del gasto/ingreso>",
+  "category_id": "<id de la categoría más apropiada del listado>",
+  "type": "<'income' o 'expense'>",
+  "currency": "<'COP', 'USD' o 'VES' - detecta según el contexto: 'dólares'/'USD'/'$' → USD, 'bolívares'/'VES'/'Bs' → VES, por defecto COP>",
+  "date": "<fecha en formato YYYY-MM-DD - 'ayer' → día anterior, 'la semana pasada' → lunes anterior, si no se menciona usa la fecha actual>"
+}
+
+Si el mensaje NO describe un gasto ni un ingreso, responde:
+{
+  "valid": false,
+  "message": "<mensaje breve y amigable explicando que solo puedes registrar transacciones>"
+}`
+}
+
+export default async function (req: Request): Promise<Response> {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: CORS_HEADERS })
+  }
+  if (req.method !== 'POST') {
+    return json(405, { success: false, error: 'Método no permitido' })
+  }
+
+  // Auth gate: requerimos Bearer token. No validamos contra la BD aquí —
+  // confiamos en que InsForge solo enruta requests con token válido. Si quieres
+  // user-scoped lógica, descomenta el bloque de getCurrentUser más abajo.
+  const authHeader = req.headers.get('Authorization')
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return json(401, { success: false, error: 'Auth requerida' })
+  }
+
+  const apiKey = Deno.env.get('ANTHROPIC_API_KEY')
+  if (!apiKey) {
+    return json(500, { success: false, error: 'Falta ANTHROPIC_API_KEY en server' })
+  }
+
+  let body: IncomingBody
+  try {
+    body = await req.json()
+  } catch {
+    return json(400, { success: false, error: 'JSON inválido en request body' })
+  }
+
+  if (!body.text || typeof body.text !== 'string') {
+    return json(400, { success: false, error: 'Falta `text`' })
+  }
+  if (!Array.isArray(body.categories)) {
+    return json(400, { success: false, error: 'Falta `categories`' })
+  }
+
+  try {
+    const anthropicRes = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01',
+      },
+      body: JSON.stringify({
+        model: 'claude-haiku-4-5',
+        max_tokens: 500,
+        messages: [{ role: 'user', content: buildPrompt(body.text, body.categories) }],
+      }),
+    })
+
+    if (!anthropicRes.ok) {
+      const errText = await anthropicRes.text()
+      console.error('Anthropic error', anthropicRes.status, errText)
+      return json(502, { success: false, error: `Anthropic ${anthropicRes.status}` })
+    }
+
+    const data = await anthropicRes.json() as {
+      content: { type: string; text: string }[]
+    }
+    const textBlock = data.content?.find((b) => b.type === 'text')
+    if (!textBlock) {
+      return json(502, { success: false, error: 'No se recibió respuesta del modelo' })
+    }
+
+    const clean = textBlock.text
+      .trim()
+      .replace(/^```(?:json)?\n?/, '')
+      .replace(/\n?```$/, '')
+
+    let parsed: CategorizedTransaction & { valid: boolean; message?: string }
+    try {
+      parsed = JSON.parse(clean)
+    } catch {
+      return json(502, { success: false, error: 'El modelo no devolvió un JSON válido' })
+    }
+
+    if (!parsed.valid) {
+      return json(200, {
+        success: false,
+        error:
+          parsed.message ?? 'Solo puedo ayudarte a registrar gastos e ingresos.',
+      })
+    }
+
+    return json(200, { success: true, data: parsed })
+  } catch (err) {
+    console.error('ai-categorize-purchase error', err)
+    return json(500, { success: false, error: 'Error al procesar con IA' })
+  }
+}

--- a/lib/services/chat.service.ts
+++ b/lib/services/chat.service.ts
@@ -1,0 +1,69 @@
+// lib/services/chat.service.ts
+//
+// Wrapper sobre la edge function `ai-categorize-purchase` de InsForge.
+// El SDK adjunta automáticamente el bearer token del usuario logueado,
+// así que no necesitamos pasar auth headers manualmente.
+import { insforge } from '@/lib/insforge'
+import type { Category, Currency, TransactionType } from '@/types/database.types'
+
+export interface CategorizedTransaction {
+  amount: number
+  description: string
+  category_id: string
+  type: TransactionType
+  currency: Currency
+  date: string
+}
+
+export interface CategorizeSuccess {
+  success: true
+  data: CategorizedTransaction
+}
+
+export interface CategorizeError {
+  success: false
+  error: string
+}
+
+export type CategorizeResult = CategorizeSuccess | CategorizeError
+
+/**
+ * Envía el texto del usuario + las categorías disponibles a la edge function.
+ * El backend llama a Claude haiku-4-5 y devuelve la transacción estructurada.
+ *
+ * Nota: solo enviamos id/name/type — el resto de campos de Category (icon,
+ * color, user_id) no son útiles para la IA y aumentarían tokens.
+ */
+export async function categorizePurchaseText(
+  text: string,
+  categories: Category[]
+): Promise<CategorizeResult> {
+  try {
+    const { data, error } = await insforge.functions.invoke(
+      'ai-categorize-purchase',
+      {
+        body: {
+          text,
+          categories: categories.map((c) => ({
+            id: c.id,
+            name: c.name,
+            type: c.type,
+          })),
+        },
+      }
+    )
+
+    if (error) {
+      return { success: false, error: error.message ?? 'Error al llamar a la IA' }
+    }
+    if (!data) {
+      return { success: false, error: 'Respuesta vacía de la IA' }
+    }
+
+    // La edge function ya devuelve el shape correcto.
+    return data as CategorizeResult
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Error desconocido'
+    return { success: false, error: message }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,5 +5,6 @@
     "paths": {
       "@/*": ["./*"]
     }
-  }
+  },
+  "exclude": ["node_modules", "insforge/functions"]
 }


### PR DESCRIPTION
## Cambios

### Backend
- **`insforge/functions/ai-categorize-purchase/index.ts`** — Edge function nueva en InsForge. Deno runtime, llama a Anthropic via `fetch` (sin SDK para mantener el bundle pequeño). Mismo prompt que `lib/actions/ai.actions.ts` del web. Auth gate por bearer token; secret `ANTHROPIC_API_KEY` ya configurado en InsForge.

### Frontend
- **`lib/services/chat.service.ts`** — Wrapper que llama a la edge function con `insforge.functions.invoke()`. El SDK adjunta el token del usuario logueado automáticamente.
- **`app/(dashboard)/chat/`** — Pantalla nueva con FlatList invertida (patrón estándar de chat), input multilinea con `KeyboardAvoidingView`, botón enviar deshabilitado mientras se envía.
- **`components/chat/MessageBubble.tsx`** — Burbujas user (primary, derecha) y assistant (surface, izquierda).
- **`components/chat/TransactionPreview.tsx`** — Card con icono de categoría, monto formateado, botones Confirmar/Descartar. Estados `pending → creating → created`. Tras crear, muestra check verde y bloquea acciones (evita duplicados).
- **`components/quick-actions/QuickActionsSheet.tsx`** — Tile nuevo 'Chat IA' (sparkles, purple).
- **`components/ui/Icon.tsx`** — Iconos `send` y `sparkles` agregados.

### Tooling
- **`tsconfig.json`** — Excluido `insforge/functions/` del typecheck (corre en Deno, no Node).
- **`.gitignore`** — Agregado por `npx @insforge/cli link`: `.insforge/` (contiene `api_key` admin) y dirs de varios agentes.

## Decisiones de diseño
- **Sin persistencia local** en este PR: el historial se pierde al cerrar la pantalla. Se puede agregar `AsyncStorage` en un PR siguiente sin tocar arquitectura.
- **Sin input por voz** en este PR: requiere instalar `expo-speech-recognition`. Se hará en un PR siguiente para mantener este enfocado.
- **Sin `account_id`** en el payload de creación: cuando la IA categoriza, no hay forma confiable de inferir la cuenta. El usuario edita la transacción después si quiere asociarla.
- **`fetch` directo a Anthropic** en la edge function en vez del SDK: la API es simple, evita carga de bundle.

## Testing
- ✅ `npx tsc --noEmit` sin errores
- ✅ Edge function probada con `functions invoke`:
  - 'Gasté 25000 en café' → `valid:true, amount:25000, currency:COP, category:Comida`
  - 'Recibí 100 dólares de freelance ayer' → `valid:true, amount:100, currency:USD, type:income, date:ayer`
  - 'cómo estás?' → `valid:false, mensaje amigable de error`
- Pendiente verificar visualmente en simulador

Closes #112