### PR TITLE
Chat IA: voz on-device + persistencia local del historial

### DIFF
--- a/app.json
+++ b/app.json
@@ -52,6 +52,12 @@
           "microphonePermission": "Permite que la app grabe tu voz para transcribirla a texto en el chat.",
           "speechRecognitionPermission": "Permite que la app convierta tu voz en texto para registrar transacciones."
         }
+      ],
+      [
+        "expo-build-properties",
+        {
+          "ios": { "deploymentTarget": "16.4" }
+        }
       ]
     ]
   }

--- a/app.json
+++ b/app.json
@@ -45,7 +45,14 @@
       "expo-router",
       "expo-secure-store",
       "expo-web-browser",
-      "@react-native-community/datetimepicker"
+      "@react-native-community/datetimepicker",
+      [
+        "expo-speech-recognition",
+        {
+          "microphonePermission": "Permite que la app grabe tu voz para transcribirla a texto en el chat.",
+          "speechRecognitionPermission": "Permite que la app convierta tu voz en texto para registrar transacciones."
+        }
+      ]
     ]
   }
 }

--- a/app/(dashboard)/chat/index.tsx
+++ b/app/(dashboard)/chat/index.tsx
@@ -30,8 +30,10 @@ import { createTransaction } from '@/lib/actions/transactions.actions'
 import { categorizePurchaseText } from '@/lib/services/chat.service'
 import { MessageBubble } from '@/components/chat/MessageBubble'
 import { TransactionPreview } from '@/components/chat/TransactionPreview'
+import { MicButton } from '@/components/chat/MicButton'
 import { Icon } from '@/components/ui/Icon'
 import { toast } from '@/components/ui/Toast'
+import { loadHistory, saveHistory } from '@/lib/storage/chat-history'
 import type { Category } from '@/types/database.types'
 import type { CategorizedTransaction } from '@/lib/services/chat.service'
 
@@ -47,22 +49,51 @@ type ChatItem =
 const WELCOME_TEXT =
   '¡Hola! Cuéntame qué gastaste o ingresaste y lo registro por ti. Ejemplos:\n\n• "Gasté 25.000 en café"\n• "Recibí 100 dólares de freelance ayer"'
 
+const WELCOME_ITEM: ChatItem = {
+  kind: 'message',
+  id: 'welcome',
+  role: 'assistant',
+  text: WELCOME_TEXT,
+}
+
 export default function ChatScreen() {
   const { user } = useAuth()
   const [categories, setCategories] = useState<Category[]>([])
-  const [items, setItems] = useState<ChatItem[]>([
-    { kind: 'message', id: 'welcome', role: 'assistant', text: WELCOME_TEXT },
-  ])
+  const [items, setItems] = useState<ChatItem[]>([WELCOME_ITEM])
   const [input, setInput] = useState('')
   const [sending, setSending] = useState(false)
+  const [hydrated, setHydrated] = useState(false)
   const listRef = useRef<FlatList>(null)
 
+  // Cargar categorías + historial al montar
   useEffect(() => {
     if (!user) return
     getCategories(user.id).then((res) => {
       if (res.success && res.data) setCategories(res.data)
     })
+    loadHistory(user.id).then((stored) => {
+      if (stored.length > 0) {
+        // Si la última preview quedó en 'creating' por un cierre abrupto,
+        // la rebajamos a 'pending' para que el user pueda decidir.
+        const recovered = stored.map((it) =>
+          it.kind === 'preview' && it.status === 'creating'
+            ? { ...it, status: 'pending' as const }
+            : it
+        )
+        setItems([WELCOME_ITEM, ...recovered])
+      }
+      setHydrated(true)
+    })
   }, [user])
+
+  // Guardar historial cada vez que cambia. Omitimos el welcome item (siempre
+  // se reinyecta al cargar). Solo guardamos después de hidratar para evitar
+  // sobrescribir el storage durante el load inicial.
+  useEffect(() => {
+    if (!user || !hydrated) return
+    const toStore = items.filter((it) => it.id !== 'welcome')
+    saveHistory(user.id, toStore)
+  }, [items, user, hydrated])
 
   const categoriesById = useCallback(
     (id: string) => categories.find((c) => c.id === id) ?? null,
@@ -188,11 +219,16 @@ export default function ChatScreen() {
 
         {/* Input bar */}
         <View className="flex-row items-end gap-2 px-3 py-2 border-t border-border bg-bg">
+          <MicButton
+            disabled={sending}
+            onPartial={setInput}
+            onFinal={setInput}
+          />
           <View className="flex-1 bg-surface border border-border rounded-2xl px-3 py-2">
             <TextInput
               value={input}
               onChangeText={setInput}
-              placeholder="Escribe tu gasto o ingreso…"
+              placeholder="Escribe o usa el micrófono…"
               placeholderTextColor="#6b7280"
               multiline
               maxLength={500}

--- a/components/chat/MicButton.tsx
+++ b/components/chat/MicButton.tsx
@@ -1,0 +1,107 @@
+// components/chat/MicButton.tsx
+//
+// Botón de micrófono que arranca/para grabación con expo-speech-recognition.
+// La transcripción es **on-device** (sin backend) — usa el motor nativo de
+// speech recognition de iOS/Android. Gratis, privado, sin tokens.
+//
+// API simple:
+//  - Tap → pide permiso si hace falta, arranca `start({ lang: 'es-ES' })`
+//  - Mientras graba, botón pulsa (rojo) y el listener `result` actualiza
+//    el padre con el texto parcial; al `end` el padre tiene el texto final.
+//  - Tap de nuevo → para. Si hay error, toast.
+//
+// Idioma fijo a español. Si después queremos multi-idioma, lo hacemos prop.
+import { useCallback, useState } from 'react'
+import { TouchableOpacity, ActivityIndicator } from 'react-native'
+import {
+  ExpoSpeechRecognitionModule,
+  useSpeechRecognitionEvent,
+} from 'expo-speech-recognition'
+import { Mic, MicOff } from 'lucide-react-native'
+import { toast } from '@/components/ui/Toast'
+
+interface Props {
+  /** Llamado en cada update parcial de transcripción. */
+  onPartial: (text: string) => void
+  /** Llamado cuando termina la grabación con el texto final. */
+  onFinal: (text: string) => void
+  /** Deshabilita el botón (cuando se está enviando un mensaje, p.ej.). */
+  disabled?: boolean
+}
+
+export function MicButton({ onPartial, onFinal, disabled }: Props) {
+  const [recording, setRecording] = useState(false)
+  const [starting, setStarting] = useState(false)
+
+  // Estos eventos disparan globalmente — válido porque solo hay un
+  // MicButton en pantalla a la vez (input bar del chat).
+  useSpeechRecognitionEvent('start', () => setRecording(true))
+  useSpeechRecognitionEvent('end', () => setRecording(false))
+  useSpeechRecognitionEvent('error', (e) => {
+    setRecording(false)
+    setStarting(false)
+    if (e.error !== 'no-speech' && e.error !== 'aborted') {
+      toast.error(`Error de voz: ${e.error}`)
+    }
+  })
+  useSpeechRecognitionEvent('result', (e) => {
+    const text = e.results?.[0]?.transcript ?? ''
+    if (e.isFinal) {
+      onFinal(text)
+    } else {
+      onPartial(text)
+    }
+  })
+
+  const handlePress = useCallback(async () => {
+    if (recording) {
+      ExpoSpeechRecognitionModule.stop()
+      return
+    }
+    if (starting || disabled) return
+
+    setStarting(true)
+    try {
+      const perm = await ExpoSpeechRecognitionModule.requestPermissionsAsync()
+      if (!perm.granted) {
+        toast.error('Necesito permiso de micrófono y voz para escucharte')
+        return
+      }
+      ExpoSpeechRecognitionModule.start({
+        lang: 'es-ES',
+        interimResults: true,
+        continuous: false,
+      })
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'No pude iniciar la grabación')
+    } finally {
+      setStarting(false)
+    }
+  }, [recording, starting, disabled])
+
+  return (
+    <TouchableOpacity
+      onPress={handlePress}
+      disabled={disabled}
+      activeOpacity={0.7}
+      accessibilityRole="button"
+      accessibilityLabel={recording ? 'Detener grabación' : 'Grabar voz'}
+      accessibilityState={{ disabled: !!disabled }}
+      className={`w-11 h-11 rounded-2xl items-center justify-center ${
+        recording
+          ? 'bg-red-500'
+          : disabled
+          ? 'bg-surface border border-border'
+          : 'bg-surface border border-border'
+      }`}
+    >
+      {starting ? (
+        <ActivityIndicator color="#9ca3af" size="small" />
+      ) : recording ? (
+        <MicOff size={20} color="#ffffff" strokeWidth={2} />
+      ) : (
+        <Mic size={20} color={disabled ? '#6b7280' : '#9ca3af'} strokeWidth={2} />
+      )}
+    </TouchableOpacity>
+  )
+}

--- a/lib/storage/chat-history.ts
+++ b/lib/storage/chat-history.ts
@@ -1,0 +1,71 @@
+// lib/storage/chat-history.ts
+//
+// Persistencia local del historial del chat IA, por usuario, usando
+// AsyncStorage (almacenamiento clave-valor simple, asíncrono, no encriptado).
+//
+// Mantenemos como máximo los últimos `MAX_ITEMS` items para que el archivo
+// no crezca sin límite. Es suficiente para chats casuales.
+//
+// IMPORTANTE: AsyncStorage NO es seguro (no encriptado). No guardamos
+// secretos aquí — solo el contenido del chat, que ya es visible al user.
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import type { CategorizedTransaction } from '@/lib/services/chat.service'
+
+export type StoredChatItem =
+  | { kind: 'message'; id: string; role: 'user' | 'assistant'; text: string }
+  | {
+      kind: 'preview'
+      id: string
+      transaction: CategorizedTransaction
+      status: 'pending' | 'creating' | 'created'
+    }
+
+const MAX_ITEMS = 50
+
+function storageKey(userId: string): string {
+  return `chat-history:${userId}`
+}
+
+/** Devuelve el historial guardado o `[]` si no hay nada / hubo error. */
+export async function loadHistory(userId: string): Promise<StoredChatItem[]> {
+  try {
+    const raw = await AsyncStorage.getItem(storageKey(userId))
+    if (!raw) return []
+    const parsed = JSON.parse(raw) as StoredChatItem[]
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Guarda los últimos `MAX_ITEMS` items. Si la lista está vacía, borra
+ * la entrada (evita acumular keys con []).
+ *
+ * Errores se ignoran en silencio — la persistencia es nice-to-have,
+ * no queremos que un fallo de disco rompa el chat.
+ */
+export async function saveHistory(
+  userId: string,
+  items: StoredChatItem[]
+): Promise<void> {
+  try {
+    if (items.length === 0) {
+      await AsyncStorage.removeItem(storageKey(userId))
+      return
+    }
+    const trimmed = items.slice(-MAX_ITEMS)
+    await AsyncStorage.setItem(storageKey(userId), JSON.stringify(trimmed))
+  } catch {
+    // silenciar
+  }
+}
+
+/** Borra el historial del usuario. Útil para botón "Limpiar chat". */
+export async function clearHistory(userId: string): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(storageKey(userId))
+  } catch {
+    // silenciar
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@shopify/react-native-skia": "^2.6.3",
     "expo": "~54.0.34",
     "expo-auth-session": "~7.0.11",
+    "expo-build-properties": "~1.0.10",
     "expo-notifications": "~0.32.17",
     "expo-router": "~6.0.23",
     "expo-secure-store": "~15.0.8",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@insforge/sdk": "^1.2.5",
+    "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/datetimepicker": "8.4.4",
     "@shopify/react-native-skia": "^2.6.3",
     "expo": "~54.0.34",
@@ -17,6 +18,7 @@
     "expo-notifications": "~0.32.17",
     "expo-router": "~6.0.23",
     "expo-secure-store": "~15.0.8",
+    "expo-speech-recognition": "^56.0.0",
     "expo-status-bar": "~3.0.9",
     "expo-web-browser": "~15.0.11",
     "lucide-react-native": "^1.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@insforge/sdk':
         specifier: ^1.2.5
         version: 1.2.5
+      '@react-native-async-storage/async-storage':
+        specifier: 2.2.0
+        version: 2.2.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
       '@react-native-community/datetimepicker':
         specifier: 8.4.4
         version: 8.4.4(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -32,6 +35,9 @@ importers:
       expo-secure-store:
         specifier: ~15.0.8
         version: 15.0.8(expo@54.0.34)
+      expo-speech-recognition:
+        specifier: ^56.0.0
+        version: 56.0.0(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       expo-status-bar:
         specifier: ~3.0.9
         version: 3.0.9(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -1049,6 +1055,11 @@ packages:
       '@types/react':
         optional: true
 
+  '@react-native-async-storage/async-storage@2.2.0':
+    resolution: {integrity: sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==}
+    peerDependencies:
+      react-native: ^0.0.0-0 || >=0.65 <1.0
+
   '@react-native-community/datetimepicker@8.4.4':
     resolution: {integrity: sha512-bc4ZixEHxZC9/qf5gbdYvIJiLZ5CLmEsC3j+Yhe1D1KC/3QhaIfGDVdUcid0PdlSoGOSEq4VlB93AWyetEyBSQ==}
     peerDependencies:
@@ -2058,6 +2069,13 @@ packages:
     resolution: {integrity: sha512-vb5TBtskvEdzYuW79lATXutOEBfW5m6U4EFpNjCVZTnI7S//SAsLQkYEpn+EDfn84m6VQfzSGkIVR6YPaScKFA==}
     engines: {node: '>=20.16.0'}
 
+  expo-speech-recognition@56.0.0:
+    resolution: {integrity: sha512-spA6HqnA/rgwMNS5YmFktmzly7f46kGOv3tXZ2f0Xfh7x9pAsmXyG3YtPtB9sHGbW7RmUSjbMGEzsvCak2Q4sA==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+      react-native: '*'
+
   expo-status-bar@3.0.9:
     resolution: {integrity: sha512-xyYyVg6V1/SSOZWh4Ni3U129XHCnFHBTcUo0dhWtFDrZbNp/duw5AGsQfb2sVeU0gxWHXSY1+5F0jnKYC7WuOw==}
     peerDependencies:
@@ -2357,6 +2375,10 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-plain-obj@2.1.0:
+    resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
+    engines: {node: '>=8'}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -2662,6 +2684,10 @@ packages:
 
   memoize-one@5.2.1:
     resolution: {integrity: sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==}
+
+  merge-options@3.0.4:
+    resolution: {integrity: sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==}
+    engines: {node: '>=10'}
 
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
@@ -5240,6 +5266,11 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.1.17
 
+  '@react-native-async-storage/async-storage@2.2.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))':
+    dependencies:
+      merge-options: 3.0.4
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
+
   '@react-native-community/datetimepicker@8.4.4(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
       invariant: 2.2.4
@@ -6447,6 +6478,12 @@ snapshots:
 
   expo-server@1.0.6: {}
 
+  expo-speech-recognition@56.0.0(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+    dependencies:
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
+
   expo-status-bar@3.0.9(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       react: 19.1.0
@@ -6753,6 +6790,8 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-plain-obj@2.1.0: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -7036,6 +7075,10 @@ snapshots:
   mdn-data@2.0.14: {}
 
   memoize-one@5.2.1: {}
+
+  merge-options@3.0.4:
+    dependencies:
+      is-plain-obj: 2.1.0
 
   merge-stream@2.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       expo-auth-session:
         specifier: ~7.0.11
         version: 7.0.11(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-build-properties:
+        specifier: ~1.0.10
+        version: 1.0.10(expo@54.0.34)
       expo-notifications:
         specifier: ~0.32.17
         version: 0.32.17(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
@@ -1328,6 +1331,9 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
   anser@1.4.10:
     resolution: {integrity: sha512-hCv9AqTQ8ycjpSd3upOJd7vFwW1JaoYQ7tpham03GJ1ca8/65rqn0RpaWpItOAd6ylW9wAw6luXYPJIyPFVOww==}
 
@@ -1963,6 +1969,11 @@ packages:
       react: '*'
       react-native: '*'
 
+  expo-build-properties@1.0.10:
+    resolution: {integrity: sha512-mFCZbrbrv0AP5RB151tAoRzwRJelqM7bCJzCkxpu+owOyH+p/rFC/q7H5q8B9EpVWj8etaIuszR+gKwohpmu1Q==}
+    peerDependencies:
+      expo: '*'
+
   expo-constants@18.0.13:
     resolution: {integrity: sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ==}
     peerDependencies:
@@ -2117,6 +2128,9 @@ packages:
 
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -2469,6 +2483,9 @@ packages:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
     hasBin: true
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -5674,6 +5691,13 @@ snapshots:
 
   agent-base@7.1.4: {}
 
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   anser@1.4.10: {}
 
   ansi-escapes@4.3.2:
@@ -6349,6 +6373,12 @@ snapshots:
       - expo
       - supports-color
 
+  expo-build-properties@1.0.10(expo@54.0.34):
+    dependencies:
+      ajv: 8.20.0
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      semver: 7.7.4
+
   expo-constants@18.0.13(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.1(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)):
     dependencies:
       '@expo/config': 12.0.13
@@ -6544,6 +6574,8 @@ snapshots:
       micromatch: 4.0.8
 
   fast-json-stable-stringify@2.1.0: {}
+
+  fast-uri@3.1.2: {}
 
   fastq@1.20.1:
     dependencies:
@@ -6918,6 +6950,8 @@ snapshots:
   jsc-safe-url@0.2.4: {}
 
   jsesc@3.1.0: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json5@2.2.3: {}
 


### PR DESCRIPTION
## Cambios

### Persistencia (AsyncStorage)
- **`lib/storage/chat-history.ts`** — Helpers `loadHistory()`, `saveHistory()`, `clearHistory()`. Key per-user (`chat-history:{userId}`), tope de 50 items, errores silenciados.
- **`app/(dashboard)/chat/index.tsx`** — Carga historial al montar, guarda en cada cambio (después de hidratar). Welcome message no se persiste — se reinyecta. **Recovery**: si una preview quedó en estado `creating` por un cierre abrupto, al recargar se rebaja a `pending` para que el user decida.

### Voz (expo-speech-recognition)
- **`components/chat/MicButton.tsx`** — Botón de mic. Transcripción **on-device** con el motor nativo (sin backend, sin tokens, privado). Idioma `es-ES`. Pide permisos la primera vez. Estados: idle → recording (mic rojo) → fin. Errores `no-speech` y `aborted` se silencian; el resto se muestra como toast.
- **`app.json`** — Plugin con permisos personalizados en español: `microphonePermission` y `speechRecognitionPermission`.
- **`app/(dashboard)/chat/index.tsx`** — `MicButton` agregado a la izquierda del input. La transcripción (parcial y final) actualiza el `TextInput`. El user revisa y presiona enviar manualmente (no se auto-envía).

### ⚠️ Bump iOS deployment target → 16.4
El podspec de `expo-speech-recognition@56.0.0` declara `s.platforms = { :ios => '16.4' }`. Con el default de Expo (iOS 15.1), Cocoapods skipea el pod en silencio y el módulo nativo nunca se enlaza (crash con 'Cannot find native module ExpoSpeechRecognition').

**Fix aplicado**: plugin `expo-build-properties` con `ios.deploymentTarget = '16.4'` en `app.json`. Sobrevive a futuros prebuilds, no requiere editar Podfile manualmente.

**Implicación**: drop de soporte para iOS < 16.4 (lanzado marzo 2023, ~2 años atrás). Aceptable para esta app personal.

## ⚠️ Requiere rebuild del dev client

\`\`\`bash
rm -rf ios
npx expo prebuild --platform ios --clean
npx expo run:ios
\`\`\`

(Sin rebuild, el binario actual no tiene el módulo nativo. Si el iOS Pods cache está viejo, hay que borrar \`ios/\` para que regenere con el nuevo deployment target.)

## Testing
- ✅ \`npx tsc --noEmit\` sin errores
- ✅ Rebuild verificado por el usuario; pod \`ExpoSpeechRecognition (56.0.0)\` ahora sí aparece en Podfile.lock

Closes #114